### PR TITLE
Refactor variants separation and cleanup redundant imports

### DIFF
--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,7 +1,6 @@
 import * as React from "react"
 import { cn } from "@/lib/utils"
 import { Text } from "@/layouts/Primitives"
-import { variants } from "@/lib/variants"
 import { badgeVariants } from "@/lib/variants"
 import type { VariantProps } from "class-variance-authority"
 

--- a/src/layouts/Box.tsx
+++ b/src/layouts/Box.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { cn, composeStyles } from "@/lib/utils"
 import { spacing, layout as layoutTokens, shadows, zIndex as zIndexTokens } from "@/styles/design-tokens"
-import { variants } from "@/lib/variants"
+import { variants } from "@/styles/variants"
 import { ResponsiveProp, getResponsiveClasses } from "./system-utils"
 
 export interface BaseProps {

--- a/src/layouts/Button.tsx
+++ b/src/layouts/Button.tsx
@@ -1,6 +1,5 @@
 import React from "react"
 import { cn } from "@/lib/utils"
-import { variants } from "@/lib/variants"
 import { buttonVariants } from "@/lib/variants"
 import { Box, BaseProps } from "./Box"
 import type { VariantProps } from "class-variance-authority"

--- a/src/layouts/Text.tsx
+++ b/src/layouts/Text.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { composeStyles } from "@/lib/utils"
 import { typography, typeSizes } from "@/styles/design-tokens"
-import { variants } from "@/lib/variants"
+import { variants } from "@/styles/variants"
 import { Box, BaseProps } from "./Box"
 import { getResponsiveClasses, type ResponsiveProp } from "./system-utils"
 

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -1,34 +1,3 @@
-import { typography } from "@/styles/design-tokens";
-
-/**
- * Standardized Variant Contracts for the Systems Console.
- * Ensures all components share a common mental model for intent, surface, and emphasis.
- */
-export const variants = {
-  surface: {
-    default: "bg-surface text-text-main",
-    muted: "bg-line/50 text-text-dim",
-    accent: "bg-accent-brand/5 border-accent-brand/20 text-accent-brand",
-    card: "bg-card-bg border-line",
-    contrast: "bg-text-main text-bg",
-  },
-  intent: {
-    default: "text-text-main",
-    success: "text-accent-brand", 
-    danger: "text-red-600",
-    warning: "text-accent",
-  },
-  emphasis: {
-    solid: "bg-text-main text-bg border-transparent",
-    outline: "border border-line bg-transparent",
-    ghost: "bg-transparent hover:bg-line/10",
-    primary: "bg-accent text-white font-mono tracking-widest text-[10px] px-8 hover:bg-text-main active:translate-y-[0px] hover:translate-y-[-2px] hover:shadow-[0_4px_12px_var(--color-accent-shadow)]",
-  },
-  radius: {
-    none: "rounded-none",
-    industrial: "rounded-[2px]",
-  }
-}
 import { cva } from "class-variance-authority";
 
 export const buttonVariants = cva(

--- a/src/styles/variants.ts
+++ b/src/styles/variants.ts
@@ -1,0 +1,29 @@
+/**
+ * Standardized Variant Contracts for the Systems Console.
+ * Ensures all components share a common mental model for intent, surface, and emphasis.
+ */
+export const variants = {
+  surface: {
+    default: "bg-surface text-text-main",
+    muted: "bg-line/50 text-text-dim",
+    accent: "bg-accent-brand/5 border-accent-brand/20 text-accent-brand",
+    card: "bg-card-bg border-line",
+    contrast: "bg-text-main text-bg",
+  },
+  intent: {
+    default: "text-text-main",
+    success: "text-accent-brand",
+    danger: "text-red-600",
+    warning: "text-accent",
+  },
+  emphasis: {
+    solid: "bg-text-main text-bg border-transparent",
+    outline: "border border-line bg-transparent",
+    ghost: "bg-transparent hover:bg-line/10",
+    primary: "bg-accent text-white font-mono tracking-widest text-[10px] px-8 hover:bg-text-main active:translate-y-[0px] hover:translate-y-[-2px] hover:shadow-[0_4px_12px_var(--color-accent-shadow)]",
+  },
+  radius: {
+    none: "rounded-none",
+    industrial: "rounded-[2px]",
+  }
+};


### PR DESCRIPTION
* Extracted raw design tokens (`surface`, `intent`, `emphasis`, `radius`) to `src/styles/variants.ts`.
* Kept CVA structural logic (`buttonVariants`, `badgeVariants`) in `src/lib/variants.ts`.
* Removed redundant `variants` imports from `badge.tsx` and `Button.tsx`.
* Updated `Box.tsx` and `Text.tsx` to reference the correct `styles/variants` import.

---
*PR created automatically by Jules for task [339358960566442601](https://jules.google.com/task/339358960566442601) started by @arii*