### PR TITLE
Migrate Client-Side Filtering to URL Search Parameters

### DIFF
--- a/src/components/ui/FilterBar.tsx
+++ b/src/components/ui/FilterBar.tsx
@@ -1,13 +1,25 @@
-import { Box, Stack, Text } from '@/layouts/Primitives';
+import { useSearchParams } from 'react-router-dom';
+import { Box, Stack } from '@/layouts/Primitives';
 import { cn } from '@/lib/utils';
 
 interface FilterBarProps {
-  activeCategory: string;
   categories: string[];
-  onSelect: (category: string) => void;
 }
 
-export function FilterBar({ activeCategory, categories, onSelect }: FilterBarProps) {
+export function FilterBar({ categories }: FilterBarProps) {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const activeCategory = searchParams.get('category') || 'All';
+
+  const onSelect = (category: string) => {
+    const params = new URLSearchParams(searchParams);
+    if (category === 'All') {
+      params.delete('category');
+    } else {
+      params.set('category', category);
+    }
+    setSearchParams(params, { replace: true });
+  };
+
   return (
     <Box className="w-full border-b border-slate-200 bg-surface/80 backdrop-blur-md sticky top-0 z-40 overflow-x-auto no-scrollbar" paddingY={5}>
       <Stack direction="row" gap={4} className="min-w-max">
@@ -26,7 +38,7 @@ export function FilterBar({ activeCategory, categories, onSelect }: FilterBarPro
                 : "bg-bg text-text-dim border-line hover:border-accent hover:text-accent"
             )}
           >
-            {cat === 'all' ? 'All Posts' : cat.split('-').map(word => word.charAt(0).toUpperCase() + word.slice(1)).join(' ')}
+            {cat === 'All' ? 'All Posts' : cat.split('-').map(word => word.charAt(0).toUpperCase() + word.slice(1)).join(' ')}
           </Box>
         ))}
       </Stack>

--- a/src/components/ui/FilterBar.tsx
+++ b/src/components/ui/FilterBar.tsx
@@ -1,4 +1,4 @@
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParam } from '@/hooks/useSearchParam';
 import { Box, Stack } from '@/layouts/Primitives';
 import { cn } from '@/lib/utils';
 
@@ -7,18 +7,7 @@ interface FilterBarProps {
 }
 
 export function FilterBar({ categories }: FilterBarProps) {
-  const [searchParams, setSearchParams] = useSearchParams();
-  const activeCategory = searchParams.get('category') || 'All';
-
-  const onSelect = (category: string) => {
-    const params = new URLSearchParams(searchParams);
-    if (category === 'All') {
-      params.delete('category');
-    } else {
-      params.set('category', category);
-    }
-    setSearchParams(params, { replace: true });
-  };
+  const [activeCategory, setActiveCategory] = useSearchParam('category', 'All');
 
   return (
     <Box className="w-full border-b border-slate-200 bg-surface/80 backdrop-blur-md sticky top-0 z-40 overflow-x-auto no-scrollbar" paddingY={5}>
@@ -27,7 +16,7 @@ export function FilterBar({ categories }: FilterBarProps) {
           <Box
             key={cat}
             as="button"
-            onClick={() => onSelect(cat)}
+            onClick={() => setActiveCategory(cat)}
             paddingX={6}
             paddingY={2.5}
             radius="full"

--- a/src/components/ui/FolioGrid.tsx
+++ b/src/components/ui/FolioGrid.tsx
@@ -1,11 +1,22 @@
-import { useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { ContentCard, ContentCardSkeleton } from '@/components/ui/ContentCard';
 import { PageHeader } from '@/components/ui/PageHeader';
 import { Box, Grid } from '@/layouts/Primitives';
 import { safeSearch } from '@/lib/utils';
 
 export default function FolioGrid({ items, categoryTitle, basePath, label, description, children, loading }: { items: any[], categoryTitle: string, basePath: string, label?: string, description?: string, children?: React.ReactNode, loading?: boolean }) {
-  const [search, setSearch] = useState('');
+  const [searchParams, setSearchParams] = useSearchParams();
+  const search = searchParams.get('search') || '';
+
+  const setSearch = (term: string) => {
+    const params = new URLSearchParams(searchParams);
+    if (term) {
+      params.set('search', term);
+    } else {
+      params.delete('search');
+    }
+    setSearchParams(params, { replace: true });
+  };
 
   const filteredItems = items.filter(item => {
     return (
@@ -38,6 +49,7 @@ export default function FolioGrid({ items, categoryTitle, basePath, label, descr
             variant="mono"
             size="sm"
             className="focus:border-accent-brand outline-none focus:ring-0"
+            value={search}
             onChange={(e: any) => setSearch(e.target.value)}
           />
         </Box>

--- a/src/components/ui/FolioGrid.tsx
+++ b/src/components/ui/FolioGrid.tsx
@@ -3,14 +3,33 @@ import { ContentCard, ContentCardSkeleton } from '@/components/ui/ContentCard';
 import { PageHeader } from '@/components/ui/PageHeader';
 import { Box, Grid } from '@/layouts/Primitives';
 import { safeSearch } from '@/lib/utils';
+import { ContentItem } from '@/lib/content';
 
-export default function FolioGrid({ items, categoryTitle, basePath, label, description, children, loading }: { items: any[], categoryTitle: string, basePath: string, label?: string, description?: string, children?: React.ReactNode, loading?: boolean }) {
+interface FolioGridProps {
+  items: ContentItem[];
+  categoryTitle: string;
+  basePath: string;
+  label?: string;
+  description?: string;
+  children?: React.ReactNode;
+  loading?: boolean;
+}
+
+export default function FolioGrid({
+  items,
+  categoryTitle,
+  basePath,
+  label,
+  description,
+  children,
+  loading
+}: FolioGridProps) {
   const [search, setSearch] = useSearchParam('search');
 
   const filteredItems = items.filter(item => {
     return (
       safeSearch(item.title, search) ||
-      item.tags?.some((t: string) => safeSearch(t, search)) ||
+      (item as any).tags?.some((t: string) => safeSearch(t, search)) ||
       safeSearch(item.category, search) ||
       safeSearch(item.excerpt, search)
     );
@@ -67,7 +86,7 @@ export default function FolioGrid({ items, categoryTitle, basePath, label, descr
               className={`hover:bg-card-bg transition-colors group ${index === 0 ? "col-span-full xl:col-span-2" : ""}`}
             >
               <ContentCard
-                {...item}
+                {...(item as any)}
                 basePath={basePath}
                 aspect="video"
               />

--- a/src/components/ui/FolioGrid.tsx
+++ b/src/components/ui/FolioGrid.tsx
@@ -27,9 +27,10 @@ export default function FolioGrid({
   const [search, setSearch] = useSearchParam('search');
 
   const filteredItems = items.filter(item => {
+    const tags = 'tags' in item ? item.tags : [];
     return (
       safeSearch(item.title, search) ||
-      (item as any).tags?.some((t: string) => safeSearch(t, search)) ||
+      tags?.some((t: string) => safeSearch(t, search)) ||
       safeSearch(item.category, search) ||
       safeSearch(item.excerpt, search)
     );
@@ -86,7 +87,7 @@ export default function FolioGrid({
               className={`hover:bg-card-bg transition-colors group ${index === 0 ? "col-span-full xl:col-span-2" : ""}`}
             >
               <ContentCard
-                {...(item as any)}
+                {...item}
                 basePath={basePath}
                 aspect="video"
               />

--- a/src/components/ui/FolioGrid.tsx
+++ b/src/components/ui/FolioGrid.tsx
@@ -1,22 +1,11 @@
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParam } from '@/hooks/useSearchParam';
 import { ContentCard, ContentCardSkeleton } from '@/components/ui/ContentCard';
 import { PageHeader } from '@/components/ui/PageHeader';
 import { Box, Grid } from '@/layouts/Primitives';
 import { safeSearch } from '@/lib/utils';
 
 export default function FolioGrid({ items, categoryTitle, basePath, label, description, children, loading }: { items: any[], categoryTitle: string, basePath: string, label?: string, description?: string, children?: React.ReactNode, loading?: boolean }) {
-  const [searchParams, setSearchParams] = useSearchParams();
-  const search = searchParams.get('search') || '';
-
-  const setSearch = (term: string) => {
-    const params = new URLSearchParams(searchParams);
-    if (term) {
-      params.set('search', term);
-    } else {
-      params.delete('search');
-    }
-    setSearchParams(params, { replace: true });
-  };
+  const [search, setSearch] = useSearchParam('search');
 
   const filteredItems = items.filter(item => {
     return (

--- a/src/features/journal/BlogFeed.tsx
+++ b/src/features/journal/BlogFeed.tsx
@@ -1,10 +1,10 @@
-import { Box, Stack } from '@/layouts/Primitives';
+import { Box } from '@/layouts/Primitives';
 import { useBlog } from './useBlog';
 import FolioGrid from '@/components/ui/FolioGrid';
 import { FilterBar } from '@/components/ui/FilterBar';
 
 export default function BlogFeed() {
-  const { posts, categories, activeCategory, setActiveCategory, isLoading } = useBlog();
+  const { posts, categories, isLoading } = useBlog();
 
   return (
     <Box as="section">
@@ -18,9 +18,7 @@ export default function BlogFeed() {
       >
         <Box marginTop={8}>
           <FilterBar
-            activeCategory={activeCategory}
             categories={categories}
-            onSelect={setActiveCategory}
           />
         </Box>
       </FolioGrid>

--- a/src/features/journal/useBlog.ts
+++ b/src/features/journal/useBlog.ts
@@ -7,8 +7,18 @@ export function useBlog() {
   const [posts, setPosts] = useState<Post[]>([]);
   const [searchParams, setSearchParams] = useSearchParams();
   const activeCategory = searchParams.get('category') || 'All';
-  const [searchTerm, setSearchTerm] = useState<string>('');
+  const searchTerm = searchParams.get('search') || '';
   const [isLoading, setIsLoading] = useState(true);
+
+  const setSearchTerm = (term: string) => {
+    const params = new URLSearchParams(searchParams);
+    if (term) {
+      params.set('search', term);
+    } else {
+      params.delete('search');
+    }
+    setSearchParams(params, { replace: true });
+  };
 
   useEffect(() => {
     setIsLoading(true);
@@ -20,16 +30,14 @@ export function useBlog() {
     return () => clearTimeout(timer);
   }, []);
 
-  const setActiveCategory = (category: string) => {
-    setIsLoading(true);
-    setTimeout(() => setIsLoading(false), 300);
-    if (category === 'All') {
-      searchParams.delete('category');
-    } else {
-      searchParams.set('category', category);
+  // Effect to handle loading state during filtering
+  useEffect(() => {
+    if (posts.length > 0) {
+      setIsLoading(true);
+      const timer = setTimeout(() => setIsLoading(false), 300);
+      return () => clearTimeout(timer);
     }
-    setSearchParams(searchParams);
-  };
+  }, [activeCategory, searchTerm, posts.length]);
 
   const categories = useMemo(() => {
     const cats = posts.map(p => p.category);
@@ -58,7 +66,6 @@ export function useBlog() {
     posts: filteredPosts,
     categories,
     activeCategory,
-    setActiveCategory,
     searchTerm,
     setSearchTerm,
     isLoading

--- a/src/features/journal/useBlog.ts
+++ b/src/features/journal/useBlog.ts
@@ -1,24 +1,13 @@
 import { useState, useEffect, useMemo } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParam } from '@/hooks/useSearchParam';
 import { getPosts, Post } from '@/lib/content';
 import { safeSearch } from '@/lib/utils';
 
 export function useBlog() {
   const [posts, setPosts] = useState<Post[]>([]);
-  const [searchParams, setSearchParams] = useSearchParams();
-  const activeCategory = searchParams.get('category') || 'All';
-  const searchTerm = searchParams.get('search') || '';
+  const [activeCategory] = useSearchParam('category', 'All');
+  const [searchTerm, setSearchTerm] = useSearchParam('search');
   const [isLoading, setIsLoading] = useState(true);
-
-  const setSearchTerm = (term: string) => {
-    const params = new URLSearchParams(searchParams);
-    if (term) {
-      params.set('search', term);
-    } else {
-      params.delete('search');
-    }
-    setSearchParams(params, { replace: true });
-  };
 
   useEffect(() => {
     setIsLoading(true);

--- a/src/features/lab/useToolbox.ts
+++ b/src/features/lab/useToolbox.ts
@@ -1,10 +1,22 @@
-import { getResources, Resource } from '@/lib/content';
-import { useMemo, useState } from 'react';
+import { getResources } from '@/lib/content';
+import { useMemo } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { safeSearch } from '@/lib/utils';
 
 export function useToolbox() {
   const resources = getResources();
-  const [searchTerm, setSearchTerm] = useState('');
+  const [searchParams, setSearchParams] = useSearchParams();
+  const searchTerm = searchParams.get('search') || '';
+
+  const setSearchTerm = (term: string) => {
+    const params = new URLSearchParams(searchParams);
+    if (term) {
+      params.set('search', term);
+    } else {
+      params.delete('search');
+    }
+    setSearchParams(params, { replace: true });
+  };
 
   const categories = [
     { id: 'dance', label: 'Row 1: Dance Equipment', description: 'Technical reviews of competitive social dance footwear and accessories.' },

--- a/src/features/lab/useToolbox.ts
+++ b/src/features/lab/useToolbox.ts
@@ -1,22 +1,11 @@
 import { getResources } from '@/lib/content';
 import { useMemo } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParam } from '@/hooks/useSearchParam';
 import { safeSearch } from '@/lib/utils';
 
 export function useToolbox() {
   const resources = getResources();
-  const [searchParams, setSearchParams] = useSearchParams();
-  const searchTerm = searchParams.get('search') || '';
-
-  const setSearchTerm = (term: string) => {
-    const params = new URLSearchParams(searchParams);
-    if (term) {
-      params.set('search', term);
-    } else {
-      params.delete('search');
-    }
-    setSearchParams(params, { replace: true });
-  };
+  const [searchTerm, setSearchTerm] = useSearchParam('search');
 
   const categories = [
     { id: 'dance', label: 'Row 1: Dance Equipment', description: 'Technical reviews of competitive social dance footwear and accessories.' },

--- a/src/hooks/useGlobalSearch.ts
+++ b/src/hooks/useGlobalSearch.ts
@@ -1,9 +1,21 @@
-import { useState, useMemo } from 'react';
-import { getPosts, getResources, getStudies, ContentItem } from '@/lib/content';
+import { useMemo } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { getPosts, getResources, getStudies } from '@/lib/content';
 import { safeSearch } from '@/lib/utils';
 
 export function useGlobalSearch() {
-  const [query, setQuery] = useState('');
+  const [searchParams, setSearchParams] = useSearchParams();
+  const query = searchParams.get('q') || '';
+
+  const setQuery = (newQuery: string) => {
+    const params = new URLSearchParams(searchParams);
+    if (newQuery) {
+      params.set('q', newQuery);
+    } else {
+      params.delete('q');
+    }
+    setSearchParams(params, { replace: true });
+  };
   
   const allContent = useMemo(() => {
     return [

--- a/src/hooks/useGlobalSearch.ts
+++ b/src/hooks/useGlobalSearch.ts
@@ -1,21 +1,10 @@
 import { useMemo } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParam } from './useSearchParam';
 import { getPosts, getResources, getStudies } from '@/lib/content';
 import { safeSearch } from '@/lib/utils';
 
 export function useGlobalSearch() {
-  const [searchParams, setSearchParams] = useSearchParams();
-  const query = searchParams.get('q') || '';
-
-  const setQuery = (newQuery: string) => {
-    const params = new URLSearchParams(searchParams);
-    if (newQuery) {
-      params.set('q', newQuery);
-    } else {
-      params.delete('q');
-    }
-    setSearchParams(params, { replace: true });
-  };
+  const [query, setQuery] = useSearchParam('q');
   
   const allContent = useMemo(() => {
     return [

--- a/src/hooks/useSearchParam.ts
+++ b/src/hooks/useSearchParam.ts
@@ -1,0 +1,23 @@
+import { useSearchParams } from 'react-router-dom';
+import { useCallback } from 'react';
+
+/**
+ * A hook to manage a single URL search parameter.
+ * Centralizes the logic for updating URL state with { replace: true }.
+ */
+export function useSearchParam(key: string, defaultValue: string = '') {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const value = searchParams.get(key) || defaultValue;
+
+  const setValue = useCallback((newValue: string) => {
+    const params = new URLSearchParams(searchParams);
+    if (newValue && newValue !== defaultValue) {
+      params.set(key, newValue);
+    } else {
+      params.delete(key);
+    }
+    setSearchParams(params, { replace: true });
+  }, [key, defaultValue, searchParams, setSearchParams]);
+
+  return [value, setValue] as const;
+}

--- a/tests/search.spec.ts
+++ b/tests/search.spec.ts
@@ -1,0 +1,77 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Search and Filter URL Persistence', () => {
+
+  test('Global Search parameter should persist after reload', async ({ page }) => {
+    await page.goto('./');
+
+    // Open search by clicking navigation button
+    const searchButton = page.locator('button').filter({ has: page.locator('svg.lucide-search') }).first();
+    await searchButton.click();
+
+    const searchInput = page.getByPlaceholder(/SEARCH REPOSITORY/i);
+    await expect(searchInput).toBeVisible();
+
+    await searchInput.fill('swing');
+
+    // Check URL
+    await expect(page).toHaveURL(/q=swing/);
+
+    // Reload
+    await page.reload();
+
+    // Open search again to verify persistence
+    const searchButtonReload = page.locator('button').filter({ has: page.locator('svg.lucide-search') }).first();
+    await searchButtonReload.click();
+
+    await expect(page.getByPlaceholder(/SEARCH REPOSITORY/i)).toHaveValue('swing');
+    await expect(page.getByText(/RESULTS FOUND/i)).not.toHaveText('0 RESULTS FOUND');
+  });
+
+  test('Blog category filter should persist after reload', async ({ page }) => {
+    await page.goto('./blog');
+
+    // Use "Tech Portfolio" category
+    const categoryButton = page.getByRole('button', { name: 'Tech Portfolio', exact: true });
+    await categoryButton.click();
+
+    // Check URL (allow for + or %20 for spaces)
+    await expect(page).toHaveURL(/category=Tech[+%20]Portfolio/);
+
+    // Reload
+    await page.reload();
+
+    // Verify the button is still active (has the accent class)
+    await expect(page.getByRole('button', { name: 'Tech Portfolio', exact: true })).toHaveClass(/bg-accent/);
+  });
+
+  test('Blog search term should persist after reload', async ({ page }) => {
+    await page.goto('./blog');
+
+    const searchInput = page.getByPlaceholder(/SEARCH_THE_ENGINE/i);
+    await searchInput.fill('west');
+
+    // Check URL
+    await expect(page).toHaveURL(/search=west/i);
+
+    // Reload
+    await page.reload();
+
+    await expect(page.getByPlaceholder(/SEARCH_THE_ENGINE/i)).toHaveValue('west');
+  });
+
+  test('Gear search term should persist after reload', async ({ page }) => {
+    await page.goto('./gear');
+
+    const searchInput = page.getByPlaceholder(/Search gear/i);
+    await searchInput.fill('shoes');
+
+    // Check URL
+    await expect(page).toHaveURL(/search=shoes/i);
+
+    // Reload
+    await page.reload();
+
+    await expect(page.getByPlaceholder(/Search gear/i)).toHaveValue('shoes');
+  });
+});


### PR DESCRIPTION
Migrated client-side filtering and search state to URL search parameters using `useSearchParams`. This change ensures that users can share specific filtered views via URLs and that the application state remains consistent after page reloads.

Refactored components and hooks include:
- `src/hooks/useGlobalSearch.ts` (parameter: `q`)
- `src/components/ui/FilterBar.tsx` (parameter: `category`)
- `src/features/journal/useBlog.ts` (parameters: `category`, `search`)
- `src/components/ui/FolioGrid.tsx` (parameter: `search`)
- `src/features/lab/useToolbox.ts` (parameter: `search`)

Verified with Playwright E2E tests and manual visual inspection.

Fixes #134

---
*PR created automatically by Jules for task [9354602435027741540](https://jules.google.com/task/9354602435027741540) started by @arii*