### PR TITLE
Fix PathSelector grayscale and scanline hover animations

### DIFF
--- a/src/components/ui/PathSelector.tsx
+++ b/src/components/ui/PathSelector.tsx
@@ -1,74 +1,90 @@
 import { useState } from 'react';
 import { NavLink } from 'react-router-dom';
 
+type PathID = 'dancer' | 'roboticist';
+
+const PATH_DATA = [
+  {
+    id: 'dancer' as PathID,
+    title: 'ARE YOU A DANCER?',
+    wrapperClass: 'lg:col-span-7 border-r border-line/20',
+    bgGradient: 'bg-gradient-to-br',
+    titleClass: 'text-4xl md:text-6xl',
+    links: [
+      { text: 'Lifestyle blog posts', to: '/blog?category=Lifestyle' },
+      { text: 'Gear reviews', to: '/gear' },
+    ],
+  },
+  {
+    id: 'roboticist' as PathID,
+    title: 'HIRING A ROBOTICIST?',
+    wrapperClass: 'lg:col-span-5',
+    bgGradient: 'bg-gradient-to-bl',
+    titleClass: 'text-3xl md:text-5xl',
+    scanlineDelay: 'delay-100',
+    links: [
+      { text: 'Tech blog posts', to: '/blog?category=Tech' },
+      { text: 'Data & Development Lab', to: '/research' },
+    ],
+  },
+];
+
 export default function PathSelector() {
-  const [hoveredPath, setHoveredPath] = useState<'dancer' | 'roboticist' | null>(null);
+  const [hoveredPath, setHoveredPath] = useState<PathID | null>(null);
 
   return (
     <div className="grid grid-cols-1 lg:grid-cols-12 gap-0 border-y border-line min-h-[60vh] w-full bg-black">
-      {/* --- DANCER PATH --- */}
-      <div
-        className="lg:col-span-7 relative group overflow-hidden cursor-pointer border-r border-line/20"
-        onMouseEnter={() => setHoveredPath('dancer')}
-        onMouseLeave={() => setHoveredPath(null)}
-      >
-        {/* Background: Colored by default, grayscales if other is hovered */}
-        <div className={`absolute inset-0 bg-gradient-to-br from-accent/30 to-black transition-all duration-700 ease-in-out ${hoveredPath === 'roboticist' ? 'grayscale opacity-60' : 'opacity-100'}`}></div>
+      {PATH_DATA.map((path) => {
+        const isHovered = hoveredPath === path.id;
+        const isOtherHovered = hoveredPath !== null && !isHovered;
 
-        {/* Scanline: Hidden by default, visible and scanning ONLY when hovered */}
-        <div className={`absolute left-0 top-0 w-full h-[2px] bg-accent shadow-[0_0_15px_#FF7F50] pointer-events-none transition-opacity duration-500 ${hoveredPath === 'dancer' ? 'opacity-100 animate-scanline' : 'opacity-0'}`}></div>
+        return (
+          <div
+            key={path.id}
+            className={`${path.wrapperClass} relative group overflow-hidden cursor-pointer`}
+            onMouseEnter={() => setHoveredPath(path.id)}
+            onMouseLeave={() => setHoveredPath(null)}
+          >
+            {/* Background */}
+            <div
+              className={`absolute inset-0 ${path.bgGradient} from-accent/30 to-black transition-all duration-700 ease-in-out ${
+                isOtherHovered ? 'grayscale opacity-60' : 'opacity-100'
+              }`}
+            ></div>
 
-        {/* Content Container */}
-        <div className="relative z-20 p-12 h-full flex flex-col justify-end bg-gradient-to-t from-black/80 via-black/20 to-transparent">
-          <h2 className="text-4xl md:text-6xl font-display font-black mb-4 text-white transition-transform duration-500 group-hover:translate-x-2">
-            ARE YOU A DANCER?
-          </h2>
-          <ul className="space-y-4 mb-6 font-mono text-sm tracking-widest uppercase text-white font-bold opacity-80 group-hover:opacity-100 transition-opacity duration-500 delay-75">
-            <li>
-              <NavLink className="hover:text-accent transition-colors flex items-center gap-2" to="/blog?category=Lifestyle">
-                <span className="text-accent transition-transform duration-300 group-hover:translate-x-1">→</span> Lifestyle blog posts
-              </NavLink>
-            </li>
-            <li>
-              <NavLink className="hover:text-accent transition-colors flex items-center gap-2" to="/gear">
-                <span className="text-accent transition-transform duration-300 group-hover:translate-x-1">→</span> Gear reviews
-              </NavLink>
-            </li>
-          </ul>
-        </div>
-      </div>
+            {/* Scanline */}
+            <div
+              className={`absolute left-0 top-0 w-full h-[2px] bg-accent shadow-[0_0_15px_#FF7F50] z-10 pointer-events-none transition-opacity duration-500 ${
+                path.scanlineDelay || ''
+              } ${isHovered ? 'opacity-100 animate-scanline' : 'opacity-0'}`}
+            ></div>
 
-      {/* --- ROBOTICIST PATH --- */}
-      <div
-        className="lg:col-span-5 relative group overflow-hidden cursor-pointer"
-        onMouseEnter={() => setHoveredPath('roboticist')}
-        onMouseLeave={() => setHoveredPath(null)}
-      >
-        {/* Background: Colored by default, grayscales if other is hovered */}
-        <div className={`absolute inset-0 bg-gradient-to-bl from-accent/30 to-black transition-all duration-700 ease-in-out ${hoveredPath === 'dancer' ? 'grayscale opacity-60' : 'opacity-100'}`}></div>
-
-        {/* Scanline: Hidden by default, visible and scanning ONLY when hovered */}
-        <div className={`absolute left-0 top-0 w-full h-[2px] bg-accent shadow-[0_0_15px_#FF7F50] z-10 pointer-events-none transition-opacity duration-500 ${hoveredPath === 'roboticist' ? 'opacity-100 animate-scanline delay-100' : 'opacity-0'}`}></div>
-
-        {/* Content Container */}
-        <div className="relative z-20 p-12 h-full flex flex-col justify-end bg-gradient-to-t from-black/80 via-black/20 to-transparent">
-          <h2 className="text-3xl md:text-5xl font-display font-black mb-4 text-white transition-transform duration-500 group-hover:translate-x-2">
-            HIRING A ROBOTICIST?
-          </h2>
-          <ul className="space-y-4 mb-6 font-mono text-sm tracking-widest uppercase text-white font-bold opacity-80 group-hover:opacity-100 transition-opacity duration-500 delay-75">
-            <li>
-              <NavLink className="hover:text-accent transition-colors flex items-center gap-2" to="/blog?category=Tech">
-                <span className="text-accent transition-transform duration-300 group-hover:translate-x-1">→</span> Tech blog posts
-              </NavLink>
-            </li>
-            <li>
-              <NavLink className="hover:text-accent transition-colors flex items-center gap-2" to="/research">
-                <span className="text-accent transition-transform duration-300 group-hover:translate-x-1">→</span> Data &amp; Development Lab
-              </NavLink>
-            </li>
-          </ul>
-        </div>
-      </div>
+            {/* Content Container */}
+            <div className="relative z-20 p-12 h-full flex flex-col justify-end bg-gradient-to-t from-black/80 via-black/20 to-transparent">
+              <h2
+                className={`${path.titleClass} font-display font-black mb-4 text-white transition-transform duration-500 group-hover:translate-x-2`}
+              >
+                {path.title}
+              </h2>
+              <ul className="space-y-4 mb-6 font-mono text-sm tracking-widest uppercase text-white font-bold opacity-80 group-hover:opacity-100 transition-opacity duration-500 delay-75">
+                {path.links.map((link) => (
+                  <li key={link.text}>
+                    <NavLink
+                      className="hover:text-accent transition-colors flex items-center gap-2"
+                      to={link.to}
+                    >
+                      <span className="text-accent transition-transform duration-300 group-hover:translate-x-1">
+                        →
+                      </span>{' '}
+                      {link.text}
+                    </NavLink>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/src/components/ui/PathSelector.tsx
+++ b/src/components/ui/PathSelector.tsx
@@ -1,15 +1,22 @@
+import { useState } from 'react';
 import { NavLink } from 'react-router-dom';
 
 export default function PathSelector() {
+  const [hoveredPath, setHoveredPath] = useState<'dancer' | 'roboticist' | null>(null);
+
   return (
     <div className="grid grid-cols-1 lg:grid-cols-12 gap-0 border-y border-line min-h-[60vh] w-full bg-black">
       {/* --- DANCER PATH --- */}
-      <div className="lg:col-span-7 relative group overflow-hidden cursor-pointer border-r border-line/20">
-        {/* Background: Grayscale by default, colored on hover */}
-        <div className="absolute inset-0 bg-gradient-to-br from-neutral-800/40 to-black group-hover:from-accent/30 group-hover:to-black transition-all duration-700 ease-in-out opacity-60 group-hover:opacity-100"></div>
+      <div
+        className="lg:col-span-7 relative group overflow-hidden cursor-pointer border-r border-line/20"
+        onMouseEnter={() => setHoveredPath('dancer')}
+        onMouseLeave={() => setHoveredPath(null)}
+      >
+        {/* Background: Colored by default, grayscales if other is hovered */}
+        <div className={`absolute inset-0 bg-gradient-to-br from-accent/30 to-black transition-all duration-700 ease-in-out ${hoveredPath === 'roboticist' ? 'grayscale opacity-60' : 'opacity-100'}`}></div>
 
-        {/* Scanline: Hidden by default, visible and scanning on hover */}
-        <div className="absolute left-0 top-0 w-full h-[2px] bg-accent shadow-[0_0_15px_#FF7F50] opacity-0 group-hover:opacity-100 animate-scanline z-10 pointer-events-none transition-opacity duration-500"></div>
+        {/* Scanline: Hidden by default, visible and scanning ONLY when hovered */}
+        <div className={`absolute left-0 top-0 w-full h-[2px] bg-accent shadow-[0_0_15px_#FF7F50] pointer-events-none transition-opacity duration-500 ${hoveredPath === 'dancer' ? 'opacity-100 animate-scanline' : 'opacity-0'}`}></div>
 
         {/* Content Container */}
         <div className="relative z-20 p-12 h-full flex flex-col justify-end bg-gradient-to-t from-black/80 via-black/20 to-transparent">
@@ -32,12 +39,16 @@ export default function PathSelector() {
       </div>
 
       {/* --- ROBOTICIST PATH --- */}
-      <div className="lg:col-span-5 relative group overflow-hidden cursor-pointer">
-        {/* Background: Grayscale by default, colored on hover */}
-        <div className="absolute inset-0 bg-gradient-to-bl from-neutral-800/40 to-black group-hover:from-accent/30 group-hover:to-black transition-all duration-700 ease-in-out opacity-60 group-hover:opacity-100"></div>
+      <div
+        className="lg:col-span-5 relative group overflow-hidden cursor-pointer"
+        onMouseEnter={() => setHoveredPath('roboticist')}
+        onMouseLeave={() => setHoveredPath(null)}
+      >
+        {/* Background: Colored by default, grayscales if other is hovered */}
+        <div className={`absolute inset-0 bg-gradient-to-bl from-accent/30 to-black transition-all duration-700 ease-in-out ${hoveredPath === 'dancer' ? 'grayscale opacity-60' : 'opacity-100'}`}></div>
 
-        {/* Scanline: Hidden by default, visible and scanning on hover */}
-        <div className="absolute left-0 top-0 w-full h-[2px] bg-accent shadow-[0_0_15px_#FF7F50] opacity-0 group-hover:opacity-100 animate-scanline z-10 pointer-events-none transition-opacity duration-500 delay-100"></div>
+        {/* Scanline: Hidden by default, visible and scanning ONLY when hovered */}
+        <div className={`absolute left-0 top-0 w-full h-[2px] bg-accent shadow-[0_0_15px_#FF7F50] z-10 pointer-events-none transition-opacity duration-500 ${hoveredPath === 'roboticist' ? 'opacity-100 animate-scanline delay-100' : 'opacity-0'}`}></div>
 
         {/* Content Container */}
         <div className="relative z-20 p-12 h-full flex flex-col justify-end bg-gradient-to-t from-black/80 via-black/20 to-transparent">

--- a/test-plan.md
+++ b/test-plan.md
@@ -1,0 +1,6 @@
+1. Use React `useState` to track which half is hovered (`'dancer'`, `'roboticist'`, or `null`).
+2. Update the background divs:
+   - Make them colored by default (remove `from-neutral-800/40`, start with `from-accent/30`).
+   - If the other half is hovered, apply `grayscale opacity-60`.
+3. Update the scanline divs:
+   - Conditionally add the `animate-scanline` class ONLY when the current half is hovered, so the animation starts from the beginning upon hover.

--- a/test-plan.md
+++ b/test-plan.md
@@ -1,6 +1,0 @@
-1. Use React `useState` to track which half is hovered (`'dancer'`, `'roboticist'`, or `null`).
-2. Update the background divs:
-   - Make them colored by default (remove `from-neutral-800/40`, start with `from-accent/30`).
-   - If the other half is hovered, apply `grayscale opacity-60`.
-3. Update the scanline divs:
-   - Conditionally add the `animate-scanline` class ONLY when the current half is hovered, so the animation starts from the beginning upon hover.


### PR DESCRIPTION
Updates the PathSelector on the main dashboard to fix incorrect hover animation logic.

Previously, the backgrounds were grayscale by default, colored when hovered, and the CSS scanline animation was always running in the background.

This PR updates the component to use React `useState` to track the `hoveredPath`. Now:
- The paths are colored by default.
- Hovering one path correctly grayscales the other.
- The `animate-scanline` class is conditionally applied, so the CSS animation always begins at 0% when the user initiates hover.

---
*PR created automatically by Jules for task [7306379440407049185](https://jules.google.com/task/7306379440407049185) started by @arii*