### PR TITLE
Enforce Type-Checking in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         run: pnpm run lint
 
       - name: Type-check
-        run: pnpm exec tsc --noEmit
+        run: pnpm run type-check
 
       - name: Run unit tests
         run: pnpm test --if-present

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,4 +35,4 @@ jobs:
         run: pnpm install --frozen-lockfile --prefer-offline
 
       - name: Run lint
-        run: pnpm run lint
+        run: pnpm run type-check

--- a/package.json
+++ b/package.json
@@ -5,12 +5,13 @@
   "type": "module",
   "scripts": {
     "dev": "vite --port=3000 --host=0.0.0.0",
-    "build": "vite build",
+    "build": "pnpm run type-check && vite build",
     "build:analyze": "ANALYZE=true vite build",
     "preview": "vite preview",
     "test:e2e": "playwright test",
     "clean": "rm -rf dist",
-    "lint": "tsc --noEmit"
+    "lint": "tsc --noEmit",
+    "type-check": "tsc --noEmit"
   },
   "dependencies": {
     "@base-ui/react": "^1.4.0",


### PR DESCRIPTION
This PR enforces TypeScript type-checking during the production build process and within the CI workflows. By integrating `tsc --noEmit` into the `build` script and standardizing CI steps, we ensure that type errors prevent deployments and are caught early in the development lifecycle.

Fixes #44

---
*PR created automatically by Jules for task [5928204881890660010](https://jules.google.com/task/5928204881890660010) started by @arii*