### PR TITLE
Fix CI and layout: Revert PathSelector to vertical stack

### DIFF
--- a/src/components/ui/PathSelector.tsx
+++ b/src/components/ui/PathSelector.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react';
 import { NavLink } from 'react-router-dom';
+import { Box, Grid, Stack, Text } from '@/layouts/Primitives';
+import { cn } from '@/lib/utils';
 
 type PathID = 'dancer' | 'roboticist';
 
@@ -7,9 +9,10 @@ const PATH_DATA = [
   {
     id: 'dancer' as PathID,
     title: 'ARE YOU A DANCER?',
-    wrapperClass: 'lg:col-span-12 border-b border-line/20',
+    span: { base: 1, lg: 7 } as const,
+    lgBorder: { r: true } as const,
     bgGradient: 'bg-gradient-to-br',
-    titleClass: 'text-4xl md:text-6xl',
+    titleSize: { base: '3xl', lg: '5xl' } as const,
     links: [
       { text: 'Lifestyle blog posts', to: '/blog?category=Lifestyle' },
       { text: 'Gear reviews', to: '/gear' },
@@ -18,9 +21,9 @@ const PATH_DATA = [
   {
     id: 'roboticist' as PathID,
     title: 'HIRING A ROBOTICIST?',
-    wrapperClass: 'lg:col-span-12',
+    span: { base: 1, lg: 5 } as const,
     bgGradient: 'bg-gradient-to-bl',
-    titleClass: 'text-3xl md:text-5xl',
+    titleSize: { base: '2xl', lg: '4xl' } as const,
     scanlineDelay: 'delay-100',
     links: [
       { text: 'Tech blog posts', to: '/blog?category=Tech' },
@@ -32,59 +35,111 @@ const PATH_DATA = [
 export default function PathSelector() {
   const [hoveredPath, setHoveredPath] = useState<PathID | null>(null);
 
+  const handleVibrate = () => {
+    if (typeof navigator !== 'undefined' && 'vibrate' in navigator) {
+      navigator.vibrate(15);
+    }
+  };
+
   return (
-    <div className="grid grid-cols-1 lg:grid-cols-12 gap-0 border-y border-line min-h-[60vh] w-full bg-black">
+    <Grid
+      as="section"
+      role="img"
+      aria-label="Interactive generative tech-dancer visualization: Choose between Dancer and Roboticist paths"
+      cols={{ base: 1, lg: 12 }}
+      gap={0}
+      border="y"
+      minHeight="30vh"
+      width="full"
+      className="bg-black touch-manipulation"
+    >
       {PATH_DATA.map((path) => {
         const isHovered = hoveredPath === path.id;
         const isOtherHovered = hoveredPath !== null && !isHovered;
 
         return (
-          <div
+          <Box
             key={path.id}
-            className={`${path.wrapperClass} relative group overflow-hidden cursor-pointer`}
+            span={path.span}
+            lgBorder={path.lgBorder as any}
+            position="relative"
+            overflow="hidden"
+            cursor="pointer"
+            className="group touch-manipulation"
             onMouseEnter={() => setHoveredPath(path.id)}
             onMouseLeave={() => setHoveredPath(null)}
+            onClick={handleVibrate}
           >
             {/* Background */}
-            <div
-              className={`absolute inset-0 ${path.bgGradient} from-accent/30 to-black transition-all duration-700 ease-in-out ${
+            <Box
+              position="absolute"
+              inset
+              className={cn(
+                path.bgGradient,
+                "from-accent/30 to-black transition-all duration-700 ease-in-out",
                 isOtherHovered ? 'grayscale opacity-60' : 'opacity-100'
-              }`}
-            ></div>
+              )}
+            />
 
             {/* Scanline */}
-            <div
-              className={`absolute left-0 top-0 w-full h-[2px] bg-accent shadow-[0_0_15px_#FF7F50] z-10 pointer-events-none transition-opacity duration-500 ${
-                path.scanlineDelay || ''
-              } ${isHovered ? 'opacity-100 animate-scanline' : 'opacity-0'}`}
-            ></div>
+            <Box
+              position="absolute"
+              inset="top"
+              height="[2px]"
+              zIndex={10}
+              className={cn(
+                "bg-accent shadow-[0_0_15px_#FF7F50] pointer-events-none transition-opacity duration-500",
+                path.scanlineDelay,
+                isHovered ? 'opacity-100 motion-safe:animate-scanline' : 'opacity-0'
+              )}
+            />
 
             {/* Content Container */}
-            <div className="relative z-20 p-12 h-full flex flex-col justify-end bg-gradient-to-t from-black/80 via-black/20 to-transparent">
-              <h2
-                className={`${path.titleClass} font-display font-black mb-4 text-white transition-transform duration-500 group-hover:translate-x-2`}
+            <Stack
+              position="relative"
+              zIndex={20}
+              padding={{ base: 6, md: 8 }}
+              height="full"
+              justify="end"
+              className="bg-gradient-to-t from-black/80 via-black/20 to-transparent"
+            >
+              <Text
+                as="h2"
+                variant="display"
+                size={path.titleSize}
+                weight="font-black"
+                color="white"
+                className="transition-transform duration-500 group-hover:translate-x-2 mb-3"
               >
                 {path.title}
-              </h2>
-              <ul className="space-y-4 mb-6 font-mono text-sm tracking-widest uppercase text-white font-bold opacity-80 group-hover:opacity-100 transition-opacity duration-500 delay-75">
+              </Text>
+
+              <Box as="ul" className="space-y-2 mb-2">
                 {path.links.map((link) => (
                   <li key={link.text}>
-                    <NavLink
-                      className="hover:text-accent transition-colors flex items-center gap-2"
+                    <Text
+                      as={NavLink}
                       to={link.to}
+                      variant="mono"
+                      size={{ base: 'xs', md: 'sm' }}
+                      tracking="widest"
+                      uppercase
+                      weight="font-bold"
+                      color="white"
+                      className="opacity-80 group-hover:opacity-100 transition-opacity hover:text-accent flex items-center gap-2"
                     >
                       <span className="text-accent transition-transform duration-300 group-hover:translate-x-1">
                         →
                       </span>{' '}
                       {link.text}
-                    </NavLink>
+                    </Text>
                   </li>
                 ))}
-              </ul>
-            </div>
-          </div>
+              </Box>
+            </Stack>
+          </Box>
         );
       })}
-    </div>
+    </Grid>
   );
 }

--- a/src/components/ui/PathSelector.tsx
+++ b/src/components/ui/PathSelector.tsx
@@ -1,7 +1,5 @@
 import { useState } from 'react';
 import { NavLink } from 'react-router-dom';
-import { Box, Grid, Stack, Text } from '@/layouts/Primitives';
-import { cn } from '@/lib/utils';
 
 type PathID = 'dancer' | 'roboticist';
 
@@ -9,10 +7,9 @@ const PATH_DATA = [
   {
     id: 'dancer' as PathID,
     title: 'ARE YOU A DANCER?',
-    span: { base: 1, lg: 7 } as const,
-    lgBorder: { r: true } as const,
+    wrapperClass: 'lg:col-span-12 border-b border-line/20',
     bgGradient: 'bg-gradient-to-br',
-    titleSize: { base: '3xl', lg: '5xl' } as const,
+    titleClass: 'text-4xl md:text-6xl',
     links: [
       { text: 'Lifestyle blog posts', to: '/blog?category=Lifestyle' },
       { text: 'Gear reviews', to: '/gear' },
@@ -21,9 +18,9 @@ const PATH_DATA = [
   {
     id: 'roboticist' as PathID,
     title: 'HIRING A ROBOTICIST?',
-    span: { base: 1, lg: 5 } as const,
+    wrapperClass: 'lg:col-span-12',
     bgGradient: 'bg-gradient-to-bl',
-    titleSize: { base: '2xl', lg: '4xl' } as const,
+    titleClass: 'text-3xl md:text-5xl',
     scanlineDelay: 'delay-100',
     links: [
       { text: 'Tech blog posts', to: '/blog?category=Tech' },
@@ -35,111 +32,59 @@ const PATH_DATA = [
 export default function PathSelector() {
   const [hoveredPath, setHoveredPath] = useState<PathID | null>(null);
 
-  const handleVibrate = () => {
-    if (typeof navigator !== 'undefined' && 'vibrate' in navigator) {
-      navigator.vibrate(15);
-    }
-  };
-
   return (
-    <Grid
-      as="section"
-      role="img"
-      aria-label="Interactive generative tech-dancer visualization: Choose between Dancer and Roboticist paths"
-      cols={{ base: 1, lg: 12 }}
-      gap={0}
-      border="y"
-      minHeight="30vh"
-      width="full"
-      className="bg-black touch-manipulation"
-    >
+    <div className="grid grid-cols-1 lg:grid-cols-12 gap-0 border-y border-line min-h-[60vh] w-full bg-black">
       {PATH_DATA.map((path) => {
         const isHovered = hoveredPath === path.id;
         const isOtherHovered = hoveredPath !== null && !isHovered;
 
         return (
-          <Box
+          <div
             key={path.id}
-            span={path.span}
-            lgBorder={path.lgBorder as any}
-            position="relative"
-            overflow="hidden"
-            cursor="pointer"
-            className="group touch-manipulation"
+            className={`${path.wrapperClass} relative group overflow-hidden cursor-pointer`}
             onMouseEnter={() => setHoveredPath(path.id)}
             onMouseLeave={() => setHoveredPath(null)}
-            onClick={handleVibrate}
           >
             {/* Background */}
-            <Box
-              position="absolute"
-              inset
-              className={cn(
-                path.bgGradient,
-                "from-accent/30 to-black transition-all duration-700 ease-in-out",
+            <div
+              className={`absolute inset-0 ${path.bgGradient} from-accent/30 to-black transition-all duration-700 ease-in-out ${
                 isOtherHovered ? 'grayscale opacity-60' : 'opacity-100'
-              )}
-            />
+              }`}
+            ></div>
 
             {/* Scanline */}
-            <Box
-              position="absolute"
-              inset="top"
-              height="[2px]"
-              zIndex={10}
-              className={cn(
-                "bg-accent shadow-[0_0_15px_#FF7F50] pointer-events-none transition-opacity duration-500",
-                path.scanlineDelay,
-                isHovered ? 'opacity-100 motion-safe:animate-scanline' : 'opacity-0'
-              )}
-            />
+            <div
+              className={`absolute left-0 top-0 w-full h-[2px] bg-accent shadow-[0_0_15px_#FF7F50] z-10 pointer-events-none transition-opacity duration-500 ${
+                path.scanlineDelay || ''
+              } ${isHovered ? 'opacity-100 animate-scanline' : 'opacity-0'}`}
+            ></div>
 
             {/* Content Container */}
-            <Stack
-              position="relative"
-              zIndex={20}
-              padding={{ base: 6, md: 8 }}
-              height="full"
-              justify="end"
-              className="bg-gradient-to-t from-black/80 via-black/20 to-transparent"
-            >
-              <Text
-                as="h2"
-                variant="display"
-                size={path.titleSize}
-                weight="font-black"
-                color="white"
-                className="transition-transform duration-500 group-hover:translate-x-2 mb-3"
+            <div className="relative z-20 p-12 h-full flex flex-col justify-end bg-gradient-to-t from-black/80 via-black/20 to-transparent">
+              <h2
+                className={`${path.titleClass} font-display font-black mb-4 text-white transition-transform duration-500 group-hover:translate-x-2`}
               >
                 {path.title}
-              </Text>
-
-              <Box as="ul" className="space-y-2 mb-2">
+              </h2>
+              <ul className="space-y-4 mb-6 font-mono text-sm tracking-widest uppercase text-white font-bold opacity-80 group-hover:opacity-100 transition-opacity duration-500 delay-75">
                 {path.links.map((link) => (
                   <li key={link.text}>
-                    <Text
-                      as={NavLink}
+                    <NavLink
+                      className="hover:text-accent transition-colors flex items-center gap-2"
                       to={link.to}
-                      variant="mono"
-                      size={{ base: 'xs', md: 'sm' }}
-                      tracking="widest"
-                      uppercase
-                      weight="font-bold"
-                      color="white"
-                      className="opacity-80 group-hover:opacity-100 transition-opacity hover:text-accent flex items-center gap-2"
                     >
                       <span className="text-accent transition-transform duration-300 group-hover:translate-x-1">
                         →
                       </span>{' '}
                       {link.text}
-                    </Text>
+                    </NavLink>
                   </li>
                 ))}
-              </Box>
-            </Stack>
-          </Box>
+              </ul>
+            </div>
+          </div>
         );
       })}
-    </Grid>
+    </div>
   );
 }

--- a/tests/verify_final.spec.ts
+++ b/tests/verify_final.spec.ts
@@ -10,5 +10,5 @@ test('capture home redesign final', async ({ page }) => {
   // Give it a moment for any animations to settle
   await page.waitForTimeout(2000);
 
-  await page.screenshot({ path: '/home/jules/verification/home_redesign_final.png', fullPage: true });
+  await page.screenshot({ path: 'home_redesign_final.png', fullPage: true });
 });


### PR DESCRIPTION
The user requested fixing CI issues and reverting recent changes to the dual path selector component (`PathSelector.tsx`), specifically instructing that the paths should be vertically stacked instead of side-by-side (horizontal).

**Changes made:**
- Investigated `origin/main` and determined it used standard HTML and Tailwind classes (`wrapperClass`) instead of the custom layout primitive properties previously attempted.
- Restored `src/components/ui/PathSelector.tsx` entirely to match the code in `origin/main` to satisfy the requested reversion.
- Modified the `wrapperClass` inside `PATH_DATA` to use `lg:col-span-12` instead of `lg:col-span-7` and `lg:col-span-5`.
- Altered the visual separation styling from a right border (`border-r`) to a bottom border (`border-b border-line/20`) on the top path, successfully making the component vertically stacked across all viewport widths.
- Ensured `pnpm exec playwright install` and port management steps were taken to successfully clear CI testing blockages, successfully passing `pnpm run test:e2e` (6/6 tests passed).
- Completed pre-commit workflows with frontend visual verification demonstrating the correct vertical path design.

---
*PR created automatically by Jules for task [17753471445811184136](https://jules.google.com/task/17753471445811184136) started by @arii*