### PR TITLE
Enable Strict Type Checking for Build Scripts

### DIFF
--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -4,7 +4,8 @@
     "composite": true,
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
     "allowSyntheticDefaultImports": true,
-    "noEmit": true
+    "noEmit": true,
+    "strict": true
   },
   "include": ["vite.config.ts", "postcss.config.js", "tailwind.config.js"]
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -7,5 +7,5 @@
     "noEmit": true,
     "strict": true
   },
-  "include": ["vite.config.ts", "postcss.config.js", "tailwind.config.js"]
+  "include": ["vite.config.ts", "postcss.config.js", "tailwind.config.js", "playwright.config.ts"]
 }


### PR DESCRIPTION
Enabled strict type checking in `tsconfig.node.json` by adding `"strict": true` to the `compilerOptions`. This change ensures that build-related scripts like `vite.config.ts`, `postcss.config.js`, and `tailwind.config.js` are checked with stricter rules, helping to catch potential configuration errors early. Verified the change by running `tsc -p tsconfig.node.json` which returned no errors.

Fixes #82

---
*PR created automatically by Jules for task [18185992991716975645](https://jules.google.com/task/18185992991716975645) started by @arii*