### PR TITLE
Fix Mobile Responsive Layout constraints and Viewport Overflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "vite": "^6.2.0"
   },
   "devDependencies": {
+    "@tailwindcss/typography": "^0.5.19",
     "@types/express": "^4.17.21",
     "@types/node": "^22.14.0",
     "autoprefixer": "^10.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
         specifier: ^6.2.0
         version: 6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
     devDependencies:
+      '@tailwindcss/typography':
+        specifier: ^0.5.19
+        version: 0.5.19(tailwindcss@4.2.2)
       '@types/express':
         specifier: ^4.17.21
         version: 4.17.25
@@ -1171,6 +1174,11 @@ packages:
   '@tailwindcss/oxide@4.2.2':
     resolution: {integrity: sha512-qEUA07+E5kehxYp9BVMpq9E8vnJuBHfJEC0vPC5e7iL/hw7HR61aDKoVoKzrG+QKp56vhNZe4qwkRmMC0zDLvg==}
     engines: {node: '>= 20'}
+
+  '@tailwindcss/typography@0.5.19':
+    resolution: {integrity: sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==}
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1'
 
   '@tailwindcss/vite@4.2.2':
     resolution: {integrity: sha512-mEiF5HO1QqCLXoNEfXVA1Tzo+cYsrqV7w9Juj2wdUFyW07JRenqMG225MvPwr3ZD9N1bFQj46X7r33iHxLUW0w==}
@@ -2636,6 +2644,10 @@ packages:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
 
+  postcss-selector-parser@6.0.10:
+    resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
+    engines: {node: '>=4'}
+
   postcss-selector-parser@7.1.1:
     resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
     engines: {node: '>=4'}
@@ -4079,6 +4091,11 @@ snapshots:
       '@tailwindcss/oxide-wasm32-wasi': 4.2.2
       '@tailwindcss/oxide-win32-arm64-msvc': 4.2.2
       '@tailwindcss/oxide-win32-x64-msvc': 4.2.2
+
+  '@tailwindcss/typography@0.5.19(tailwindcss@4.2.2)':
+    dependencies:
+      postcss-selector-parser: 6.0.10
+      tailwindcss: 4.2.2
 
   '@tailwindcss/vite@4.2.2(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))':
     dependencies:
@@ -5674,6 +5691,11 @@ snapshots:
   picomatch@4.0.4: {}
 
   pkce-challenge@5.0.1: {}
+
+  postcss-selector-parser@6.0.10:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
 
   postcss-selector-parser@7.1.1:
     dependencies:

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -47,7 +47,7 @@ export default function Navigation() {
         <Box as={NavLink} to="/" onClick={() => setIsOpen(false)}>
           <Text variant="mono" size="sm" weight="font-bold" className="text-accent-navy tracking-wider uppercase">TECH-DANCER</Text>
         </Box>
-        <Box as="button" onClick={() => setIsOpen(!isOpen)} padding={2}>
+        <Box as="button" onClick={() => setIsOpen(!isOpen)} padding={2} className="min-h-[44px] min-w-[44px] flex items-center justify-center">
           {isOpen ? <X className="w-6 h-6" /> : <Menu className="w-6 h-6" />}
         </Box>
       </Box>
@@ -61,7 +61,7 @@ export default function Navigation() {
             animate={{ x: 0 }}
             exit={{ x: '-100%' }}
             position="fixed"
-            className="top-16 left-0 right-0 bottom-0 z-[100] bg-bg lg:hidden"
+            className="top-16 left-0 right-0 bottom-0 z-[100] bg-bg lg:hidden w-full"
             padding={8}
             overflow="y-auto"
           >

--- a/src/components/ui/PathSelector.tsx
+++ b/src/components/ui/PathSelector.tsx
@@ -3,9 +3,9 @@ import { NavLink } from 'react-router-dom';
 
 export default function PathSelector() {
   return (
-    <div className="grid grid-cols-12 gap-0 border-y border-line min-h-[60vh]">
+    <div className="grid grid-cols-1 md:grid-cols-12 gap-0 border-y border-line min-h-[60vh] w-full">
       {/* Dancer Path: Lifestyle & Gear */}
-      <div className="col-span-12 lg:col-span-7 relative group overflow-hidden border-r border-line bg-gradient-to-br from-slate-900 to-blue-900 bg-[length:200%_200%] animate-gradient">
+      <div className="md:col-span-12 lg:col-span-7 relative group overflow-hidden border-r border-line bg-gradient-to-br from-slate-900 to-blue-900 bg-[length:200%_200%] animate-gradient w-full">
         {/* Scanning Scanline Effect */}
         <motion.div
            variants={{ hover: { top: '100%', opacity: 1 } }}
@@ -33,7 +33,7 @@ export default function PathSelector() {
       </div>
 
       {/* Tech Path: Robotics & AI */}
-      <div className="col-span-12 lg:col-span-5 relative group overflow-hidden bg-gradient-to-br from-slate-800 to-blue-950 bg-[length:200%_200%] animate-gradient">
+      <div className="md:col-span-12 lg:col-span-5 relative group overflow-hidden bg-gradient-to-br from-slate-800 to-blue-950 bg-[length:200%_200%] animate-gradient w-full">
         {/* Scanning Scanline Effect */}
         <motion.div
            variants={{ hover: { top: '100%', opacity: 1 } }}

--- a/src/features/email-capture/EmailCaptureBar.tsx
+++ b/src/features/email-capture/EmailCaptureBar.tsx
@@ -19,14 +19,16 @@ export function EmailCaptureBar() {
       position="fixed"
       inset="bottom"
       zIndex="top"
+      width="full"
     >
       <Stack 
         direction={{ base: 'col', md: 'row' }} 
         align="center" 
         justify="between" 
         gap={{ base: 4, md: 8 }}
+        className="w-full"
       >
-        <Stack direction="row" align="center" gap={4}>
+        <Stack direction="row" align="center" gap={4} className="w-full md:w-auto">
           <Box padding="compact" surface="accent" opacity={5} display={{ base: 'none', sm: 'block' }}>
             <Mail className="w-5 h-5 text-accent-brand" />
           </Box>

--- a/src/features/email-capture/EmailForm.tsx
+++ b/src/features/email-capture/EmailForm.tsx
@@ -8,8 +8,8 @@ export function EmailForm() {
   const { email, setEmail, status, handleSubmit } = useEmailCapture();
 
   return (
-    <Box as="form" onSubmit={handleSubmit} width="full" maxWidth="md">
-      <Stack direction="row" gap={0} position="relative">
+    <Box as="form" onSubmit={handleSubmit} width="full" maxWidth="md" className="w-full md:w-auto">
+      <Stack direction={{ base: 'col', sm: 'row' }} gap={{ base: 2, sm: 0 }} position="relative" className="w-full">
         <input
           type="email"
           placeholder="Email Address"
@@ -17,12 +17,13 @@ export function EmailForm() {
           onChange={(e) => setEmail(e.target.value)}
           required
           disabled={status === 'loading' || status === 'success'}
-          className={inputs.base}
+          className={`${inputs.base} min-h-[44px] w-full`}
         />
         <Button
           type="submit"
           disabled={status === 'loading' || status === 'success'}
           minWidth={60}
+          className="min-h-[44px] w-full sm:w-auto"
         >
           <AnimatePresence mode="wait">
             {status === 'loading' ? (

--- a/src/features/journal/BlogPost.tsx
+++ b/src/features/journal/BlogPost.tsx
@@ -76,7 +76,7 @@ export default function BlogPost() {
             </Box>
           )}
 
-          <Box className="prose prose-slate max-w-none prose-headings:font-display prose-p:font-sans prose-p:text-text-dim prose-strong:text-text-main">
+          <Box className="prose prose-sm md:prose-base prose-slate max-w-none w-full overflow-hidden break-words prose-headings:font-display prose-p:font-sans prose-p:text-text-dim prose-strong:text-text-main">
             <ReactMarkdown>{post.content}</ReactMarkdown>
           </Box>
 

--- a/src/features/resources/ResourceGallery.tsx
+++ b/src/features/resources/ResourceGallery.tsx
@@ -62,7 +62,7 @@ function ResourceDetails({ resource, onBack }: { resource: Resource; onBack: () 
           </Stack>
         </Stack>
 
-        <Box className="markdown-body prose prose-invert max-w-none text-text-body space-y-6">
+        <Box className="markdown-body prose prose-sm md:prose-base prose-invert max-w-none w-full overflow-hidden break-words text-text-body space-y-6">
           <Markdown>{resource.content}</Markdown>
         </Box>
       </Stack>

--- a/src/index.css
+++ b/src/index.css
@@ -69,7 +69,7 @@
 
 @layer base {
   body {
-    @apply bg-bg text-text-body font-sans antialiased;
+    @apply bg-bg text-text-body font-sans antialiased overflow-x-hidden w-full;
     line-height: 1.6;
   }
 
@@ -84,13 +84,13 @@
   h3 { font-size: clamp(1.5rem, 3vw, 2.25rem); }
 
   p {
-    max-width: 70ch;
-    @apply text-text-body;
+    max-width: 65ch;
+    @apply text-text-body break-words;
   }
 }
 
 .panel {
-  @apply bg-bg p-6 md:p-12 relative overflow-hidden;
+  @apply bg-bg p-4 sm:p-6 md:p-12 relative overflow-hidden w-full;
 }
 
 .nav-rail {
@@ -98,7 +98,7 @@
 }
 
 .main-grid {
-  @apply flex-1 grid grid-cols-1 lg:grid-cols-2 gap-[1px] bg-line;
+  @apply flex-1 grid grid-cols-1 md:grid-cols-2 gap-[1px] bg-line w-full;
 }
 
 .stats-widget {

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -7,15 +7,15 @@ import { GlobalSearch } from '@/components/GlobalSearch';
 
 export function MainLayout({ children }: { children: React.ReactNode }) {
   return (
-    <Box layout="root" className="min-h-screen relative">
+    <Box layout="root" className="min-h-screen relative overflow-x-hidden w-full">
       <GlobalSearch />
       
-      <Box display="flex" className="min-h-screen">
+      <Box display="flex" className="min-h-screen w-full">
         <Navigation />
-        <Box as="main" flex={1} position="relative" overflow="y-auto" className="bg-bg pt-16 lg:pt-0">
-          <Box paddingX={6} paddingY={12} className="mx-auto min-h-full max-w-7xl w-full">
-            <Stack gap={12}>
-              <Box flex={1}>
+        <Box as="main" flex={1} position="relative" overflow="y-auto" className="bg-bg pt-16 lg:pt-0 max-w-full w-full">
+          <Box paddingX={{ base: 4, md: 6, lg: 12 }} paddingY={12} className="mx-auto min-h-full max-w-7xl w-full">
+            <Stack gap={12} className="w-full">
+              <Box flex={1} className="w-full">
                 {children}
               </Box>
               <Footer />

--- a/src/styles/design-tokens.ts
+++ b/src/styles/design-tokens.ts
@@ -41,11 +41,11 @@ export const animation = {
 export const layout = {
   root: "flex min-h-screen bg-bg",
   navRail: "nav-rail hidden lg:flex flex-col justify-between min-h-screen sticky top-0",
-  mobileHeader: "lg:hidden fixed top-0 left-0 right-0 h-16 bg-surface z-[110] flex items-center justify-between px-6 border-b border-line",
-  panel: "panel h-full overflow-y-auto",
-  card: "bg-surface border border-line rounded-none transition-all duration-300",
+  mobileHeader: "lg:hidden fixed top-0 left-0 right-0 h-16 bg-surface z-[110] flex items-center justify-between px-6 border-b border-line w-full",
+  panel: "panel h-full overflow-y-auto w-full",
+  card: "bg-surface border border-line rounded-none transition-all duration-300 w-full",
   interactive: "cursor-pointer",
-  grid: "grid grid-cols-1 md:grid-cols-12 gap-8",
+  grid: "grid grid-cols-1 md:grid-cols-12 gap-4 md:gap-8 w-full",
   section: "mt-24 space-y-8",
   divider: "border-b border-line pb-4 flex items-end justify-between",
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -32,5 +32,7 @@ export default {
       }
     },
   },
-  plugins: [],
+  plugins: [
+    require('@tailwindcss/typography'),
+  ],
 }


### PR DESCRIPTION
Applied mobile-first layout optimizations based on the provided technical checklist.

Key resolutions:
1. **Viewport Overflow:** Addressed the root cause of horizontal scrolling by configuring `overflow-x-hidden` combined with fluid `w-full` attributes.
2. **Typography Restraints:** Added fluid spacing and strict width rules for paragraph elements ensuring readability constraints (`max-w-[65ch]`) so long lines/URLs break comfortably onto the next line without blowing out the layout.
3. **Component Grids:** Overhauled layout tokens (`design-tokens.ts`) and manual grids (`PathSelector.tsx`) to shift from absolute column counts to fluid responsive behavior (stacking on `base`, spreading out on `md`+).
4. **Touch-friendly Navigation:** Ensured navigation targets (like hamburger overlays) comply with minimum mobile touch-target sizes (`min-h-[44px]`) to reduce miss-clicks and improved flex handling.
5. **Sticky Captures:** Refactored the email capture UI to wrap flexibly on small vertical columns.
6. **Markdown Layouts:** Enforced appropriate document rendering limitations via `@tailwindcss/typography` usage with `break-words` and `overflow-hidden`.

---
*PR created automatically by Jules for task [7697949942638469296](https://jules.google.com/task/7697949942638469296) started by @arii*