### PR TITLE
Fix syntax error in `vite.config.ts`

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -38,8 +38,6 @@ export default defineConfig(({mode}) => {
           multipass: true,
         },
       }),
-    ],
-      ViteImageOptimizer(),
       analyze && visualizer({
         open: false,
         filename: 'bundle-analysis.html',


### PR DESCRIPTION
Fixes a syntax error in `vite.config.ts` where the `plugins` array was prematurely closed and `ViteImageOptimizer()` was duplicated, causing build errors.

---
*PR created automatically by Jules for task [5645611927521851530](https://jules.google.com/task/5645611927521851530) started by @arii*