### PR TITLE
Refactor layout variants to use CVA within the lib utility directory

### DIFF
--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import { cn } from "@/lib/utils"
 import { Text } from "@/layouts/Primitives"
-import { variants } from "@/styles/variants"
+import { variants } from "@/lib/variants"
 
 interface BadgeProps extends React.ComponentProps<typeof Text> {
   className?: string

--- a/src/layouts/Box.tsx
+++ b/src/layouts/Box.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { cn, composeStyles } from "@/lib/utils"
 import { spacing, layout as layoutTokens, shadows } from "@/styles/design-tokens"
-import { variants } from "@/styles/variants"
+import { variants } from "@/lib/variants"
 import { ResponsiveProp, getResponsiveClasses } from "./system-utils"
 
 export interface BaseProps {

--- a/src/layouts/Button.tsx
+++ b/src/layouts/Button.tsx
@@ -1,35 +1,26 @@
 import React from "react"
 import { cn } from "@/lib/utils"
-import { variants } from "@/lib/variants"
+import { buttonVariants } from "@/lib/variants"
+import { type VariantProps } from "class-variance-authority"
 import { Box, BaseProps } from "./Box"
 
-interface ButtonProps extends BaseProps, React.ButtonHTMLAttributes<HTMLButtonElement> {
+interface ButtonProps
+  extends BaseProps,
+    Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'color'>,
+    VariantProps<typeof buttonVariants> {
   as?: any
   href?: string
-  variant?: keyof typeof variants.emphasis
-  intent?: keyof typeof variants.intent
-  size?: "sm" | "md" | "lg"
-  fullWidth?: boolean
   loading?: boolean
 }
 
 export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, as = "button", variant = "solid", intent = "default", size = "md", fullWidth, loading, children, ...props }, ref) => {
+  ({ className, as = "button", variant, intent, size, fullWidth, loading, children, ...props }, ref) => {
     return (
       <Box
         as={as}
         ref={ref as any}
         cursor="pointer"
-        className={cn(
-          "inline-flex items-center justify-center transition-all duration-200 font-bold uppercase tracking-widest disabled:opacity-50 disabled:cursor-not-allowed min-h-[44px] min-w-[44px]",
-          variants.emphasis[variant],
-          variants.intent[intent],
-          size === "sm" && "px-4 py-2 text-[10px]",
-          size === "md" && "px-6 py-3 text-xs",
-          size === "lg" && "px-8 py-4 text-sm",
-          fullWidth && "w-full",
-          className
-        )}
+        className={cn(buttonVariants({ variant, intent, size, fullWidth }), className)}
         {...props}
       >
         {children}

--- a/src/layouts/Button.tsx
+++ b/src/layouts/Button.tsx
@@ -1,9 +1,11 @@
 import React from "react"
 import { cn } from "@/lib/utils"
-import { variants } from "@/styles/variants"
+import { variants } from "@/lib/variants"
 import { Box, BaseProps } from "./Box"
 
 interface ButtonProps extends BaseProps, React.ButtonHTMLAttributes<HTMLButtonElement> {
+  as?: any
+  href?: string
   variant?: keyof typeof variants.emphasis
   intent?: keyof typeof variants.intent
   size?: "sm" | "md" | "lg"
@@ -12,10 +14,10 @@ interface ButtonProps extends BaseProps, React.ButtonHTMLAttributes<HTMLButtonEl
 }
 
 export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant = "solid", intent = "default", size = "md", fullWidth, loading, children, ...props }, ref) => {
+  ({ className, as = "button", variant = "solid", intent = "default", size = "md", fullWidth, loading, children, ...props }, ref) => {
     return (
       <Box
-        as="button"
+        as={as}
         ref={ref as any}
         cursor="pointer"
         className={cn(

--- a/src/layouts/Text.tsx
+++ b/src/layouts/Text.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { composeStyles } from "@/lib/utils"
 import { typography, typeSizes } from "@/styles/design-tokens"
-import { variants } from "@/styles/variants"
+import { variants } from "@/lib/variants"
 import { Box, BaseProps } from "./Box"
 import { getResponsiveClasses, type ResponsiveProp } from "./system-utils"
 

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -1,4 +1,5 @@
 import { typography } from "@/styles/design-tokens";
+import { cva } from "class-variance-authority";
 
 /**
  * Standardized Variant Contracts for the Systems Console.
@@ -28,4 +29,27 @@ export const variants = {
     none: "rounded-none",
     industrial: "rounded-[2px]",
   }
-}
+};
+
+export const buttonVariants = cva(
+  "inline-flex items-center justify-center transition-all duration-200 font-bold uppercase tracking-widest disabled:opacity-50 disabled:cursor-not-allowed min-h-[44px] min-w-[44px]",
+  {
+    variants: {
+      variant: variants.emphasis,
+      intent: variants.intent,
+      size: {
+        sm: "px-4 py-2 text-[10px]",
+        md: "px-6 py-3 text-xs",
+        lg: "px-8 py-4 text-sm",
+      },
+      fullWidth: {
+        true: "w-full",
+      },
+    },
+    defaultVariants: {
+      variant: "solid",
+      intent: "default",
+      size: "md",
+    },
+  }
+);

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -1,4 +1,4 @@
-import { typography } from "./design-tokens";
+import { typography } from "@/styles/design-tokens";
 
 /**
  * Standardized Variant Contracts for the Systems Console.


### PR DESCRIPTION
Addresses the requirement to use `class-variance-authority` by installing it, moving the `variants.ts` config to `src/lib`, and updating component imports. Added polymorphic support (`as` prop) to the `Button` component allowing it to correctly render as anchor links across the app while inheriting styling.

---
*PR created automatically by Jules for task [11203642981149612388](https://jules.google.com/task/11203642981149612388) started by @arii*