### PR TITLE
refactor: move and update variants to src/lib/variants.ts

### DIFF
--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import { cn } from "@/lib/utils"
 import { Text } from "@/layouts/Primitives"
-import { variants } from "@/styles/variants"
+import { variants } from "@/lib/variants"
 
 interface BadgeProps extends React.ComponentProps<typeof Text> {
   className?: string

--- a/src/layouts/Box.tsx
+++ b/src/layouts/Box.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { cn, composeStyles } from "@/lib/utils"
 import { spacing, layout as layoutTokens, shadows } from "@/styles/design-tokens"
-import { variants } from "@/styles/variants"
+import { variants } from "@/lib/variants"
 import { ResponsiveProp, getResponsiveClasses } from "./system-utils"
 
 export interface BaseProps {

--- a/src/layouts/Button.tsx
+++ b/src/layouts/Button.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { cn } from "@/lib/utils"
-import { variants } from "@/styles/variants"
+import { variants } from "@/lib/variants"
 import { Box, BaseProps } from "./Box"
 
 interface ButtonProps extends BaseProps, React.ButtonHTMLAttributes<HTMLButtonElement> {

--- a/src/layouts/Text.tsx
+++ b/src/layouts/Text.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { composeStyles } from "@/lib/utils"
 import { typography, typeSizes } from "@/styles/design-tokens"
-import { variants } from "@/styles/variants"
+import { variants } from "@/lib/variants"
 import { Box, BaseProps } from "./Box"
 import { getResponsiveClasses, type ResponsiveProp } from "./system-utils"
 

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -1,4 +1,4 @@
-import { typography } from "./design-tokens";
+import { typography } from "@/styles/design-tokens";
 
 /**
  * Standardized Variant Contracts for the Systems Console.


### PR DESCRIPTION
Moves the style variants definitions to `src/lib/variants.ts` to follow standard library conventions. Updates imports across all components to use the aliased path `@/lib/variants`. Fixes the internal import in the variants file itself to use `@/styles/design-tokens`. Ensure TypeScript type check passes.

---
*PR created automatically by Jules for task [10283396414818221058](https://jules.google.com/task/10283396414818221058) started by @arii*