### PR TITLE
Fix Browser Router URL Navigation on GitHub Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,11 +13,12 @@
           }).join('?');
 
           // Calculate the actual base path (where index.html is located)
-          var base = l.pathname.replace(/\/index\.html$/, '').replace(/\/$/, '');
-          window.__ROUTER_BASENAME__ = base || '/';
+          var base = l.pathname.replace(/\/index\.html$/, '');
+          window.__ROUTER_BASENAME__ = base;
 
           // Restore the intended URL without a page reload
-          window.history.replaceState(null, null, (base || '') + decodedPath + l.hash);
+          // We use base.replace(/\/$/, '') to avoid double slashes when joining with decodedPath
+          window.history.replaceState(null, null, base.replace(/\/$/, '') + decodedPath + l.hash);
         }
       }(window.location))
     </script>

--- a/index.html
+++ b/index.html
@@ -6,24 +6,16 @@
     <title>Tech-Dancer // The Roboticist's Guide to WCS</title>
     <script type="text/javascript">
       (function(l) {
-        if (l.search) {
-          var q = {};
-          l.search.slice(1).split('&').forEach(function(v) {
-            var a = v.split('=');
-            q[a[0]] = a.slice(1).join('=').replace(/~and~/g, '&');
-          });
-          if (q.p !== undefined) {
-            // Reconstruct the path by removing "index.html" if present at the end of pathname
-            var base = l.pathname.replace(/\/index\.html$/, '');
-            // Ensure no double slashes when joining base and q.p
-            // base is like /tech-dancer/fix/branch
-            // q.p is like /blog
-            var cleanBase = base.replace(/\/$/, '');
-            var cleanPath = q.p.startsWith('/') ? q.p : '/' + q.p;
-            var newUrl = cleanBase + cleanPath + (q.q ? ('?' + q.q) : '') + l.hash;
+        // Always calculate the basename based on the current pathname of index.html
+        var base = l.pathname.replace(/\/index\.html$/, '').replace(/\/$/, '');
+        window.__ROUTER_BASENAME__ = base || '/';
 
-            window.history.replaceState(null, null, newUrl);
-          }
+        if (l.search[1] === '/') {
+          var decodedPath = l.search.slice(1).split('&').map(function(s) {
+            return s.replace(/~and~/g, '&')
+          }).join('?');
+
+          window.history.replaceState(null, null, (base || '/') + decodedPath + l.hash);
         }
       }(window.location))
     </script>

--- a/index.html
+++ b/index.html
@@ -6,16 +6,18 @@
     <title>Tech-Dancer // The Roboticist's Guide to WCS</title>
     <script type="text/javascript">
       (function(l) {
-        // Always calculate the basename based on the current pathname of index.html
-        var base = l.pathname.replace(/\/index\.html$/, '').replace(/\/$/, '');
-        window.__ROUTER_BASENAME__ = base || '/';
-
+        // If we were redirected from 404.html, the route is encoded in the query string starting with /
         if (l.search[1] === '/') {
           var decodedPath = l.search.slice(1).split('&').map(function(s) {
             return s.replace(/~and~/g, '&')
           }).join('?');
 
-          window.history.replaceState(null, null, (base || '/') + decodedPath + l.hash);
+          // Calculate the actual base path (where index.html is located)
+          var base = l.pathname.replace(/\/index\.html$/, '').replace(/\/$/, '');
+          window.__ROUTER_BASENAME__ = base || '/';
+
+          // Restore the intended URL without a page reload
+          window.history.replaceState(null, null, (base || '') + decodedPath + l.hash);
         }
       }(window.location))
     </script>

--- a/public/404.html
+++ b/public/404.html
@@ -43,7 +43,7 @@
           if (best > 0) {
             redirect(best);
           } else {
-            // Fallback to the known repo base if all probes fail
+            // Fallback to the repo root if all probes fail
             redirect(1);
           }
         });

--- a/public/404.html
+++ b/public/404.html
@@ -4,19 +4,13 @@
     <meta charset="utf-8">
     <title>Tech-Dancer // Redirecting...</title>
     <script type="text/javascript">
-      // SPA redirect for GitHub Pages. Works for both the main deployment
-      // (/tech-dancer/) and branch preview deployments
-      // (/tech-dancer/<branch-type>/<branch-name>/).
-      //
-      // GitHub Pages only serves one 404.html (from the repo root), so this
-      // script must handle redirects for all deployment depths. It walks up the
-      // path hierarchy using HEAD requests to find the deepest index.html that
-      // exists, then redirects to that index with the remaining path encoded as
-      // a query string (picked up by the redirect script in index.html).
+      // SPA redirect for GitHub Pages.
+      // This script handles redirects for both the main deployment (/tech-dancer/)
+      // and branch preview deployments (/tech-dancer/<branch>/).
+      // It probes the path hierarchy to find the deepest index.html.
       (function () {
         var l = window.location;
         var pathParts = l.pathname.split('/').filter(function (p) { return p !== ''; });
-        // e.g. ['tech-dancer', 'fix', 'branch-name', 'blog']
 
         function redirect(baseDepth) {
           var basePath = '/' + pathParts.slice(0, baseDepth).join('/') + '/';
@@ -29,9 +23,7 @@
           );
         }
 
-        // Fire HEAD requests for every candidate depth in parallel, then pick
-        // the deepest index.html that returns HTTP 200. A branch preview at
-        // depth 3 wins over the main site at depth 1.
+        // Probing depths to find where the app is actually hosted
         var checks = pathParts.map(function (_, i) {
           var depth = i + 1;
           return fetch(
@@ -43,13 +35,15 @@
         });
 
         Promise.all(checks).then(function (depths) {
-          var best = Math.max.apply(null, depths);
+          var best = 0;
+          for (var i = 0; i < depths.length; i++) {
+            if (depths[i] > best) best = depths[i];
+          }
+
           if (best > 0) {
             redirect(best);
           } else {
-            // All probes failed (network error or no index.html found).
-            // Fall back to the repo root so the user sees something useful.
-            console.error('[404] Could not locate an index.html for', l.pathname, '– falling back to depth 1');
+            // Fallback to the known repo base if all probes fail
             redirect(1);
           }
         });

--- a/public/404.html
+++ b/public/404.html
@@ -43,7 +43,7 @@
           if (best > 0) {
             redirect(best);
           } else {
-            // Fallback to the repo root if all probes fail
+            // Fallback to the known repo base if all probes fail
             redirect(1);
           }
         });

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -20,18 +20,18 @@ const getBasename = () => {
   }
 
   const fullPath = window.location.pathname;
-  // Standardize buildBase to not have a trailing slash
-  const buildBase = (import.meta.env.BASE_URL || '/').replace(/\/$/, '');
+  const buildBase = import.meta.env.BASE_URL || '/';
+  const buildBaseClean = buildBase.replace(/\/$/, '');
 
   const segments = fullPath.split('/').filter(Boolean);
-  const baseSegments = buildBase.split('/').filter(Boolean);
+  const baseSegments = buildBaseClean.split('/').filter(Boolean);
 
   // 2. Heuristic: If we are in a subdirectory deeper than buildBase,
   // check if the next segment is a known route.
   if (segments.length > baseSegments.length) {
     const possibleRouteSegment = segments[baseSegments.length];
 
-    // Extract valid top-level paths from the route configuration to distinguish between routes and subdirectories
+    // Extract valid top-level paths from the route configuration
     const children = routes[0].children || [];
     const validTopLevelPaths = new Set<string>();
     for (const route of children) {
@@ -45,12 +45,12 @@ const getBasename = () => {
 
     if (!isStandardRoute && !isIndexHtml) {
       // It's likely a branch deployment. The basename includes this extra segment.
-      return '/' + segments.slice(0, baseSegments.length + 1).join('/');
+      return '/' + segments.slice(0, baseSegments.length + 1).join('/') + '/';
     }
   }
 
   // 3. Fallback: Use the build-time BASE_URL
-  return buildBase || '/';
+  return buildBase;
 };
 
 const router = createBrowserRouter(routes, {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -27,21 +27,18 @@ const getBasename = () => {
   const baseSegments = buildBase.split('/').filter(Boolean);
 
   // 2. Heuristic: If we are in a subdirectory deeper than buildBase,
-  // check if the next segment is a known route. If not, it's likely a branch name.
+  // check if the next segment is a known top-level route.
   if (segments.length > baseSegments.length) {
     const possibleRouteSegment = segments[baseSegments.length];
 
-    // Extract valid top-level paths from the route configuration to distinguish between routes and subdirectories
-    const validTopLevelPaths = routes[0].children
-      ?.map(r => r.path)
-      .filter((path): path is string => !!path && path !== '*' && path !== '/')
-      .map(path => path.split('/')[0]) || [];
+    // Whitelist of standard top-level routes to avoid misidentifying them as branch names
+    const standardRoutes = ['gear', 'research', 'blog', 'resources', 'about', 'contact', 'ux-auditor'];
 
-    const isStandardRoute = validTopLevelPaths.includes(possibleRouteSegment);
+    const isStandardRoute = standardRoutes.indexOf(possibleRouteSegment) !== -1;
     const isIndexHtml = possibleRouteSegment === 'index.html';
 
     if (!isStandardRoute && !isIndexHtml) {
-      // It's likely a branch deployment. The basename includes this extra segment.
+      // It's likely a branch name. The basename includes this extra segment.
       return '/' + segments.slice(0, baseSegments.length + 1).join('/');
     }
   }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,8 +9,35 @@ import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import { routes } from './App.tsx';
 import './index.css';
 
+// Function to calculate the actual basename at runtime to support GitHub Pages branch previews
+const getBasename = () => {
+  const fullPath = window.location.pathname;
+  const buildBase = import.meta.env.BASE_URL || '/';
+
+  // If index.html already calculated a basename, use it
+  if ((window as any).__ROUTER_BASENAME__) {
+      return (window as any).__ROUTER_BASENAME__;
+  }
+
+  // Check if we are running in a subdirectory deeper than the build-time base (e.g., branch preview)
+  // This helps when navigating normally (without a 404 redirect)
+  if (fullPath.startsWith(buildBase) && fullPath !== buildBase) {
+    const segments = fullPath.split('/');
+    // For GitHub Pages: ['', 'tech-dancer', 'branch-name', 'route']
+    if (segments.length > 2 && segments[1] === 'tech-dancer' && segments[2] !== '') {
+      const firstSegment = segments[2];
+      const standardRoutes = ['gear', 'research', 'blog', 'resources', 'about', 'contact', 'ux-auditor'];
+      // Treat segments[2] as a branch if it has a dash or isn't a standard route
+      if (firstSegment.includes('-') || standardRoutes.indexOf(firstSegment) === -1) {
+        return `/${segments[1]}/${segments[2]}`;
+      }
+    }
+  }
+  return buildBase;
+};
+
 const router = createBrowserRouter(routes, {
-  basename: import.meta.env.BASE_URL || '/',
+  basename: getBasename(),
 });
 
 createRoot(document.getElementById('root')!).render(

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,7 @@
 import { Buffer } from 'buffer';
 
 // polyfilling Buffer for browser environment
-(window as any).Buffer = (window as any).Buffer || Buffer;
+window.Buffer = window.Buffer || Buffer;
 
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
@@ -15,8 +15,8 @@ import './index.css';
  */
 const getBasename = () => {
   // 1. Priority: Use the basename detected by index.html during a 404 restoration
-  if ((window as any).__ROUTER_BASENAME__) {
-    return (window as any).__ROUTER_BASENAME__;
+  if (window.__ROUTER_BASENAME__) {
+    return window.__ROUTER_BASENAME__;
   }
 
   const fullPath = window.location.pathname;
@@ -27,18 +27,24 @@ const getBasename = () => {
   const baseSegments = buildBase.split('/').filter(Boolean);
 
   // 2. Heuristic: If we are in a subdirectory deeper than buildBase,
-  // check if the next segment is a known top-level route.
+  // check if the next segment is a known route.
   if (segments.length > baseSegments.length) {
     const possibleRouteSegment = segments[baseSegments.length];
 
-    // Whitelist of standard top-level routes to avoid misidentifying them as branch names
-    const standardRoutes = ['gear', 'research', 'blog', 'resources', 'about', 'contact', 'ux-auditor'];
+    // Extract valid top-level paths from the route configuration to distinguish between routes and subdirectories
+    const children = routes[0].children || [];
+    const validTopLevelPaths = new Set<string>();
+    for (const route of children) {
+      if (route.path && route.path !== '*' && route.path !== '/') {
+        validTopLevelPaths.add(route.path.split('/')[0]);
+      }
+    }
 
-    const isStandardRoute = standardRoutes.indexOf(possibleRouteSegment) !== -1;
+    const isStandardRoute = validTopLevelPaths.has(possibleRouteSegment);
     const isIndexHtml = possibleRouteSegment === 'index.html';
 
     if (!isStandardRoute && !isIndexHtml) {
-      // It's likely a branch name. The basename includes this extra segment.
+      // It's likely a branch deployment. The basename includes this extra segment.
       return '/' + segments.slice(0, baseSegments.length + 1).join('/');
     }
   }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,7 @@
 import { Buffer } from 'buffer';
 
 // polyfilling Buffer for browser environment
-window.Buffer = window.Buffer || Buffer;
+(window as any).Buffer = (window as any).Buffer || Buffer;
 
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
@@ -9,31 +9,45 @@ import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import { routes } from './App.tsx';
 import './index.css';
 
-// Function to calculate the actual basename at runtime to support GitHub Pages branch previews
+/**
+ * Function to calculate the actual basename at runtime.
+ * This ensures correct routing regardless of deployment depth (e.g. GitHub Pages branch previews).
+ */
 const getBasename = () => {
-  const fullPath = window.location.pathname;
-  const buildBase = import.meta.env.BASE_URL || '/';
-
-  // If index.html already calculated a basename, use it
-  if (window.__ROUTER_BASENAME__) {
-      return window.__ROUTER_BASENAME__;
+  // 1. Priority: Use the basename detected by index.html during a 404 restoration
+  if ((window as any).__ROUTER_BASENAME__) {
+    return (window as any).__ROUTER_BASENAME__;
   }
 
-  // Check if we are running in a subdirectory deeper than the build-time base (e.g., branch preview)
-  // This helps when navigating normally (without a 404 redirect)
-  if (fullPath.startsWith(buildBase) && fullPath !== buildBase) {
-    const segments = fullPath.split('/');
-    // For GitHub Pages: ['', 'tech-dancer', 'branch-name', 'route']
-    if (segments.length > 2 && segments[1] === 'tech-dancer' && segments[2] !== '') {
-      const firstSegment = segments[2];
-      const standardRoutes = ['gear', 'research', 'blog', 'resources', 'about', 'contact', 'ux-auditor'];
-      // Treat segments[2] as a branch if it has a dash or isn't a standard route
-      if (firstSegment.includes('-') || standardRoutes.indexOf(firstSegment) === -1) {
-        return `/${segments[1]}/${segments[2]}`;
-      }
+  const fullPath = window.location.pathname;
+  // Standardize buildBase to not have a trailing slash
+  const buildBase = (import.meta.env.BASE_URL || '/').replace(/\/$/, '');
+
+  const segments = fullPath.split('/').filter(Boolean);
+  const baseSegments = buildBase.split('/').filter(Boolean);
+
+  // 2. Heuristic: If we are in a subdirectory deeper than buildBase,
+  // check if the next segment is a known route. If not, it's likely a branch name.
+  if (segments.length > baseSegments.length) {
+    const possibleRouteSegment = segments[baseSegments.length];
+
+    // Extract valid top-level paths from the route configuration to distinguish between routes and subdirectories
+    const validTopLevelPaths = routes[0].children
+      ?.map(r => r.path)
+      .filter((path): path is string => !!path && path !== '*' && path !== '/')
+      .map(path => path.split('/')[0]) || [];
+
+    const isStandardRoute = validTopLevelPaths.includes(possibleRouteSegment);
+    const isIndexHtml = possibleRouteSegment === 'index.html';
+
+    if (!isStandardRoute && !isIndexHtml) {
+      // It's likely a branch deployment. The basename includes this extra segment.
+      return '/' + segments.slice(0, baseSegments.length + 1).join('/');
     }
   }
-  return buildBase;
+
+  // 3. Fallback: Use the build-time BASE_URL
+  return buildBase || '/';
 };
 
 const router = createBrowserRouter(routes, {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,7 @@
 import { Buffer } from 'buffer';
 
 // polyfilling Buffer for browser environment
-(window as any).Buffer = (window as any).Buffer || Buffer;
+window.Buffer = window.Buffer || Buffer;
 
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
@@ -15,8 +15,8 @@ const getBasename = () => {
   const buildBase = import.meta.env.BASE_URL || '/';
 
   // If index.html already calculated a basename, use it
-  if ((window as any).__ROUTER_BASENAME__) {
-      return (window as any).__ROUTER_BASENAME__;
+  if (window.__ROUTER_BASENAME__) {
+      return window.__ROUTER_BASENAME__;
   }
 
   // Check if we are running in a subdirectory deeper than the build-time base (e.g., branch preview)

--- a/src/types/window.d.ts
+++ b/src/types/window.d.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+interface Window {
+  __ROUTER_BASENAME__?: string;
+  Buffer: any;
+}

--- a/src/types/window.d.ts
+++ b/src/types/window.d.ts
@@ -1,9 +1,0 @@
-/**
- * @license
- * SPDX-License-Identifier: Apache-2.0
- */
-
-interface Window {
-  __ROUTER_BASENAME__?: string;
-  Buffer: any;
-}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="vite/client" />
+
+interface Window {
+  __ROUTER_BASENAME__?: string;
+  Buffer: any;
+}


### PR DESCRIPTION
This PR fixes the issue where direct navigation or page refreshes on GitHub Pages subpages (including branch previews) would fail or redirect incorrectly. 

The fix implements a more robust, environment-aware routing strategy:
1. **Dynamic Probe (404.html)**: Instead of hardcoded paths, the 404 page now probes the path hierarchy to find the deepest `index.html`. This allows it to automatically detect if it's running in the root repo or a branch subdirectory.
2. **Runtime Basename (index.html & main.tsx)**: The application now determines its own `basename` at runtime based on the actual location of `index.html`. This eliminates the mismatch between build-time assumptions and runtime reality on GitHub Pages.
3. **Improved Restoration**: The URL restoration logic was standardized to correctly handle the `?/` prefix, ensuring query parameters and hashes are preserved during the restoration process.

Verified locally with E2E tests and a custom Playwright script simulating the GitHub Pages redirect flow.

Fixes #192

---
*PR created automatically by Jules for task [14450745139327826279](https://jules.google.com/task/14450745139327826279) started by @arii*