### PR TITLE
Fix Multi-Deploy Concurrency and Implement Cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,11 @@ name: CI
 
 on:
   push:
-    branches: [main, develop]
+    branches:
+      - '**'
   pull_request:
-    branches: [main]
+    branches:
+      - '**'
 
 permissions:
   contents: read
@@ -12,6 +14,9 @@ permissions:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   build-and-test:
@@ -27,7 +32,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -1,0 +1,34 @@
+name: Cleanup Deleted Branch Previews
+
+on:
+  delete:
+
+concurrency:
+  group: "gh-pages-publish"
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    if: github.event.ref_type == 'branch' && (startsWith(github.event.ref, 'feature/') || startsWith(github.event.ref, 'feat/') || startsWith(github.event.ref, 'fix/') || startsWith(github.event.ref, 'ux/'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+
+      - name: Remove branch folder
+        run: |
+          if [ -d "${{ github.event.ref }}" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+
+            git rm -r "${{ github.event.ref }}"
+            git commit -m "chore: cleanup preview site for deleted branch ${{ github.event.ref }}"
+            git pull --rebase origin gh-pages
+            git push origin gh-pages
+          else
+            echo "Directory ${{ github.event.ref }} not found. Nothing to clean up."
+          fi

--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -7,9 +7,12 @@ concurrency:
   group: "gh-pages-publish"
   cancel-in-progress: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   cleanup:
-    if: github.event.ref_type == 'branch' && (startsWith(github.event.ref, 'feature/') || startsWith(github.event.ref, 'feat/') || startsWith(github.event.ref, 'fix/') || startsWith(github.event.ref, 'ux/'))
+    if: github.event.ref_type == 'branch' && github.event.ref != 'main'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,10 +40,11 @@ jobs:
 
       - name: Build Site
         run: |
+          REPO_NAME=${{ github.event.repository.name }}
           if [ "${{ github.ref_name }}" = "main" ]; then
-            export VITE_BASE_PATH=/tech-dancer/
+            export VITE_BASE_PATH=/$REPO_NAME/
           else
-            export VITE_BASE_PATH=/tech-dancer/${{ github.ref_name }}/
+            export VITE_BASE_PATH=/$REPO_NAME/${{ github.ref_name }}/
           fi
           pnpm run build
 
@@ -57,7 +58,7 @@ jobs:
           user_name: 'github-actions[bot]'
           user_email: 'github-actions[bot]@users.noreply.github.com'
 
-      - name: Post Comment on PR
+      - name: Post or Update Comment on PR
         uses: actions/github-script@v7
         with:
           script: |
@@ -77,11 +78,30 @@ jobs:
             for (const pr of pullRequests) {
               const baseUrl = `https://${owner}.github.io/${repo}/`;
               const previewUrl = `${baseUrl}${branchName}/`;
+              const commentTag = `<!-- preview-url-comment-${branchName} -->`;
+              const body = `🚀 **Deployment Complete!**\n\n- **Main Site:** ${baseUrl}\n- **Preview URL:** ${previewUrl}\n\n${commentTag}`;
 
-              await github.rest.issues.createComment({
+              const { data: comments } = await github.rest.issues.listComments({
+                owner,
+                repo,
                 issue_number: pr.number,
-                owner: owner,
-                repo: repo,
-                body: `🚀 **Deployment Complete!**\n\n- **Main Site:** ${baseUrl}\n- **Preview URL:** ${previewUrl}`
               });
+
+              const existingComment = comments.find(c => c.body.includes(commentTag));
+
+              if (existingComment) {
+                await github.rest.issues.updateComment({
+                  owner,
+                  repo,
+                  comment_id: existingComment.id,
+                  body,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  issue_number: pr.number,
+                  owner,
+                  repo,
+                  body,
+                });
+              }
             }

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,6 +58,26 @@ jobs:
           user_name: 'github-actions[bot]'
           user_email: 'github-actions[bot]@users.noreply.github.com'
 
+      # GitHub Pages only serves the root 404.html for all 404s, regardless of
+      # which subdirectory the request is for. Branch previews deploy their
+      # dist/ to a subdirectory, so their 404.html is never served by GitHub
+      # Pages. This step ensures the root 404.html is always the latest smart
+      # redirect version after any branch push.
+      - name: Update root 404.html on gh-pages for branch previews
+        if: github.ref_name != 'main'
+        run: mkdir -p /tmp/root-404 && cp dist/404.html /tmp/root-404/404.html
+
+      - name: Deploy root 404.html to gh-pages
+        if: github.ref_name != 'main'
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: /tmp/root-404
+          destination_dir: .
+          keep_files: true
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
+
       - name: Post or Update Comment on PR
         uses: actions/github-script@v7
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,21 +4,27 @@ on:
   push:
     branches:
       - main
+      - 'feature/*'
+      - 'feat/*'
+      - 'fix/*'
+      - 'ux/*'
 
 permissions:
-  contents: read
+  contents: write
   pages: write
   id-token: write
+  pull-requests: write
+  issues: write
 
 concurrency:
-  group: "pages"
+  group: "gh-pages-publish"
   cancel-in-progress: false
 
 jobs:
-  build:
+  build_and_deploy:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
+      - name: Checkout Branch
         uses: actions/checkout@v4
 
       - name: Setup pnpm
@@ -27,29 +33,56 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: 'pnpm'
 
-      - name: Install dependencies
+      - name: Install Dependencies
         run: pnpm install
 
-      - name: Build the app
-        run: pnpm run build
-        env:
-          NODE_ENV: production
+      - name: Build Site
+        run: |
+          if [ "${{ github.ref_name }}" = "main" ]; then
+            export VITE_BASE_PATH=/tech-dancer/
+          else
+            export VITE_BASE_PATH=/tech-dancer/${{ github.ref_name }}/
+          fi
+          pnpm run build
 
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+      - name: Deploy to gh-pages branch
+        uses: peaceiris/actions-gh-pages@v4
         with:
-          path: ./dist
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist
+          destination_dir: ${{ github.ref_name == 'main' && '.' || github.ref_name }}
+          keep_files: true
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
 
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+      - name: Post Comment on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const branchName = context.ref.replace('refs/heads/', '');
+
+            if (branchName === 'main') return;
+
+            const { data: pullRequests } = await github.rest.pulls.list({
+              owner,
+              repo,
+              head: `${owner}:${branchName}`,
+              state: 'open'
+            });
+
+            for (const pr of pullRequests) {
+              const baseUrl = `https://${owner}.github.io/${repo}/`;
+              const previewUrl = `${baseUrl}${branchName}/`;
+
+              await github.rest.issues.createComment({
+                issue_number: pr.number,
+                owner: owner,
+                repo: repo,
+                body: `🚀 **Deployment Complete!**\n\n- **Main Site:** ${baseUrl}\n- **Preview URL:** ${previewUrl}`
+              });
+            }

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,11 +3,7 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches:
-      - main
-      - 'feature/*'
-      - 'feat/*'
-      - 'fix/*'
-      - 'ux/*'
+      - '**'
 
 permissions:
   contents: write
@@ -19,6 +15,9 @@ permissions:
 concurrency:
   group: "gh-pages-publish"
   cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   build_and_deploy:

--- a/public/404.html
+++ b/public/404.html
@@ -4,15 +4,56 @@
     <meta charset="utf-8">
     <title>Tech-Dancer // Redirecting...</title>
     <script type="text/javascript">
-      const l = window.location;
-      const pathSegmentsToKeep = l.pathname.toLowerCase().startsWith('/tech-dancer') ? 1 : 0;
-      l.replace(
-        l.protocol + '//' + l.hostname + (l.port ? ':' + l.port : '') +
-        l.pathname.split('/').slice(0, 1 + pathSegmentsToKeep).join('/') + '/?/' +
-        l.pathname.split('/').slice(1 + pathSegmentsToKeep).join('/').replace(/&/g, '~and~') +
-        (l.search ? '&' + l.search.slice(1).replace(/&/g, '~and~') : '') +
-        l.hash
-      );
+      // SPA redirect for GitHub Pages. Works for both the main deployment
+      // (/tech-dancer/) and branch preview deployments
+      // (/tech-dancer/<branch-type>/<branch-name>/).
+      //
+      // GitHub Pages only serves one 404.html (from the repo root), so this
+      // script must handle redirects for all deployment depths. It walks up the
+      // path hierarchy using HEAD requests to find the deepest index.html that
+      // exists, then redirects to that index with the remaining path encoded as
+      // a query string (picked up by the redirect script in index.html).
+      (function () {
+        var l = window.location;
+        var pathParts = l.pathname.split('/').filter(function (p) { return p !== ''; });
+        // e.g. ['tech-dancer', 'fix', 'branch-name', 'blog']
+
+        function redirect(baseDepth) {
+          var basePath = '/' + pathParts.slice(0, baseDepth).join('/') + '/';
+          var routePath = pathParts.slice(baseDepth).join('/').replace(/&/g, '~and~');
+          l.replace(
+            l.protocol + '//' + l.hostname + (l.port ? ':' + l.port : '') +
+            basePath + '?/' + routePath +
+            (l.search ? '&' + l.search.slice(1).replace(/&/g, '~and~') : '') +
+            l.hash
+          );
+        }
+
+        // Fire HEAD requests for every candidate depth in parallel, then pick
+        // the deepest index.html that returns HTTP 200. A branch preview at
+        // depth 3 wins over the main site at depth 1.
+        var checks = pathParts.map(function (_, i) {
+          var depth = i + 1;
+          return fetch(
+            '/' + pathParts.slice(0, depth).join('/') + '/index.html',
+            { method: 'HEAD', cache: 'no-store' }
+          )
+            .then(function (r) { return r.ok ? depth : 0; })
+            .catch(function () { return 0; });
+        });
+
+        Promise.all(checks).then(function (depths) {
+          var best = Math.max.apply(null, depths);
+          if (best > 0) {
+            redirect(best);
+          } else {
+            // All probes failed (network error or no index.html found).
+            // Fall back to the repo root so the user sees something useful.
+            console.error('[404] Could not locate an index.html for', l.pathname, '– falling back to depth 1');
+            redirect(1);
+          }
+        });
+      })();
     </script>
   </head>
   <body>


### PR DESCRIPTION
Implemented a robust multi-branch deployment strategy for GitHub Pages. 

Key changes:
- Modified `.github/workflows/deploy.yml` to deploy feature branches into sub-directories while keeping `main` at the root.
- Introduced a shared concurrency group `gh-pages-publish` with `cancel-in-progress: false` across both deployment and cleanup workflows to ensure Git operations are queued and processed sequentially, preventing push conflicts.
- Added `.github/workflows/cleanup-preview.yml` which automatically deletes the corresponding folder on the `gh-pages` branch when a feature branch is deleted.
- Updated the build environment to Node.js 24.
- Refined the PR comment logic to correctly identify and link to the branch-specific preview URLs.
- Verified the build and routing logic with linting, type-checking, and Playwright smoke tests.

Fixes #119

---
*PR created automatically by Jules for task [2103566858933977717](https://jules.google.com/task/2103566858933977717) started by @arii*