### PR TITLE
feat: Automate Issue Planning for Vite Environment

### DIFF
--- a/scripts/generate_plan.py
+++ b/scripts/generate_plan.py
@@ -1,31 +1,80 @@
 import subprocess
 import sys
 import os
+import logging
+import shutil
+import tempfile
+
+# Configure structured logging
+logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
+logger = logging.getLogger(__name__)
 
 def generate_plan(issue_number):
-    # 1. Fetch Issue from GitHub
-    print(f"Fetching issue #{issue_number}...")
-    issue_data = subprocess.check_output(
-        ["gh", "issue", "view", str(issue_number), "--json", "title,body"],
-        text=True
-    )
+    # 1. Validate dependencies and context
+    if not shutil.which("gh"):
+        logger.error("The 'gh' CLI tool is not installed or not in PATH.")
+        sys.exit(1)
 
-    # 2. Prepare the prompt for the Agent
-    # Note: Replace 'llm-command' with your specific AI CLI (e.g., 'gpt', 'gemini', 'anthropic')
-    prompt = f"Using this issue data: {issue_data}, fill out the plan-template.md."
+    if not shutil.which("llm"):
+        logger.error("The 'llm' CLI tool is not installed or not in PATH.")
+        sys.exit(1)
 
-    # 3. Call the Agent and save to plan.md
-    # This assumes you have a CLI tool for your LLM installed
-    with open("plan.md", "w") as f:
-        subprocess.run(
-            ["llm", "prompt", "-s", "You are a senior dev.", prompt],
-            stdout=f
+    template_path = os.path.join(os.path.dirname(__file__), "plan-template.md")
+    if not os.path.exists(template_path):
+        logger.error(f"Template not found at {template_path}. Ensure it exists before execution.")
+        sys.exit(1)
+
+    instructions_path = os.path.join(os.path.dirname(__file__), "instructions.txt")
+    if not os.path.exists(instructions_path):
+        logger.error(f"Instructions not found at {instructions_path}.")
+        sys.exit(1)
+
+    # Load template and instructions
+    with open(template_path, "r") as f:
+        template_content = f.read()
+    with open(instructions_path, "r") as f:
+        instructions_content = f.read()
+
+    # 2. Fetch Issue from GitHub
+    logger.info(f"Fetching issue #{issue_number}...")
+    try:
+        issue_data = subprocess.check_output(
+            ["gh", "issue", "view", str(issue_number), "--json", "title,body"],
+            text=True
         )
+    except subprocess.CalledProcessError as e:
+        logger.error(f"Failed to fetch issue #{issue_number}: {e}")
+        sys.exit(1)
 
-    print("Successfully created plan.md")
+    # 3. Prepare the prompt for the Agent
+    prompt = f"Instructions:\n{instructions_content}\n\nTemplate:\n{template_content}\n\nUsing this issue data: {issue_data}, fill out the plan-template.md."
+
+    # 4. Call the Agent and save to plan.md atomically
+    logger.info("Generating plan...")
+    temp_fd, temp_path = tempfile.mkstemp(suffix=".md")
+    os.close(temp_fd)
+
+    try:
+        with open(temp_path, "w") as f:
+            subprocess.run(
+                ["llm", "prompt", "-s", "You are a senior dev.", prompt],
+                stdout=f,
+                check=True
+            )
+
+        # Atomic replacement of the final file
+        shutil.move(temp_path, "plan.md")
+        logger.info("Successfully created plan.md")
+
+    except subprocess.CalledProcessError as e:
+        logger.error(f"LLM generation failed: {e}")
+        if os.path.exists(temp_path):
+            os.remove(temp_path)
+        sys.exit(1)
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:
-        print("Usage: python generate_plan.py <issue_number>")
+        logger.error("Usage: python generate_plan.py <issue_number>")
+        sys.exit(1)
     else:
         generate_plan(sys.argv[1])

--- a/scripts/generate_plan.py
+++ b/scripts/generate_plan.py
@@ -9,39 +9,46 @@ import tempfile
 logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
 logger = logging.getLogger(__name__)
 
+class PlanGenerationError(Exception):
+    """Custom exception for plan generation failures."""
+    pass
+
 def validate_env():
     """Validates required CLIs and files exist."""
+    missing_dependencies = []
     if not shutil.which("gh"):
-        logger.error("The 'gh' CLI tool is not installed or not in PATH.")
-        sys.exit(1)
-
+        missing_dependencies.append("gh")
     if not shutil.which("llm"):
-        logger.error("The 'llm' CLI tool is not installed or not in PATH.")
-        sys.exit(1)
+        missing_dependencies.append("llm")
+
+    if missing_dependencies:
+        raise PlanGenerationError(f"Missing required CLI tools: {', '.join(missing_dependencies)}")
 
     template_path = os.path.join(os.path.dirname(__file__), "plan-template.md")
     if not os.path.exists(template_path):
-        logger.error(f"Template not found at {template_path}. Ensure it exists before execution.")
-        sys.exit(1)
+        raise PlanGenerationError(f"Template not found at {template_path}")
 
     instructions_path = os.path.join(os.path.dirname(__file__), "instructions.txt")
     if not os.path.exists(instructions_path):
-        logger.error(f"Instructions not found at {instructions_path}.")
-        sys.exit(1)
+        raise PlanGenerationError(f"Instructions not found at {instructions_path}")
 
     return template_path, instructions_path
 
 def fetch_issue(issue_number):
     """Fetches issue data from GitHub."""
-    logger.info(f"Fetching issue #{issue_number}...")
+    logger.debug(f"Attempting to fetch issue #{issue_number}")
     try:
-        return subprocess.check_output(
+        issue_data = subprocess.check_output(
             ["gh", "issue", "view", str(issue_number), "--json", "title,body"],
-            text=True
+            text=True,
+            stderr=subprocess.PIPE
         )
+        logger.info(f"Successfully fetched issue #{issue_number}")
+        return issue_data
     except subprocess.CalledProcessError as e:
-        logger.error(f"Failed to fetch issue #{issue_number}: {e}")
-        sys.exit(1)
+        error_msg = e.stderr.strip() if e.stderr else str(e)
+        logger.debug(f"gh cli error: {error_msg}")
+        raise PlanGenerationError(f"Failed to fetch issue #{issue_number}: {error_msg}") from e
 
 def render_plan(issue_data, template_path, instructions_path):
     """Calls the LLM to generate the plan and saves it atomically."""
@@ -52,7 +59,7 @@ def render_plan(issue_data, template_path, instructions_path):
 
     prompt = f"Instructions:\n{instructions_content}\n\nTemplate:\n{template_content}\n\nUsing this issue data: {issue_data}, fill out the plan-template.md."
 
-    logger.info("Generating plan...")
+    logger.info("Generating plan via LLM...")
     temp_fd, temp_path = tempfile.mkstemp(suffix=".md")
     os.close(temp_fd)
 
@@ -61,7 +68,9 @@ def render_plan(issue_data, template_path, instructions_path):
             subprocess.run(
                 ["llm", "prompt", "-s", "You are a senior dev.", prompt],
                 stdout=f,
-                check=True
+                stderr=subprocess.PIPE,
+                check=True,
+                text=True
             )
 
         # Atomic replacement of the final file
@@ -69,17 +78,29 @@ def render_plan(issue_data, template_path, instructions_path):
         logger.info("Successfully created plan.md")
 
     except subprocess.CalledProcessError as e:
-        logger.error(f"LLM generation failed: {e}")
+        error_msg = e.stderr.strip() if e.stderr else str(e)
+        logger.debug(f"llm cli error: {error_msg}")
         if os.path.exists(temp_path):
             os.remove(temp_path)
-        sys.exit(1)
+        raise PlanGenerationError(f"LLM generation failed: {error_msg}") from e
 
 def generate_plan(issue_number):
-    template_path, instructions_path = validate_env()
-    issue_data = fetch_issue(issue_number)
-    render_plan(issue_data, template_path, instructions_path)
+    try:
+        template_path, instructions_path = validate_env()
+        issue_data = fetch_issue(issue_number)
+        render_plan(issue_data, template_path, instructions_path)
+    except PlanGenerationError as e:
+        logger.error(str(e))
+        sys.exit(1)
+    except Exception as e:
+        logger.exception(f"An unexpected error occurred: {e}")
+        sys.exit(1)
 
 if __name__ == "__main__":
+    # Allow overriding log level via environment variable for debugging
+    log_level = os.environ.get("LOG_LEVEL", "INFO").upper()
+    logging.getLogger().setLevel(log_level)
+
     if len(sys.argv) < 2:
         logger.error("Usage: python generate_plan.py <issue_number>")
         sys.exit(1)

--- a/scripts/generate_plan.py
+++ b/scripts/generate_plan.py
@@ -1,0 +1,31 @@
+import subprocess
+import sys
+import os
+
+def generate_plan(issue_number):
+    # 1. Fetch Issue from GitHub
+    print(f"Fetching issue #{issue_number}...")
+    issue_data = subprocess.check_output(
+        ["gh", "issue", "view", str(issue_number), "--json", "title,body"],
+        text=True
+    )
+
+    # 2. Prepare the prompt for the Agent
+    # Note: Replace 'llm-command' with your specific AI CLI (e.g., 'gpt', 'gemini', 'anthropic')
+    prompt = f"Using this issue data: {issue_data}, fill out the plan-template.md."
+
+    # 3. Call the Agent and save to plan.md
+    # This assumes you have a CLI tool for your LLM installed
+    with open("plan.md", "w") as f:
+        subprocess.run(
+            ["llm", "prompt", "-s", "You are a senior dev.", prompt],
+            stdout=f
+        )
+
+    print("Successfully created plan.md")
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python generate_plan.py <issue_number>")
+    else:
+        generate_plan(sys.argv[1])

--- a/scripts/generate_plan.py
+++ b/scripts/generate_plan.py
@@ -13,26 +13,10 @@ class PlanGenerationError(Exception):
     """Custom exception for plan generation failures."""
     pass
 
-def validate_env():
-    """Validates required CLIs and files exist."""
-    missing_dependencies = []
-    if not shutil.which("gh"):
-        missing_dependencies.append("gh")
-    if not shutil.which("llm"):
-        missing_dependencies.append("llm")
-
-    if missing_dependencies:
-        raise PlanGenerationError(f"Missing required CLI tools: {', '.join(missing_dependencies)}")
-
-    template_path = os.path.join(os.path.dirname(__file__), "plan-template.md")
-    if not os.path.exists(template_path):
-        raise PlanGenerationError(f"Template not found at {template_path}")
-
-    instructions_path = os.path.join(os.path.dirname(__file__), "instructions.txt")
-    if not os.path.exists(instructions_path):
-        raise PlanGenerationError(f"Instructions not found at {instructions_path}")
-
-    return template_path, instructions_path
+def get_resource_paths():
+    """Returns the paths for the template and instructions."""
+    base_dir = os.path.dirname(__file__)
+    return os.path.join(base_dir, "plan-template.md"), os.path.join(base_dir, "instructions.txt")
 
 def fetch_issue(issue_number):
     """Fetches issue data from GitHub."""
@@ -86,7 +70,7 @@ def render_plan(issue_data, template_path, instructions_path):
 
 def generate_plan(issue_number):
     try:
-        template_path, instructions_path = validate_env()
+        template_path, instructions_path = get_resource_paths()
         issue_data = fetch_issue(issue_number)
         render_plan(issue_data, template_path, instructions_path)
     except PlanGenerationError as e:

--- a/scripts/generate_plan.py
+++ b/scripts/generate_plan.py
@@ -9,8 +9,8 @@ import tempfile
 logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
 logger = logging.getLogger(__name__)
 
-def generate_plan(issue_number):
-    # 1. Validate dependencies and context
+def validate_env():
+    """Validates required CLIs and files exist."""
     if not shutil.which("gh"):
         logger.error("The 'gh' CLI tool is not installed or not in PATH.")
         sys.exit(1)
@@ -29,16 +29,13 @@ def generate_plan(issue_number):
         logger.error(f"Instructions not found at {instructions_path}.")
         sys.exit(1)
 
-    # Load template and instructions
-    with open(template_path, "r") as f:
-        template_content = f.read()
-    with open(instructions_path, "r") as f:
-        instructions_content = f.read()
+    return template_path, instructions_path
 
-    # 2. Fetch Issue from GitHub
+def fetch_issue(issue_number):
+    """Fetches issue data from GitHub."""
     logger.info(f"Fetching issue #{issue_number}...")
     try:
-        issue_data = subprocess.check_output(
+        return subprocess.check_output(
             ["gh", "issue", "view", str(issue_number), "--json", "title,body"],
             text=True
         )
@@ -46,10 +43,15 @@ def generate_plan(issue_number):
         logger.error(f"Failed to fetch issue #{issue_number}: {e}")
         sys.exit(1)
 
-    # 3. Prepare the prompt for the Agent
+def render_plan(issue_data, template_path, instructions_path):
+    """Calls the LLM to generate the plan and saves it atomically."""
+    with open(template_path, "r") as f:
+        template_content = f.read()
+    with open(instructions_path, "r") as f:
+        instructions_content = f.read()
+
     prompt = f"Instructions:\n{instructions_content}\n\nTemplate:\n{template_content}\n\nUsing this issue data: {issue_data}, fill out the plan-template.md."
 
-    # 4. Call the Agent and save to plan.md atomically
     logger.info("Generating plan...")
     temp_fd, temp_path = tempfile.mkstemp(suffix=".md")
     os.close(temp_fd)
@@ -71,6 +73,11 @@ def generate_plan(issue_number):
         if os.path.exists(temp_path):
             os.remove(temp_path)
         sys.exit(1)
+
+def generate_plan(issue_number):
+    template_path, instructions_path = validate_env()
+    issue_data = fetch_issue(issue_number)
+    render_plan(issue_data, template_path, instructions_path)
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:

--- a/scripts/instructions.txt
+++ b/scripts/instructions.txt
@@ -1,0 +1,7 @@
+> **Role:** You are an expert Senior Software Engineer specializing in Vite, React/Vue, and modern web performance.
+> **Task:** Read the provided GitHub Issue and populate the plan-template.md.
+> **Guidelines:**
+>  1. Be specific. Don't just say "Fix the bug"; say "Update the useAuth hook to handle 401 errors."
+>  2. For Vite repos, prioritize build-efficiency and tree-shaking.
+>  3. Ensure the Verification section includes specific visual checks relevant to the issue.
+>  4. Keep the tone professional and concise.

--- a/scripts/instructions.txt
+++ b/scripts/instructions.txt
@@ -1,3 +1,5 @@
+# Last reviewed: 2024-05-15 — keep in sync with AGENTS.md
+
 > **Role:** You are an expert Senior Software Engineer specializing in Vite, React/Vue, and modern web performance.
 > **Task:** Read the provided GitHub Issue and populate the plan-template.md.
 > **Guidelines:**
@@ -5,3 +7,4 @@
 >  2. For Vite repos, prioritize build-efficiency and tree-shaking.
 >  3. Ensure the Verification section includes specific visual checks relevant to the issue.
 >  4. Keep the tone professional and concise.
+>  5. Adhere strictly to the architectural and styling conventions documented in `AGENTS.md`.

--- a/scripts/plan-template.md
+++ b/scripts/plan-template.md
@@ -1,0 +1,35 @@
+# Implementation Plan: {{issue_title}}
+
+## 📄 Original Issue Content
+{{issue_body}}
+
+---
+
+## 🛠️ Proposed Solution
+*Overview of the architectural changes or logic updates required.*
+
+---
+
+## 🏃 Implementation Steps
+1. [ ] **Setup:** (e.g., Create branch `feat/issue-{{issue_number}}`)
+2. [ ] **Core Logic:** ...
+3. [ ] **UI/UX Updates:** ...
+4. [ ] **Cleanup:** (e.g., Remove deprecated components)
+
+---
+
+## ✅ Verification Checklist (Vite/Frontend)
+
+### ⚙️ Build & Syntax
+- [ ] **Linting:** Run `npm run lint` (ensure no new warnings).
+- [ ] **Type Check:** Run `npx tsc` (if using TypeScript).
+- [ ] **Production Build:** Run `npm run build` to ensure the Vite optimizer and Rollup build succeed.
+
+### 🧪 Automated Testing
+- [ ] **Unit Tests:** Run `npm run test` (Vitest).
+- [ ] **Visual/UX:** Run `npx playwright test` or `cypress run`.
+
+### 👁️ Manual UX Review
+- [ ] **Responsive Check:** Verify on Mobile/Desktop breakpoints.
+- [ ] **Theme Check:** Verify Light/Dark mode transitions.
+- [ ] **Performance:** Check "Network" tab in DevTools for unexpected bundle bloat.


### PR DESCRIPTION
Added a set of scripts to automate creating structured Vite implementation plans from GitHub issues. Includes a markdown template (`plan-template.md`), an agent instruction file (`instructions.txt`), and a python script (`generate_plan.py`) to tie it all together using the GitHub CLI and an LLM.

---
*PR created automatically by Jules for task [9534672763496798450](https://jules.google.com/task/9534672763496798450) started by @arii*