### PR TITLE
UX Audit: Unify and Optimize Blog & Gear Cards

### DIFF
--- a/src/components/ui/CardImagePlaceholder.tsx
+++ b/src/components/ui/CardImagePlaceholder.tsx
@@ -1,0 +1,62 @@
+import { Box, Text } from '@/layouts/Primitives';
+import { cn } from '@/lib/utils';
+
+interface CardImagePlaceholderProps {
+  image?: string;
+  category: string;
+  date?: string;
+  title: string;
+}
+
+export function CardImagePlaceholder({ image, category, date, title }: CardImagePlaceholderProps) {
+  const norm = (category || '').toLowerCase();
+
+  let surfaceVariant: "brand" | "accent" | "warning" | "danger" | "muted" = 'muted';
+  if (norm.includes('tech')) surfaceVariant = 'brand';
+  else if (norm.includes('travel') || norm.includes('wcs')) surfaceVariant = 'accent';
+  else if (norm.includes('gear')) surfaceVariant = 'warning';
+  else if (norm.includes('lifestyle')) surfaceVariant = 'danger';
+
+  if (image) {
+    return (
+      <Box className="relative w-full aspect-video max-h-[160px] overflow-hidden border-b border-line bg-bg">
+        <img
+          src={image}
+          alt={title}
+          className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-700"
+        />
+        <Box className="absolute top-3 left-3">
+          <Box surface={surfaceVariant} className="px-2 py-0.5 border border-line/20 backdrop-blur-sm bg-opacity-90">
+            <Text variant="mono" size="micro" weight="font-bold" uppercase className="tracking-wider">
+              {category}
+            </Text>
+          </Box>
+        </Box>
+      </Box>
+    );
+  }
+
+  return (
+    <Box
+      surface={surfaceVariant}
+      className={cn(
+        "w-full h-10 flex items-center px-4 border-b border-line/10",
+        "bg-opacity-10" // subtle background
+      )}
+    >
+      <Box display="flex" align="center" gap={2}>
+        <Text variant="mono" size="micro" weight="font-bold" uppercase className="tracking-widest opacity-80">
+          {category}
+        </Text>
+        {date && (
+          <>
+            <Box className="w-1 h-1 rounded-full bg-current opacity-30" />
+            <Text variant="mono" size="micro" uppercase className="tracking-widest opacity-60">
+              {date}
+            </Text>
+          </>
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/src/components/ui/ContentCard.tsx
+++ b/src/components/ui/ContentCard.tsx
@@ -1,8 +1,8 @@
 import { NavLink } from 'react-router-dom';
-import { motion } from 'motion/react';
 import { Box, Stack, Text } from '@/layouts/Primitives';
 import { readingTime } from '@/lib/content';
-import { CategoryPlaceholder } from '@/components/ui/CategoryPlaceholder';
+import { CardImagePlaceholder } from '@/components/ui/CardImagePlaceholder';
+import { Skeleton } from '@/components/ui/Skeleton';
 
 interface ContentCardProps {
   slug: string;
@@ -18,24 +18,24 @@ interface ContentCardProps {
 
 export function ContentCardSkeleton() {
   return (
-    <Box className="flex flex-col h-full bg-surface border border-line rounded-none overflow-hidden animate-pulse">
-      <Box className="relative aspect-video bg-line/50" />
-      <Stack gap={5} className="p-6 lg:p-8" flex={1} justify="between">
-        <Stack gap={4}>
-          <Box className="h-4 w-24 bg-line/50 rounded" />
-          <Box className="h-8 w-3/4 bg-line/50 rounded" />
+    <Box className="flex flex-col h-full bg-surface border border-line rounded-none overflow-hidden">
+      <Skeleton className="w-full aspect-video max-h-[160px] rounded-none" />
+      <Stack gap={4} className="p-5" flex={1} justify="between">
+        <Stack gap={3}>
+          <Skeleton className="h-3 w-24" />
+          <Skeleton className="h-6 w-3/4" />
           <Stack gap={2}>
-            <Box className="h-4 w-full bg-line/50 rounded" />
-            <Box className="h-4 w-5/6 bg-line/50 rounded" />
+            <Skeleton className="h-3 w-full" />
+            <Skeleton className="h-3 w-5/6" />
           </Stack>
         </Stack>
-        <Box className="h-4 w-20 bg-line/50 rounded mt-auto" />
+        <Skeleton className="h-3 w-20 mt-auto" />
       </Stack>
     </Box>
   );
 }
 
-export function ContentCard({ slug, title, category, excerpt, date, image, basePath, content, aspect = "video" }: ContentCardProps) {
+export function ContentCard({ slug, title, category, excerpt, date, image, basePath, content }: ContentCardProps) {
   const rt = readingTime(content, excerpt);
 
   return (
@@ -44,57 +44,64 @@ export function ContentCard({ slug, title, category, excerpt, date, image, baseP
       to={`${basePath}/${slug}`}
       className="group cursor-pointer flex flex-col h-full bg-surface border border-line hover:border-accent transition-all duration-300 rounded-none overflow-hidden"
     >
-      {/* Visual Thumbnail */}
-      <Box className="relative aspect-video overflow-hidden border-b border-line bg-bg">
-        {image ? (
-          <img 
-            src={image} 
-            alt={title} 
-            className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-700"
-          />
-        ) : (
-          <CategoryPlaceholder category={category} />
-        )}
-        <Box className="absolute top-4 left-4">
-          <Box className="px-3 py-1 bg-surface/90 backdrop-blur-sm border border-line rounded-none">
-            <Text variant="mono" size="micro" weight="font-bold" className="text-accent-navy uppercase tracking-wider">
-              {category}
-            </Text>
-          </Box>
-        </Box>
-      </Box>
+      <CardImagePlaceholder
+        image={image}
+        category={category}
+        date={date}
+        title={title}
+      />
 
       {/* Content Area */}
-      <Stack gap={5} padding={6} flex={1} justify="between">
-        <Stack gap={4}>
-          <Box display="flex" align="center" gap={3}>
-            <Text variant="mono" size="xs" color="dim" uppercase className="tracking-widest">
-              {date}
-            </Text>
-            <Box className="w-1 h-1 rounded-full bg-line" />
-            <Text variant="mono" size="xs" color="dim" uppercase className="tracking-widest flex items-center gap-1">
-              <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="opacity-50"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg>
-              {rt} min read
-            </Text>
-          </Box>
+      <Stack gap={4} padding={5} flex={1} justify="between">
+        <Stack gap={3}>
+          {/* Only show meta row if we have an image (since no-image uses compact header) */}
+          {image && (
+            <Box display="flex" align="center" gap={3}>
+              <Text variant="mono" size="xs" color="dim" uppercase className="tracking-widest">
+                {date}
+              </Text>
+              <Box className="w-1 h-1 rounded-full bg-line" />
+              <Text variant="mono" size="xs" color="dim" uppercase className="tracking-widest flex items-center gap-1">
+                <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="opacity-50"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg>
+                {rt} min
+              </Text>
+            </Box>
+          )}
+
+          {/* If no image, we still want to show reading time somewhere if possible,
+              but let's keep it clean as requested. The audit says "compact header strip"
+              and "footer row" for card structure. */}
+
+          {!image && (
+             <Box display="flex" align="center" gap={3}>
+                <Text variant="mono" size="xs" color="dim" uppercase className="tracking-widest flex items-center gap-1">
+                  <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="opacity-30"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg>
+                  {rt} min
+                </Text>
+             </Box>
+          )}
+
           <Text 
             variant="body"
-            size="xl" 
+            size="lg"
             weight="font-bold"
-            className="text-accent-navy leading-snug group-hover:text-accent transition-colors"
+            className="text-accent-navy leading-tight group-hover:text-accent transition-colors line-clamp-2"
           >
             {title}
           </Text>
-          <Text variant="body" size="base" color="dim" className="line-clamp-2 leading-relaxed">
-             {excerpt || `Discover the technical intersections of robotics and dance in this deep dive into ${category.toLowerCase()} methodology and engineering principles.`}
+          <Text variant="body" size="sm" color="dim" className="line-clamp-2 leading-relaxed opacity-80">
+             {excerpt || `Discover technical insights in ${category.toLowerCase()} methodology.`}
           </Text>
         </Stack>
 
-        <Box display="flex" align="center" gap={2} paddingTop={6} className="border-t border-line mt-auto">
-          <Text variant="mono" size="xs" className="text-accent font-semibold uppercase tracking-[0.15em]">
-            Read {title}
+        <Box display="flex" align="center" gap={2} paddingTop={4} className="border-t border-line/50 mt-auto">
+          <Text variant="mono" size="xs" weight="font-bold" className="text-accent tracking-wider">
+            Read Article
           </Text>
-          <Box className="w-0 h-[1.5px] bg-accent group-hover:w-8 transition-all duration-500" />
+          <Box className="w-0 h-[1px] bg-accent group-hover:w-6 transition-all duration-500" />
+          <Text variant="mono" size="xs" className="text-accent ml-auto opacity-0 group-hover:opacity-100 transition-opacity">
+            →
+          </Text>
         </Box>
       </Stack>
     </Box>

--- a/src/components/ui/ContentCard.tsx
+++ b/src/components/ui/ContentCard.tsx
@@ -42,7 +42,7 @@ export function ContentCard({ slug, title, category, excerpt, date, image, baseP
     <Box 
       as={NavLink}
       to={`${basePath}/${slug}`}
-      className="group cursor-pointer flex flex-col h-full bg-surface border border-line hover:border-accent transition-all duration-300 rounded-none overflow-hidden"
+      className="group flex flex-col h-full bg-surface border border-line hover:border-accent transition-all duration-300 rounded-none overflow-hidden"
     >
       <CardImagePlaceholder
         image={image}

--- a/src/components/ui/ListRow.tsx
+++ b/src/components/ui/ListRow.tsx
@@ -23,7 +23,7 @@ export function ListRow({ slug, title, category, excerpt, date, basePath, conten
       className="group hover:bg-surface/50 transition-colors"
     >
       <Box className="w-1 self-stretch bg-accent shrink-0 opacity-0 group-hover:opacity-100 transition-opacity" />
-      <Box className="w-12 h-12 m-3 shrink-0 rounded-none overflow-hidden">
+      <Box className="w-12 h-12 m-3 shrink-0 rounded-none overflow-hidden flex items-center justify-center">
         <CategoryPlaceholder category={category} size="md" />
       </Box>
       <Stack gap={1} flex className="py-3 min-w-0">
@@ -31,7 +31,7 @@ export function ListRow({ slug, title, category, excerpt, date, basePath, conten
           <Text variant="mono" size="micro" color="brand" className="uppercase shrink-0">{category}</Text>
           <Text variant="mono" size="micro" color="dim">{date}</Text>
         </Box>
-        <Text variant="display" size="sm" weight="font-bold" className="line-clamp-2">{title}</Text>
+        <Text variant="display" size="sm" weight="font-bold" className="line-clamp-1">{title}</Text>
         <Text variant="body" size="xs" color="dim" className="truncate">{excerpt}</Text>
       </Stack>
       <Box display="flex" align="center" gap={3} padding={4} className="shrink-0 text-text-dim">

--- a/src/components/ui/Skeleton.tsx
+++ b/src/components/ui/Skeleton.tsx
@@ -2,6 +2,13 @@ import { cn } from '@/lib/utils';
 
 export function Skeleton({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
   return (
-    <div className={cn('animate-pulse rounded-md bg-line/20', className)} {...props} />
+    <div
+      className={cn(
+        'relative overflow-hidden bg-line/10',
+        'before:absolute before:inset-0 before:-translate-x-full before:animate-[shimmer_2s_infinite] before:bg-gradient-to-r before:from-transparent before:via-white/10 before:to-transparent',
+        className
+      )}
+      {...props}
+    />
   );
 }

--- a/src/features/lab/GearCard.tsx
+++ b/src/features/lab/GearCard.tsx
@@ -1,7 +1,7 @@
 import { NavLink } from 'react-router-dom';
 import { Box, Stack, Text } from '@/layouts/Primitives';
 import { Resource } from '@/lib/content';
-import { CategoryPlaceholder } from '@/components/ui/CategoryPlaceholder';
+import { CardImagePlaceholder } from '@/components/ui/CardImagePlaceholder';
 
 interface GearCardProps extends Resource {
   basePath: string;
@@ -20,89 +20,78 @@ export function GearCard({
   updatedDate
 }: GearCardProps) {
   return (
-    <NavLink
+    <Box
+      as={NavLink}
       to={`${basePath}/${slug}`}
-      className="group flex flex-col bg-surface border border-line transition-all duration-300 overflow-hidden"
+      className="group flex flex-col h-full bg-surface border border-line hover:border-accent transition-all duration-300 rounded-none overflow-hidden"
     >
-      {/* Image Wrapper */}
-      <div className="aspect-square md:aspect-video relative overflow-hidden border-b border-line bg-bg">
-        {image ? (
-          <img
-            src={image}
-            alt={title}
-            className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500"
-          />
-        ) : (
-          <CategoryPlaceholder category={category} />
-        )}
-        <div className="absolute top-4 left-4">
-          <div className="bg-surface/90 backdrop-blur px-3 py-1 rounded-none border border-line">
-            <Text variant="mono" size="micro" weight="font-bold" className="text-accent-navy uppercase">
-              {category}
-            </Text>
-          </div>
-        </div>
-        {verdict && (
-          <div className="absolute top-4 right-4">
-            <div className="bg-accent-brand px-2 py-1 rounded-none">
-              <Text variant="mono" size="micro" weight="font-bold" className="text-white uppercase">
-                {verdict}
-              </Text>
-            </div>
-          </div>
-        )}
-      </div>
+      <CardImagePlaceholder
+        image={image}
+        category={category}
+        date={updatedDate}
+        title={title}
+      />
 
       {/* Content Area */}
-      <div className="flex flex-col gap-4 p-6 flex-1">
-        <div className="flex flex-col gap-2">
-          {rating && (
-            <div className="flex items-center gap-1 mb-1">
-              <span className="text-amber-500 drop-shadow-sm">
-                {'★'.repeat(Math.floor(rating))}
-                {rating % 1 !== 0 ? '½' : ''}
-              </span>
-              <Text variant="mono" size="micro" color="dim" emphasis="low">
-                ({rating}/5)
-              </Text>
-            </div>
-          )}
+      <Stack gap={4} padding={5} flex={1} justify="between">
+        <Stack gap={3}>
+          <Box display="flex" align="center" justify="between" wrap>
+            {rating && (
+              <Box display="flex" align="center" gap={1}>
+                <span className="text-amber-500 text-xs">
+                  {'★'.repeat(Math.floor(rating))}
+                  {rating % 1 !== 0 ? '½' : ''}
+                </span>
+                <Text variant="mono" size="micro" color="dim">
+                  ({rating}/5)
+                </Text>
+              </Box>
+            )}
 
-          <h3 className="font-sans font-bold tracking-tight leading-tight text-xl text-accent-navy group-hover:text-accent transition-colors">
+            {verdict && (
+              <Box surface="brand" className="px-1.5 py-0.5 rounded-none border border-line/10">
+                <Text variant="mono" size="micro" weight="font-bold" className="uppercase">
+                  {verdict}
+                </Text>
+              </Box>
+            )}
+          </Box>
+
+          <Text
+            variant="body"
+            size="lg"
+            weight="font-bold"
+            className="text-accent-navy leading-tight group-hover:text-accent transition-colors line-clamp-2"
+          >
             {title}
-          </h3>
-
-          <p className="font-sans leading-relaxed text-text-body text-sm line-clamp-2">
-             {excerpt}
-          </p>
-
-          {(priceCategory || updatedDate) && (
-            <div className="flex flex-wrap items-center gap-3 mt-2">
-               {priceCategory && (
-                 <Box border className="bg-amber-50 px-2 py-0.5 border-amber-200">
-                   <Text variant="mono" size="tiny" weight="font-bold" className="text-amber-700">{priceCategory}</Text>
-                 </Box>
-               )}
-               {updatedDate && (
-                 <Text variant="mono" size="tiny" color="dim">Updated {updatedDate}</Text>
-               )}
-            </div>
-          )}
-        </div>
-
-        <div className="flex flex-col gap-3 mt-auto">
-          <Text variant="mono" size="xs" color="dim" className="leading-tight mb-2">
-            * This post contains affiliate links. I may earn a commission at no extra cost to you.
           </Text>
-          <div className="flex items-center justify-between pt-4 border-t border-line/50">
-            <Text variant="mono" size="xs" color="brand" weight="font-bold">
-              Read {title} Review
+
+          <Text variant="body" size="sm" color="dim" className="line-clamp-2 leading-relaxed opacity-80">
+             {excerpt}
+          </Text>
+
+          {priceCategory && (
+             <Box border className="bg-amber-50/50 px-2 py-0.5 border-amber-200/50 w-fit">
+               <Text variant="mono" size="micro" weight="font-bold" className="text-amber-700">{priceCategory}</Text>
+             </Box>
+          )}
+        </Stack>
+
+        <Stack gap={3} marginTop="auto">
+          <Text variant="mono" size="micro" color="dim" className="leading-tight opacity-70 italic">
+            * Affiliate links — commission earned at no cost to you.
+          </Text>
+
+          <Box display="flex" align="center" gap={2} paddingTop={4} className="border-t border-line/50">
+            <Text variant="mono" size="xs" weight="font-bold" className="text-accent tracking-wider">
+              Read Review
             </Text>
-            <div className="group-hover:translate-x-1 transition-transform duration-300">
+            <Box className="w-0 h-[1px] bg-accent group-hover:w-6 transition-all duration-500" />
+            <Box className="group-hover:translate-x-1 transition-transform duration-300 ml-auto">
               <svg
                 xmlns="http://www.w3.org/2000/svg"
-                width="16"
-                height="16"
+                width="14"
+                height="14"
                 viewBox="0 0 24 24"
                 fill="none"
                 stroke="currentColor"
@@ -113,10 +102,10 @@ export function GearCard({
               >
                 <polyline points="9 18 15 12 9 6"></polyline>
               </svg>
-            </div>
-          </div>
-        </div>
-      </div>
-    </NavLink>
+            </Box>
+          </Box>
+        </Stack>
+      </Stack>
+    </Box>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -46,6 +46,12 @@
     animation: scanline 2.5s linear infinite;
   }
 
+  @keyframes shimmer {
+    100% {
+      transform: translateX(100%);
+    }
+  }
+
   /* Premium Industrial Utilities */
   .glass-panel {
     @apply bg-white/70 backdrop-blur-xl border border-white/20 shadow-[0_8px_32px_0_rgba(0,0,0,0.05)];

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,11 +1,39 @@
-module.exports = {
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: [
+    "./index.html",
+    "./src/**/*.{js,ts,jsx,tsx}",
+  ],
   theme: {
     extend: {
-      keyframes: {
-        shimmer: {
-          '100%': { transform: 'translateX(100%)' },
-        },
+      colors: {
+        bg: 'var(--color-bg)',
+        surface: 'var(--color-surface)',
+        'surface-alt': 'var(--color-surface-alt)',
+        accent: 'var(--color-accent)',
+        'accent-navy': 'var(--color-accent-navy)',
+        'text-main': 'var(--color-text-main)',
+        'text-body': 'var(--color-text-body)',
+        'text-dim': 'var(--color-text-dim)',
+        line: 'var(--color-line)',
       },
+      fontFamily: {
+        display: ['var(--font-display)'],
+        mono: ['var(--font-mono)'],
+        sans: ['var(--font-sans)'],
+      },
+      keyframes: {
+        gradient: {
+          '0%, 100%': { backgroundPosition: '0% 50%' },
+          '50%': { backgroundPosition: '100% 50%' },
+        }
+      },
+      animation: {
+        gradient: 'gradient 8s ease infinite',
+      }
     },
   },
-};
+  plugins: [
+    require('@tailwindcss/typography'),
+  ],
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,39 +1,11 @@
-/** @type {import('tailwindcss').Config} */
-export default {
-  content: [
-    "./index.html",
-    "./src/**/*.{js,ts,jsx,tsx}",
-  ],
+module.exports = {
   theme: {
     extend: {
-      colors: {
-        bg: 'var(--color-bg)',
-        surface: 'var(--color-surface)',
-        'surface-alt': 'var(--color-surface-alt)',
-        accent: 'var(--color-accent)',
-        'accent-navy': 'var(--color-accent-navy)',
-        'text-main': 'var(--color-text-main)',
-        'text-body': 'var(--color-text-body)',
-        'text-dim': 'var(--color-text-dim)',
-        line: 'var(--color-line)',
-      },
-      fontFamily: {
-        display: ['var(--font-display)'],
-        mono: ['var(--font-mono)'],
-        sans: ['var(--font-sans)'],
-      },
       keyframes: {
-        gradient: {
-          '0%, 100%': { backgroundPosition: '0% 50%' },
-          '50%': { backgroundPosition: '100% 50%' },
-        }
+        shimmer: {
+          '100%': { transform: 'translateX(100%)' },
+        },
       },
-      animation: {
-        gradient: 'gradient 8s ease infinite',
-      }
     },
   },
-  plugins: [
-    require('@tailwindcss/typography'),
-  ],
-}
+};


### PR DESCRIPTION
This PR implements the UX audit recommendations for Blog Posts and Gear Reviews. 

Key changes:
1. **Unification**: Introduced `CardImagePlaceholder.tsx` used by both `ContentCard` (Blog) and `GearCard`.
2. **Space Optimization**: Images are now capped at 160px height. Items without images use a compact (40px) header strip instead of a large icon placeholder, dramatically increasing content density.
3. **CTA Refinement**: Redundant all-caps titles in CTAs were replaced with simple "Read Article" or "Read Review" labels.
4. **Loading States**: Updated `ContentCardSkeleton` to use a new shimmer-enabled `Skeleton` component, providing a more intentional loading experience.
5. **Affiliate Styling**: The affiliate disclaimer in gear cards is now muted, smaller, and uses normal case to reduce visual noise.

Verified via Playwright screenshots and E2E smoke tests.

Fixes #211

---
*PR created automatically by Jules for task [2392375378923336404](https://jules.google.com/task/2392375378923336404) started by @arii*