### PR TITLE
refactor: fix arbitrary tailwind tokens and remove React import bloat

### DIFF
--- a/src/features/contact/components/ContactFormView.tsx
+++ b/src/features/contact/components/ContactFormView.tsx
@@ -3,7 +3,7 @@ import { Box, Stack, Text, Grid, Button } from '@/layouts/Primitives';
 import { PageHeader } from '@/components/ui/PageHeader';
 import { FormField } from './FormField';
 import { cn } from '@/lib/utils';
-import React from 'react';
+import type { ChangeEvent, FormEvent } from 'react';
 
 // Specific types for the data managed by use-contact-form
 interface ContactFormViewProps {
@@ -19,8 +19,8 @@ interface ContactFormViewProps {
     message?: string;
   };
   isSubmitting: boolean;
-  onChange: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => void;
-  onSubmit: (e: React.FormEvent) => void;
+  onChange: (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => void;
+  onSubmit: (e: FormEvent) => void;
 }
 
 const inputClasses = "w-full bg-bg border px-4 py-3 text-base sm:text-sm font-sans rounded-lg transition-all focus:outline-none focus:border-accent-brand focus:ring-2 focus:ring-accent-brand/20 placeholder:text-text-dim/50";
@@ -59,7 +59,7 @@ export function ContactFormView({ formData, errors, isSubmitting, onChange, onSu
                     </Box>
                     <Stack gap={1}>
                       <Text variant="sans" size="base" weight="font-bold" className="text-accent-navy">{item.label}</Text>
-                      <Text variant="mono" color="dim" size="xs" weight="font-semibold" className="tracking-[0.15em] uppercase">{item.channel}</Text>
+                      <Text variant="mono" color="dim" size="xs" weight="font-semibold" className="tracking-widest uppercase">{item.channel}</Text>
                     </Stack>
                   </Box>
                 ))}

--- a/src/features/contact/components/FormField.tsx
+++ b/src/features/contact/components/FormField.tsx
@@ -1,10 +1,10 @@
-import React, { useId } from 'react';
+import { useId, cloneElement, type ReactElement } from 'react';
 import { Box, Stack, Text } from '@/layouts/Primitives';
 
 interface FormFieldProps {
   label: string;
   error?: string;
-  children: React.ReactElement;
+  children: ReactElement;
 }
 
 export function FormField({ label, error, children }: FormFieldProps) {
@@ -14,7 +14,7 @@ export function FormField({ label, error, children }: FormFieldProps) {
   return (
     <Stack gap={2} marginBottom={6}>
       <Box display="flex" justify="between" align="center">
-        <Text as="label" htmlFor={id} variant="mono" size="xs" weight="font-semibold" color="dim" className="tracking-[0.15em] uppercase">
+        <Text as="label" htmlFor={id} variant="mono" size="xs" weight="font-semibold" color="dim" className="tracking-widest uppercase">
           {label}
         </Text>
         {error && (
@@ -23,7 +23,7 @@ export function FormField({ label, error, children }: FormFieldProps) {
           </Text>
         )}
       </Box>
-      {React.cloneElement(children, {
+      {cloneElement(children, {
         id,
         'aria-describedby': error ? errorId : undefined,
         'aria-invalid': !!error

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -24,7 +24,7 @@ export const variants = {
     solid: "bg-text-main text-bg border-transparent",
     outline: "border border-line bg-transparent",
     ghost: "bg-transparent hover:bg-line/10",
-    primary: "bg-accent text-white font-mono tracking-widest text-[10px] px-8 hover:bg-text-main active:translate-y-[0px] hover:translate-y-[-2px] hover:shadow-[0_4px_12px_var(--color-accent-shadow)]",
+    primary: "bg-accent text-white font-mono tracking-widest text-xs px-8 hover:bg-text-main active:translate-y-[0px] hover:translate-y-[-2px] hover:shadow-[0_4px_12px_var(--color-accent-shadow)]",
     professional: "bg-text-main text-white font-sans rounded-lg hover:bg-text-main/90 transition-all shadow-sm active:scale-[0.98] normal-case tracking-normal",
   },
   radius: {
@@ -46,7 +46,7 @@ export const buttonVariants = cva(
       },
       size: {
         default: "h-[40px] px-6 text-xs",
-        sm: "h-8 px-4 text-[10px]",
+        sm: "h-8 px-4 text-xs",
         md: "h-[40px] px-6 text-xs",
         lg: "h-12 px-8 text-sm",
         icon: "h-[40px] w-[40px]",
@@ -63,7 +63,7 @@ export const buttonVariants = cva(
 );
 
 export const badgeVariants = cva(
-  "inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden border px-2 py-0.5 text-[9px] font-mono font-bold uppercase tracking-widest whitespace-nowrap transition-all rounded-[2px]",
+  "inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden border px-2 py-0.5 text-xs font-mono font-bold uppercase tracking-widest whitespace-nowrap transition-all rounded-[2px]",
   {
     variants: {
       emphasis: variants.emphasis,

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FormEvent } from 'react';
 import { useContactForm } from '@/hooks/use-contact-form';
 import { SuccessState } from '@/features/contact/components/SuccessState';
 import { ContactFormView } from '@/features/contact/components/ContactFormView';
@@ -19,7 +19,7 @@ export default function Contact() {
     reset
   } = useContactForm();
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = (e: FormEvent) => {
     e.preventDefault();
     submit();
   };


### PR DESCRIPTION
This PR removes arbitrary Tailwind spacing and sizing values (`tracking-[0.15em]`, `text-[10px]`, `text-[9px]`) from various components to comply with the design system tokens. It also removes the unnecessary `import React from 'react';` imports across `Contact.tsx`, `ContactFormView.tsx`, and `FormField.tsx`, leveraging specific hook/type imports suitable for React 17+.

---
*PR created automatically by Jules for task [8920019549148613344](https://jules.google.com/task/8920019549148613344) started by @arii*