### PR TITLE
Refactor UI Components with class-variance-authority Variants

### DIFF
--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,29 +1,22 @@
 import * as React from "react"
 import { cn } from "@/lib/utils"
 import { Text } from "@/layouts/Primitives"
-import { variants } from "@/styles/variants"
+import { badgeVariants } from "@/lib/variants"
+import type { VariantProps } from "class-variance-authority"
 
-interface BadgeProps extends React.ComponentProps<typeof Text> {
-  className?: string
-  intent?: keyof typeof variants.intent
-  emphasis?: keyof typeof variants.emphasis
-}
+export interface BadgeProps
+  extends Omit<React.ComponentProps<typeof Text>, "intent">,
+    VariantProps<typeof badgeVariants> {}
 
 function Badge({
   className,
-  intent = "default",
-  emphasis = "solid",
+  intent,
+  emphasis,
   ...props
 }: BadgeProps) {
   return (
     <Text
-      className={cn(
-        "inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden border px-2 py-0.5 text-[9px] font-mono font-bold uppercase tracking-widest whitespace-nowrap transition-all",
-        variants.intent[intent],
-        variants.emphasis[emphasis],
-        variants.radius.industrial,
-        className
-      )}
+      className={cn(badgeVariants({ intent, emphasis }), className)}
       {...props}
     />
   )

--- a/src/features/email-capture/EmailForm.tsx
+++ b/src/features/email-capture/EmailForm.tsx
@@ -26,11 +26,9 @@ export function EmailForm() {
         />
         <Button
           type="submit"
-          disabled={status !== 'idle'}
-          className="min-h-[44px] w-full sm:w-auto min-w-[180px] px-6"
           variant="primary"
           disabled={status === 'loading' || status === 'success'}
-          className="w-full sm:w-auto"
+          className="min-h-[44px] w-full sm:w-auto min-w-[180px] px-6"
         >
           <AnimatePresence mode="wait">
             <motion.div

--- a/src/layouts/Button.tsx
+++ b/src/layouts/Button.tsx
@@ -1,31 +1,25 @@
 import React from "react"
 import { cn } from "@/lib/utils"
-import { variants } from "@/styles/variants"
+import { buttonVariants } from "@/lib/variants"
 import { Box, BaseProps } from "./Box"
+import type { VariantProps } from "class-variance-authority"
 
-interface ButtonProps extends BaseProps, React.ButtonHTMLAttributes<HTMLButtonElement> {
-  variant?: keyof typeof variants.emphasis
-  intent?: keyof typeof variants.intent
-  size?: "sm" | "md" | "lg"
-  fullWidth?: boolean
+interface ButtonProps
+  extends BaseProps,
+    React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
   loading?: boolean
 }
 
 export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant = "solid", intent = "default", size = "md", fullWidth, loading, children, ...props }, ref) => {
+  ({ className, variant, intent, size, fullWidth, loading, children, ...props }, ref) => {
     return (
       <Box
         as="button"
         ref={ref as any}
         cursor="pointer"
         className={cn(
-          "inline-flex items-center justify-center transition-all duration-200 font-bold uppercase tracking-widest disabled:opacity-50 disabled:cursor-not-allowed min-h-[44px] min-w-[44px]",
-          variants.emphasis[variant],
-          intent && variants.intent[intent],
-          size === "sm" && "px-4 py-2 text-[10px]",
-          size === "md" && "px-6 py-3 text-xs",
-          size === "lg" && "px-8 py-4 text-sm",
-          fullWidth && "w-full",
+          buttonVariants({ variant, intent, size, fullWidth }),
           className
         )}
         {...props}

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -1,0 +1,58 @@
+import { cva } from "class-variance-authority";
+
+export const buttonVariants = cva(
+  "inline-flex items-center justify-center transition-all duration-200 font-bold uppercase tracking-widest disabled:opacity-50 disabled:cursor-not-allowed min-h-[44px] min-w-[44px]",
+  {
+    variants: {
+      variant: {
+        solid: "bg-text-main text-bg border-transparent",
+        outline: "border border-line bg-transparent",
+        ghost: "bg-transparent hover:bg-line/10",
+        primary: "bg-accent text-white font-mono tracking-widest text-[10px] px-8 hover:bg-text-main active:translate-y-[0px] hover:translate-y-[-2px] hover:shadow-[0_4px_12px_var(--color-accent-shadow)]",
+      },
+      intent: {
+        default: "text-text-main",
+        success: "text-accent-brand",
+        danger: "text-red-600",
+        warning: "text-accent",
+      },
+      size: {
+        sm: "px-4 py-2 text-[10px]",
+        md: "px-6 py-3 text-xs",
+        lg: "px-8 py-4 text-sm",
+      },
+      fullWidth: {
+        true: "w-full",
+      },
+    },
+    defaultVariants: {
+      variant: "solid",
+      intent: "default",
+      size: "md",
+    },
+  }
+);
+
+export const badgeVariants = cva(
+  "inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden border px-2 py-0.5 text-[9px] font-mono font-bold uppercase tracking-widest whitespace-nowrap transition-all rounded-[2px]",
+  {
+    variants: {
+      emphasis: {
+        solid: "bg-text-main text-bg border-transparent",
+        outline: "border border-line bg-transparent",
+        ghost: "bg-transparent hover:bg-line/10",
+        primary: "bg-accent text-white font-mono tracking-widest text-[10px] px-8 hover:bg-text-main active:translate-y-[0px] hover:translate-y-[-2px] hover:shadow-[0_4px_12px_var(--color-accent-shadow)]",
+      },
+      intent: {
+        default: "text-text-main",
+        success: "text-accent-brand",
+        danger: "text-red-600",
+        warning: "text-accent",
+      },
+    },
+    defaultVariants: {
+      emphasis: "solid",
+      intent: "default",
+    },
+  }
+);


### PR DESCRIPTION
This change extracts inline styling strings from UI components (`Button` and `Badge`) into a centralized file `src/lib/variants.ts` utilizing `class-variance-authority` (cva). Both components' Prop types have been mapped to extend `VariantProps` from `cva` maintaining type-safety while cleaning up component files. Also removed a duplicated className prop in `EmailForm.tsx` that previously caused JSX parser warnings. All tests and linters pass.

---
*PR created automatically by Jules for task [14319070911501169305](https://jules.google.com/task/14319070911501169305) started by @arii*