### PR TITLE
Remove unused Gemini API key environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,2 @@
-# Required for Gemini AI API calls
-VITE_GEMINI_API_KEY=""
-
 # The URL where this applet is hosted
 VITE_APP_URL=""


### PR DESCRIPTION
Removed the unused `VITE_GEMINI_API_KEY` and its corresponding comment from `.env.example`. Validated changes by successfully running `pnpm run lint` and `pnpm run build`.

---
*PR created automatically by Jules for task [14556091900584290347](https://jules.google.com/task/14556091900584290347) started by @arii*