### PR TITLE
Fix GearPost array crash and Refactor Button to use cva

### DIFF
--- a/src/layouts/Button.tsx
+++ b/src/layouts/Button.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { cn } from "@/lib/utils"
 import { variants } from "@/styles/variants"
+import { buttonVariants } from "@/lib/variants"
 import { Box, BaseProps } from "./Box"
 
 interface ButtonProps extends BaseProps, React.ButtonHTMLAttributes<HTMLButtonElement> {
@@ -18,16 +19,12 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         as="button"
         ref={ref as any}
         cursor="pointer"
-        className={cn(
-          "inline-flex items-center justify-center transition-all duration-200 font-bold uppercase tracking-widest disabled:opacity-50 disabled:cursor-not-allowed min-h-[44px] min-w-[44px]",
-          variants.emphasis[variant],
-          variants.intent[intent],
-          size === "sm" && "px-4 py-2 text-[10px]",
-          size === "md" && "px-6 py-3 text-xs",
-          size === "lg" && "px-8 py-4 text-sm",
-          fullWidth && "w-full",
-          className
-        )}
+        className={cn(buttonVariants({
+          variant: variant as any,
+          intent: intent as any,
+          size: size as any,
+          fullWidth
+        }), className)}
         {...props}
       >
         {children}

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -19,14 +19,29 @@ function parseFrontmatter(content: string) {
     const [key, ...vals] = line.split(':');
     if (key && vals.length) {
       let value = vals.join(':').trim();
-      // Basic type conversion
-      if (value.startsWith('"') && value.endsWith('"')) value = value.slice(1, -1);
-      else if (value.startsWith("'") && value.endsWith("'")) value = value.slice(1, -1);
-
-      if (value.includes(',')) {
-        data[key.trim()] = value.split(',').map(v => v.trim());
+      // Handle arrays
+      if (value.startsWith('[') && value.endsWith(']')) {
+        const inner = value.slice(1, -1).trim();
+        if (inner.length === 0) {
+          data[key.trim()] = [];
+        } else {
+          data[key.trim()] = inner.split(',').map(v => {
+            let item = v.trim();
+            if (item.startsWith('"') && item.endsWith('"')) item = item.slice(1, -1);
+            else if (item.startsWith("'") && item.endsWith("'")) item = item.slice(1, -1);
+            return item;
+          });
+        }
       } else {
-        data[key.trim()] = value;
+        // Basic type conversion for strings
+        if (value.startsWith('"') && value.endsWith('"')) value = value.slice(1, -1);
+        else if (value.startsWith("'") && value.endsWith("'")) value = value.slice(1, -1);
+
+        if (value.includes(',')) {
+          data[key.trim()] = value.split(',').map(v => v.trim());
+        } else {
+          data[key.trim()] = value;
+        }
       }
     }
   });

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -18,14 +18,15 @@ function parseFrontmatter(content: string) {
   yaml.split('\n').forEach(line => {
     const [key, ...vals] = line.split(':');
     if (key && vals.length) {
+      const parsedKey = key.trim();
       let value = vals.join(':').trim();
       // Handle arrays
       if (value.startsWith('[') && value.endsWith(']')) {
         const inner = value.slice(1, -1).trim();
         if (inner.length === 0) {
-          data[key.trim()] = [];
+          data[parsedKey] = [];
         } else {
-          data[key.trim()] = inner.split(',').map(v => {
+          data[parsedKey] = inner.split(',').map(v => {
             let item = v.trim();
             if (item.startsWith('"') && item.endsWith('"')) item = item.slice(1, -1);
             else if (item.startsWith("'") && item.endsWith("'")) item = item.slice(1, -1);
@@ -38,9 +39,9 @@ function parseFrontmatter(content: string) {
         else if (value.startsWith("'") && value.endsWith("'")) value = value.slice(1, -1);
 
         if (value.includes(',')) {
-          data[key.trim()] = value.split(',').map(v => v.trim());
+          data[parsedKey] = value.split(',').map(v => v.trim());
         } else {
-          data[key.trim()] = value;
+          data[parsedKey] = value;
         }
       }
     }

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -1,0 +1,25 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import { variants } from "@/styles/variants";
+
+export const buttonVariants = cva(
+  "inline-flex items-center justify-center transition-all duration-200 font-bold uppercase tracking-widest disabled:opacity-50 disabled:cursor-not-allowed min-h-[44px] min-w-[44px]",
+  {
+    variants: {
+      variant: variants.emphasis,
+      intent: variants.intent,
+      size: {
+        sm: "px-4 py-2 text-[10px]",
+        md: "px-6 py-3 text-xs",
+        lg: "px-8 py-4 text-sm",
+      },
+      fullWidth: {
+        true: "w-full",
+      },
+    },
+    defaultVariants: {
+      variant: "solid",
+      intent: "default",
+      size: "md",
+    },
+  }
+);


### PR DESCRIPTION
This PR addresses two objectives:
1. It resolves a crash on the `/gear/loop-earplugs` detail page where `affiliateIds.map is not a function`. The custom frontmatter parser in `src/lib/content.ts` previously read single-item bracketed arrays as raw strings. The parser was updated to correctly unwrap bracketed strings into JavaScript arrays.
2. It refactors UI component styling logic as requested by moving the `Button` classes into a `class-variance-authority` pattern exported from a new `src/lib/variants.ts` file. The layout `<Button />` was subsequently updated to use `buttonVariants()`.

---
*PR created automatically by Jules for task [1648823517728215132](https://jules.google.com/task/1648823517728215132) started by @arii*