### PR TITLE
Automated Preview Index and Cleanup for GitHub Pages

### DIFF
--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -22,16 +22,23 @@ jobs:
         with:
           ref: gh-pages
 
-      - name: Remove branch folder
+      - name: Remove branch folder and update index
         run: |
-          if [ -d "${{ github.event.ref }}" ]; then
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
 
+          if [ -d "${{ github.event.ref }}" ]; then
             git rm -r "${{ github.event.ref }}"
             git commit -m "chore: cleanup preview site for deleted branch ${{ github.event.ref }}"
-            git pull --rebase origin gh-pages
-            git push origin gh-pages
           else
-            echo "Directory ${{ github.event.ref }} not found. Nothing to clean up."
+            echo "Directory ${{ github.event.ref }} not found. Skipping deletion."
           fi
+
+          # Since cleanup doesn't have a 'build' step, we have to rely on the fact
+          # that the fancy previews/index.html was already committed to the branch
+          # or is being maintained by the deployment action.
+          # If it gets deleted somehow, the deployment action will restore it.
+          # Here we just make sure we push the cleanup change.
+
+          git pull --rebase origin gh-pages
+          git push origin gh-pages

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -150,3 +150,24 @@ jobs:
                 });
               }
             }
+
+      - name: Checkout gh-pages for index update
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: gh-pages-branch
+
+      - name: Generate and Deploy Previews Index
+        run: |
+          cd gh-pages-branch
+          mkdir -p previews
+
+          # Copy the fancy dashboard from the build
+          cp ../dist/previews/index.html previews/index.html
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add previews/index.html
+          git commit -m "chore: update previews index after deployment" || echo "No changes to commit"
+          git pull --rebase origin gh-pages
+          git push origin gh-pages

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -88,6 +88,7 @@ jobs:
             const branchName = context.ref.replace('refs/heads/', '');
             const baseUrl = `https://${owner}.github.io/${repo}/`;
             const previewUrl = branchName === 'main' ? baseUrl : `${baseUrl}${branchName}/`;
+            const dashboardUrl = `${baseUrl}previews/index.html`;
 
             const pstTime = new Date().toLocaleString('en-US', {
               timeZone: 'America/Los_Angeles',
@@ -101,7 +102,8 @@ jobs:
               .addTable([
                 ['Site', 'URL'],
                 ['Main Site', `<a href="${baseUrl}">${baseUrl}</a>`],
-                ['Preview URL', `<a href="${previewUrl}">${previewUrl}</a>`]
+                ['Preview URL', `<a href="${previewUrl}">${previewUrl}</a>`],
+                ['Preview Dashboard', `<a href="${dashboardUrl}">${dashboardUrl}</a>`]
               ])
               .addRaw(`**Last updated:** ${pstTime} PST`)
               .write();

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -117,11 +117,13 @@ jobs:
 
             for (const pr of pullRequests) {
               const commentTag = `<!-- preview-url-comment-${branchName} -->`;
+              const dashboardUrl = `${baseUrl}previews/index.html`;
               const body = [
                 `🚀 **Deployment Details** (Last updated: ${pstTime} PST)`,
                 '',
                 `- **Main Site:** ${baseUrl}`,
                 `- **Preview URL:** ${previewUrl}`,
+                `- **Preview Dashboard:** ${dashboardUrl}`,
                 '',
                 commentTag
               ].join('\n');

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -166,6 +166,12 @@ jobs:
           cd gh-pages-branch
           mkdir -p previews
 
+          # Validation: Ensure the dashboard exists in build artifacts
+          if [ ! -f "../dist/previews/index.html" ]; then
+            echo "Error: dist/previews/index.html not found! Deployment of preview index failed."
+            exit 1
+          fi
+
           # Copy the fancy dashboard from the build
           cp ../dist/previews/index.html previews/index.html
 

--- a/.github/workflows/prune-stale-previews.yml
+++ b/.github/workflows/prune-stale-previews.yml
@@ -1,0 +1,56 @@
+name: Prune Stale Previews
+on:
+  schedule:
+    - cron: '0 0 * * *' # Runs daily at midnight UTC
+  workflow_dispatch: # Allows manual triggering
+
+jobs:
+  prune:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Checkout gh-pages
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: gh-pages-branch
+
+      - name: Prune orphaned directories
+        run: |
+          cd gh-pages-branch
+
+          # Get list of all active remote branches
+          ACTIVE_BRANCHES=$(git ls-remote --heads origin | awk -F'refs/heads/' '{print $2}')
+
+          CHANGES_MADE=false
+
+          for dir in */; do
+            dir=${dir%/}
+
+            # Skip special folders
+            if [[ "$dir" == "assets" || "$dir" == "tmp" || "$dir" == "previews" || ! -f "$dir/index.html" ]]; then
+              continue
+            fi
+
+            # Remove folder if it doesn't match an active branch
+            if ! echo "$ACTIVE_BRANCHES" | grep -qx "$dir"; then
+              echo "Branch '$dir' no longer exists. Removing preview..."
+              git rm -r "$dir"
+              CHANGES_MADE=true
+            fi
+          done
+
+          if [ "$CHANGES_MADE" = true ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git commit -m "chore: prune orphaned branch previews"
+            git push origin gh-pages
+          else
+            echo "No stale previews to prune."
+          fi

--- a/.github/workflows/prune-stale-previews.yml
+++ b/.github/workflows/prune-stale-previews.yml
@@ -30,11 +30,12 @@ jobs:
 
           CHANGES_MADE=false
 
-          for dir in */; do
-            dir=${dir%/}
+          # Find all index.html files to identify deployment directories (including nested ones)
+          for index_file in $(find . -maxdepth 3 -name "index.html"); do
+            dir=$(dirname "$index_file" | sed 's|^\./||')
 
-            # Skip special folders
-            if [[ "$dir" == "assets" || "$dir" == "tmp" || "$dir" == "previews" || ! -f "$dir/index.html" ]]; then
+            # Skip special folders and the root site
+            if [[ "$dir" == "." || "$dir" == "assets" || "$dir" == "tmp" || "$dir" == "previews" ]]; then
               continue
             fi
 

--- a/public/previews/index.html
+++ b/public/previews/index.html
@@ -47,7 +47,7 @@
     <script>
         const REPO_OWNER = 'arii', REPO_NAME = 'tech-dancer';
         const BASE_URL = `https://${REPO_OWNER}.github.io/${REPO_NAME}`;
-        const EXCLUDED_FOLDERS = ['assets', 'previews', 'css', 'js', 'img', 'images', 'public'];
+        const EXCLUDED = ['assets', 'previews', 'css', 'js', 'img', 'images', 'public'];
         const ICONS = {
             pr: `<svg class="w-5 h-5 shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><circle cx="18" cy="18" r="3"/><circle cx="6" cy="6" r="3"/><path d="M13 6h3a2 2 0 0 1 2 2v7"/><line x1="6" x2="6" y1="9" y2="21"/></svg>`,
             branch: `<svg class="w-5 h-5 shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><line x1="6" x2="6" y1="3" y2="15"/><circle cx="18" cy="6" r="3"/><circle cx="6" cy="18" r="3"/><path d="M18 9a9 9 0 0 1-9 9"/></svg>`,
@@ -57,19 +57,20 @@
         async function init() {
             const grid = document.getElementById('grid'), loading = document.getElementById('loading'), errorAlert = document.getElementById('error-alert');
             try {
-                const [contents, prs] = await Promise.all([
-                    fetch(`https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/contents?ref=gh-pages`).then(r => r.ok ? r.json() : Promise.reject(new Error(`API Error: ${r.status}`))),
+                const [treeData, prs] = await Promise.all([
+                    fetch(`https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/git/trees/gh-pages?recursive=1`).then(r => r.ok ? r.json() : Promise.reject(new Error(`API Error: ${r.status}`))),
                     fetch(`https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/pulls?state=open`).then(r => r.ok ? r.json() : [])
                 ]);
                 loading.style.display = 'none';
-                const folders = contents.filter(i => i.type === 'dir' && !i.name.startsWith('.') && !EXCLUDED_FOLDERS.includes(i.name))
-                    .sort((a, b) => (prs.find(p => p.head.ref === b.name) ? 1 : 0) - (prs.find(p => p.head.ref === a.name) ? 1 : 0) || a.name.localeCompare(b.name));
+                const folders = treeData.tree.filter(i => i.path.endsWith('/index.html') && !EXCLUDED.some(e => i.path.startsWith(e)) && i.path !== 'index.html' && i.path !== '404.html')
+                    .map(i => i.path.replace('/index.html', ''))
+                    .sort((a, b) => (prs.find(p => p.head.ref === b) ? 1 : 0) - (prs.find(p => p.head.ref === a) ? 1 : 0) || a.localeCompare(b));
                 if (!folders.length) {
                     grid.innerHTML = `<div class="text-center py-16 bg-white dark:bg-slate-900 rounded-xl border border-slate-200 dark:border-slate-800 shadow-sm"><p class="text-slate-500 dark:text-slate-400 text-lg">No active preview branches found.</p></div>`;
                     return;
                 }
-                folders.forEach(folder => {
-                    const pr = prs.find(p => p.head.ref === folder.name), url = `${BASE_URL}/${folder.name}/`;
+                folders.forEach(name => {
+                    const pr = prs.find(p => p.head.ref === name), url = `${BASE_URL}/${name}/`;
                     const card = document.createElement('div');
                     card.className = 'bg-white dark:bg-slate-900 rounded-xl border border-slate-200 dark:border-slate-800 p-5 sm:p-6 shadow-sm hover:shadow-md transition-all flex flex-col sm:flex-row justify-between items-start sm:items-center gap-5 hover:border-blue-300 dark:hover:border-blue-700';
                     const badge = pr
@@ -81,7 +82,7 @@
                                 ${pr ? `<a href="${pr.html_url}" target="_blank" rel="noopener" class="text-blue-600 dark:text-blue-400 hover:underline font-semibold text-lg sm:text-xl flex items-center gap-2 truncate">${ICONS.pr} PR #${pr.number}: ${escapeHtml(pr.title)}</a>` : `<div class="text-slate-800 dark:text-slate-200 font-semibold text-lg sm:text-xl flex items-center gap-2">${ICONS.branch} Deployed Branch</div>`}
                                 <div class="hidden sm:block">${badge}</div>
                             </div>
-                            <div class="flex items-center gap-2"><span class="text-sm bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-400 font-mono px-2 py-1 rounded border border-slate-200 dark:border-slate-700 truncate">${escapeHtml(folder.name)}</span><div class="sm:hidden">${badge}</div></div>
+                            <div class="flex items-center gap-2"><span class="text-sm bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-400 font-mono px-2 py-1 rounded border border-slate-200 dark:border-slate-700 truncate">${escapeHtml(name)}</span><div class="sm:hidden">${badge}</div></div>
                         </div>
                         <a href="${url}" target="_blank" rel="noopener" class="w-full sm:w-auto bg-slate-900 dark:bg-blue-600 text-white font-medium py-2.5 px-5 rounded-lg flex items-center justify-center gap-2 shadow-sm">View Deployment ${ICONS.external}</a>`;
                     grid.appendChild(card);

--- a/public/previews/index.html
+++ b/public/previews/index.html
@@ -1,0 +1,227 @@
+<!DOCTYPE html>
+<html lang="en" class="antialiased">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Preview Environments | Tech Dancer</title>
+    <!-- Tailwind CSS for a modern, responsive, and dark-mode compatible UI -->
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+        tailwind.config = {
+            darkMode: 'media',
+            theme: {
+                extend: {
+                    fontFamily: {
+                        sans: ['system-ui', '-apple-system', 'sans-serif'],
+                        mono: ['ui-monospace', 'SFMono-Regular', 'Menlo', 'monospace'],
+                    }
+                }
+            }
+        }
+    </script>
+    <style>
+        /* Custom Scrollbar */
+        ::-webkit-scrollbar { width: 8px; }
+        ::-webkit-scrollbar-track { background: transparent; }
+        ::-webkit-scrollbar-thumb { background: #cbd5e1; border-radius: 4px; }
+        @media (prefers-color-scheme: dark) {
+            ::-webkit-scrollbar-thumb { background: #475569; }
+        }
+    </style>
+</head>
+<body class="min-h-screen bg-slate-50 dark:bg-slate-950 text-slate-900 dark:text-slate-100 transition-colors duration-200">
+    <div class="max-w-5xl mx-auto px-4 py-12 sm:px-6 lg:px-8">
+
+        <!-- Header Section -->
+        <div class="mb-10 text-center sm:text-left flex flex-col sm:flex-row sm:items-end justify-between gap-4 border-b border-slate-200 dark:border-slate-800 pb-6">
+            <div>
+                <h1 class="text-3xl font-extrabold tracking-tight sm:text-4xl mb-2 flex items-center justify-center sm:justify-start gap-3">
+                    <svg class="w-8 h-8 text-blue-500" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/></svg>
+                    Preview Environments
+                </h1>
+                <p class="text-slate-500 dark:text-slate-400 text-lg max-w-2xl">
+                    Live index of all deployed feature branches and active pull requests.
+                </p>
+            </div>
+            <a href="../" class="inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 border border-slate-300 bg-white hover:bg-slate-100 dark:border-slate-700 dark:bg-slate-900 dark:hover:bg-slate-800 h-10 px-4 py-2 shrink-0 shadow-sm">
+                &larr; Back to Main Site
+            </a>
+        </div>
+
+        <!-- Alert/Error Box -->
+        <div id="error-alert" class="hidden mb-8 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 text-red-800 dark:text-red-400 px-4 py-4 rounded-lg shadow-sm" role="alert">
+            <div class="flex items-center gap-3">
+                <svg class="w-5 h-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+                <span id="error-msg" class="font-medium"></span>
+            </div>
+        </div>
+
+        <!-- Loading State -->
+        <div id="loading" class="flex flex-col items-center justify-center py-20 gap-4">
+            <svg class="animate-spin h-10 w-10 text-blue-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+            </svg>
+            <span class="text-lg text-slate-500 dark:text-slate-400 font-medium animate-pulse">Scanning gh-pages deployments...</span>
+        </div>
+
+        <!-- Previews Grid -->
+        <div id="grid" class="grid gap-4 flex-col">
+            <!-- Cards injected via JS -->
+        </div>
+
+    </div>
+
+    <script>
+        // Auto-detect the repository context from the URL if deployed to GitHub Pages
+        const hostname = window.location.hostname;
+        const pathname = window.location.pathname;
+
+        let REPO_OWNER = 'arii';
+        let REPO_NAME = 'tech-dancer';
+
+        if (hostname.endsWith('.github.io')) {
+            REPO_OWNER = hostname.replace('.github.io', '');
+            const pathParts = pathname.split('/').filter(Boolean);
+            if (pathParts.length > 0) {
+                REPO_NAME = pathParts[0];
+            }
+        }
+
+        const BASE_URL = `https://${REPO_OWNER}.github.io/${REPO_NAME}`;
+
+        // Standard directories deployed by Vite/React that are NOT branch previews
+        const EXCLUDED_FOLDERS = ['assets', 'previews', 'css', 'js', 'img', 'images', 'public'];
+
+        const ICONS = {
+            pr: `<svg class="w-5 h-5 shrink-0" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24"><circle cx="18" cy="18" r="3"/><circle cx="6" cy="6" r="3"/><path d="M13 6h3a2 2 0 0 1 2 2v7"/><line x1="6" x2="6" y1="9" y2="21"/></svg>`,
+            branch: `<svg class="w-5 h-5 shrink-0" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24"><line x1="6" x2="6" y1="3" y2="15"/><circle cx="18" cy="6" r="3"/><circle cx="6" cy="18" r="3"/><path d="M18 9a9 9 0 0 1-9 9"/></svg>`,
+            external: `<svg class="w-4 h-4 shrink-0" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" x2="21" y1="14" y2="3"/></svg>`
+        };
+
+        async function init() {
+            const grid = document.getElementById('grid');
+            const loading = document.getElementById('loading');
+            const errorAlert = document.getElementById('error-alert');
+            const errorMsg = document.getElementById('error-msg');
+
+            try {
+                // 1. Fetch exactly what is currently deployed in the gh-pages branch
+                const contentsRes = await fetch(`https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/contents?ref=gh-pages`);
+
+                if (contentsRes.status === 403 || contentsRes.status === 429) {
+                    throw new Error(`GitHub API rate limit exceeded. Please try again later.`);
+                }
+                if (!contentsRes.ok) {
+                    throw new Error(`GitHub API Error: ${contentsRes.status} ${contentsRes.statusText}`);
+                }
+
+                const contents = await contentsRes.json();
+
+                // Extract only directories that aren't system/build folders
+                const branchFolders = contents.filter(item =>
+                    item.type === 'dir' &&
+                    !item.name.startsWith('.') &&
+                    !EXCLUDED_FOLDERS.includes(item.name)
+                );
+
+                // 2. Fetch open PRs to enrich the folders with contextual titles
+                let prs = [];
+                try {
+                    const prsRes = await fetch(`https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/pulls?state=open`);
+                    if (prsRes.ok) {
+                        prs = await prsRes.json();
+                    }
+                } catch (e) {
+                    console.warn("Could not fetch open PRs for enrichment", e);
+                }
+
+                loading.style.display = 'none';
+
+                if (branchFolders.length === 0) {
+                    grid.innerHTML = `
+                        <div class="text-center py-16 bg-white dark:bg-slate-900 rounded-xl border border-slate-200 dark:border-slate-800 shadow-sm">
+                            <p class="text-slate-500 dark:text-slate-400 text-lg">No active preview branches found on gh-pages.</p>
+                        </div>
+                    `;
+                    return;
+                }
+
+                // Sort: Folders linked to open PRs show up first
+                branchFolders.sort((a, b) => {
+                    const prA = prs.find(p => p.head.ref === a.name);
+                    const prB = prs.find(p => p.head.ref === b.name);
+                    if (prA && !prB) return -1;
+                    if (!prA && prB) return 1;
+                    return a.name.localeCompare(b.name);
+                });
+
+                branchFolders.forEach(folder => {
+                    const pr = prs.find(p => p.head.ref === folder.name);
+                    const url = `${BASE_URL}/${folder.name}/`;
+
+                    const card = document.createElement('div');
+                    card.className = 'bg-white dark:bg-slate-900 rounded-xl border border-slate-200 dark:border-slate-800 p-5 sm:p-6 shadow-sm hover:shadow-md transition-all duration-200 flex flex-col sm:flex-row justify-between items-start sm:items-center gap-5 hover:border-blue-300 dark:hover:border-blue-700';
+
+                    let titleHtml = '';
+                    let badgeHtml = '';
+
+                    if (pr) {
+                        titleHtml = `
+                            <a href="${pr.html_url}" target="_blank" rel="noopener noreferrer" class="text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 hover:underline font-semibold text-lg sm:text-xl flex items-center gap-2 group transition-colors line-clamp-1">
+                                ${ICONS.pr}
+                                <span class="truncate">PR #${pr.number}: ${escapeHtml(pr.title)}</span>
+                            </a>`;
+                        badgeHtml = `<span class="bg-blue-50 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400 text-xs font-semibold px-2.5 py-1 rounded-full whitespace-nowrap border border-blue-200 dark:border-blue-800">Open PR</span>`;
+                    } else {
+                        titleHtml = `
+                            <div class="text-slate-800 dark:text-slate-200 font-semibold text-lg sm:text-xl flex items-center gap-2">
+                                ${ICONS.branch}
+                                <span>Deployed Branch</span>
+                            </div>`;
+                        badgeHtml = `<span class="bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-400 text-xs font-semibold px-2.5 py-1 rounded-full whitespace-nowrap border border-slate-200 dark:border-slate-700">Inactive / Merged</span>`;
+                    }
+
+                    card.innerHTML = `
+                        <div class="flex-1 min-w-0 w-full">
+                            <div class="flex flex-col sm:flex-row sm:items-center gap-3 mb-3">
+                                ${titleHtml}
+                                <div class="hidden sm:block">${badgeHtml}</div>
+                            </div>
+                            <div class="flex items-center gap-2">
+                                <span class="text-sm bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-400 font-mono px-2 py-1 rounded border border-slate-200 dark:border-slate-700 truncate max-w-full inline-block">
+                                    ${escapeHtml(folder.name)}
+                                </span>
+                                <div class="sm:hidden">${badgeHtml}</div>
+                            </div>
+                        </div>
+
+                        <a href="${url}" target="_blank" rel="noopener noreferrer" class="shrink-0 w-full sm:w-auto bg-slate-900 hover:bg-slate-800 dark:bg-blue-600 dark:hover:bg-blue-500 text-white font-medium py-2.5 px-5 rounded-lg transition-colors flex items-center justify-center gap-2 shadow-sm outline-none focus:ring-2 focus:ring-offset-2 focus:ring-slate-900 dark:focus:ring-blue-600 dark:focus:ring-offset-slate-900">
+                            View Deployment
+                            ${ICONS.external}
+                        </a>
+                    `;
+
+                    grid.appendChild(card);
+                });
+
+            } catch (err) {
+                loading.style.display = 'none';
+                errorMsg.textContent = err.message;
+                errorAlert.classList.remove('hidden');
+            }
+        }
+
+        function escapeHtml(unsafe) {
+            return unsafe
+                 .replace(/&/g, "&amp;")
+                 .replace(/</g, "&lt;")
+                 .replace(/>/g, "&gt;")
+                 .replace(/"/g, "&quot;")
+                 .replace(/'/g, "&#039;");
+        }
+
+        init();
+    </script>
+</body>
+</html>

--- a/public/previews/index.html
+++ b/public/previews/index.html
@@ -1,4 +1,10 @@
 <!DOCTYPE html>
+<!--
+  PREVIEW DASHBOARD (Infrastructure Tool)
+  This is a standalone DevOps utility deployed independently to gh-pages.
+  EXCEPTION: It uses CDN Tailwind and raw utility classes to remain zero-dependency
+  and lightweight for operational use outside the main React application boundary.
+-->
 <html lang="en" class="antialiased">
 <head>
     <meta charset="UTF-8">

--- a/public/previews/index.html
+++ b/public/previews/index.html
@@ -4,223 +4,88 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Preview Environments | Tech Dancer</title>
-    <!-- Tailwind CSS for a modern, responsive, and dark-mode compatible UI -->
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
-        tailwind.config = {
-            darkMode: 'media',
-            theme: {
-                extend: {
-                    fontFamily: {
-                        sans: ['system-ui', '-apple-system', 'sans-serif'],
-                        mono: ['ui-monospace', 'SFMono-Regular', 'Menlo', 'monospace'],
-                    }
-                }
-            }
-        }
+        tailwind.config = { darkMode: 'media', theme: { extend: { fontFamily: { sans: ['system-ui', '-apple-system', 'sans-serif'], mono: ['ui-monospace', 'monospace'] } } } }
     </script>
     <style>
-        /* Custom Scrollbar */
         ::-webkit-scrollbar { width: 8px; }
-        ::-webkit-scrollbar-track { background: transparent; }
         ::-webkit-scrollbar-thumb { background: #cbd5e1; border-radius: 4px; }
-        @media (prefers-color-scheme: dark) {
-            ::-webkit-scrollbar-thumb { background: #475569; }
-        }
+        @media (prefers-color-scheme: dark) { ::-webkit-scrollbar-thumb { background: #475569; } }
     </style>
 </head>
 <body class="min-h-screen bg-slate-50 dark:bg-slate-950 text-slate-900 dark:text-slate-100 transition-colors duration-200">
     <div class="max-w-5xl mx-auto px-4 py-12 sm:px-6 lg:px-8">
-
-        <!-- Header Section -->
         <div class="mb-10 text-center sm:text-left flex flex-col sm:flex-row sm:items-end justify-between gap-4 border-b border-slate-200 dark:border-slate-800 pb-6">
             <div>
                 <h1 class="text-3xl font-extrabold tracking-tight sm:text-4xl mb-2 flex items-center justify-center sm:justify-start gap-3">
-                    <svg class="w-8 h-8 text-blue-500" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/></svg>
+                    <svg class="w-8 h-8 text-blue-500" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/></svg>
                     Preview Environments
                 </h1>
-                <p class="text-slate-500 dark:text-slate-400 text-lg max-w-2xl">
-                    Live index of all deployed feature branches and active pull requests.
-                </p>
+                <p class="text-slate-500 dark:text-slate-400 text-lg max-w-2xl">Live index of all deployed feature branches and active pull requests.</p>
             </div>
-            <a href="../" class="inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 border border-slate-300 bg-white hover:bg-slate-100 dark:border-slate-700 dark:bg-slate-900 dark:hover:bg-slate-800 h-10 px-4 py-2 shrink-0 shadow-sm">
-                &larr; Back to Main Site
-            </a>
+            <a href="../" class="inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors border border-slate-300 bg-white hover:bg-slate-100 dark:border-slate-700 dark:bg-slate-900 dark:hover:bg-slate-800 h-10 px-4 py-2 shadow-sm">&larr; Back to Main Site</a>
         </div>
-
-        <!-- Alert/Error Box -->
         <div id="error-alert" class="hidden mb-8 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 text-red-800 dark:text-red-400 px-4 py-4 rounded-lg shadow-sm" role="alert">
             <div class="flex items-center gap-3">
                 <svg class="w-5 h-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
                 <span id="error-msg" class="font-medium"></span>
             </div>
         </div>
-
-        <!-- Loading State -->
         <div id="loading" class="flex flex-col items-center justify-center py-20 gap-4">
-            <svg class="animate-spin h-10 w-10 text-blue-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-            </svg>
+            <svg class="animate-spin h-10 w-10 text-blue-500" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path></svg>
             <span class="text-lg text-slate-500 dark:text-slate-400 font-medium animate-pulse">Scanning gh-pages deployments...</span>
         </div>
-
-        <!-- Previews Grid -->
-        <div id="grid" class="grid gap-4 flex-col">
-            <!-- Cards injected via JS -->
-        </div>
-
+        <div id="grid" class="grid gap-4 flex-col"></div>
     </div>
-
     <script>
-        // Auto-detect the repository context from the URL if deployed to GitHub Pages
-        const hostname = window.location.hostname;
-        const pathname = window.location.pathname;
-
-        let REPO_OWNER = 'arii';
-        let REPO_NAME = 'tech-dancer';
-
-        if (hostname.endsWith('.github.io')) {
-            REPO_OWNER = hostname.replace('.github.io', '');
-            const pathParts = pathname.split('/').filter(Boolean);
-            if (pathParts.length > 0) {
-                REPO_NAME = pathParts[0];
-            }
-        }
-
+        const REPO_OWNER = 'arii', REPO_NAME = 'tech-dancer';
         const BASE_URL = `https://${REPO_OWNER}.github.io/${REPO_NAME}`;
-
-        // Standard directories deployed by Vite/React that are NOT branch previews
         const EXCLUDED_FOLDERS = ['assets', 'previews', 'css', 'js', 'img', 'images', 'public'];
-
         const ICONS = {
-            pr: `<svg class="w-5 h-5 shrink-0" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24"><circle cx="18" cy="18" r="3"/><circle cx="6" cy="6" r="3"/><path d="M13 6h3a2 2 0 0 1 2 2v7"/><line x1="6" x2="6" y1="9" y2="21"/></svg>`,
-            branch: `<svg class="w-5 h-5 shrink-0" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24"><line x1="6" x2="6" y1="3" y2="15"/><circle cx="18" cy="6" r="3"/><circle cx="6" cy="18" r="3"/><path d="M18 9a9 9 0 0 1-9 9"/></svg>`,
-            external: `<svg class="w-4 h-4 shrink-0" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" x2="21" y1="14" y2="3"/></svg>`
+            pr: `<svg class="w-5 h-5 shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><circle cx="18" cy="18" r="3"/><circle cx="6" cy="6" r="3"/><path d="M13 6h3a2 2 0 0 1 2 2v7"/><line x1="6" x2="6" y1="9" y2="21"/></svg>`,
+            branch: `<svg class="w-5 h-5 shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><line x1="6" x2="6" y1="3" y2="15"/><circle cx="18" cy="6" r="3"/><circle cx="6" cy="18" r="3"/><path d="M18 9a9 9 0 0 1-9 9"/></svg>`,
+            external: `<svg class="w-4 h-4 shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" x2="21" y1="14" y2="3"/></svg>`
         };
-
+        const escapeHtml = (u) => u.replace(/[&<>"']/g, m => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":"&#039;"}[m]));
         async function init() {
-            const grid = document.getElementById('grid');
-            const loading = document.getElementById('loading');
-            const errorAlert = document.getElementById('error-alert');
-            const errorMsg = document.getElementById('error-msg');
-
+            const grid = document.getElementById('grid'), loading = document.getElementById('loading'), errorAlert = document.getElementById('error-alert');
             try {
-                // 1. Fetch exactly what is currently deployed in the gh-pages branch
-                const contentsRes = await fetch(`https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/contents?ref=gh-pages`);
-
-                if (contentsRes.status === 403 || contentsRes.status === 429) {
-                    throw new Error(`GitHub API rate limit exceeded. Please try again later.`);
-                }
-                if (!contentsRes.ok) {
-                    throw new Error(`GitHub API Error: ${contentsRes.status} ${contentsRes.statusText}`);
-                }
-
-                const contents = await contentsRes.json();
-
-                // Extract only directories that aren't system/build folders
-                const branchFolders = contents.filter(item =>
-                    item.type === 'dir' &&
-                    !item.name.startsWith('.') &&
-                    !EXCLUDED_FOLDERS.includes(item.name)
-                );
-
-                // 2. Fetch open PRs to enrich the folders with contextual titles
-                let prs = [];
-                try {
-                    const prsRes = await fetch(`https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/pulls?state=open`);
-                    if (prsRes.ok) {
-                        prs = await prsRes.json();
-                    }
-                } catch (e) {
-                    console.warn("Could not fetch open PRs for enrichment", e);
-                }
-
+                const [contents, prs] = await Promise.all([
+                    fetch(`https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/contents?ref=gh-pages`).then(r => r.ok ? r.json() : Promise.reject(new Error(`API Error: ${r.status}`))),
+                    fetch(`https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/pulls?state=open`).then(r => r.ok ? r.json() : [])
+                ]);
                 loading.style.display = 'none';
-
-                if (branchFolders.length === 0) {
-                    grid.innerHTML = `
-                        <div class="text-center py-16 bg-white dark:bg-slate-900 rounded-xl border border-slate-200 dark:border-slate-800 shadow-sm">
-                            <p class="text-slate-500 dark:text-slate-400 text-lg">No active preview branches found on gh-pages.</p>
-                        </div>
-                    `;
+                const folders = contents.filter(i => i.type === 'dir' && !i.name.startsWith('.') && !EXCLUDED_FOLDERS.includes(i.name))
+                    .sort((a, b) => (prs.find(p => p.head.ref === b.name) ? 1 : 0) - (prs.find(p => p.head.ref === a.name) ? 1 : 0) || a.name.localeCompare(b.name));
+                if (!folders.length) {
+                    grid.innerHTML = `<div class="text-center py-16 bg-white dark:bg-slate-900 rounded-xl border border-slate-200 dark:border-slate-800 shadow-sm"><p class="text-slate-500 dark:text-slate-400 text-lg">No active preview branches found.</p></div>`;
                     return;
                 }
-
-                // Sort: Folders linked to open PRs show up first
-                branchFolders.sort((a, b) => {
-                    const prA = prs.find(p => p.head.ref === a.name);
-                    const prB = prs.find(p => p.head.ref === b.name);
-                    if (prA && !prB) return -1;
-                    if (!prA && prB) return 1;
-                    return a.name.localeCompare(b.name);
-                });
-
-                branchFolders.forEach(folder => {
-                    const pr = prs.find(p => p.head.ref === folder.name);
-                    const url = `${BASE_URL}/${folder.name}/`;
-
+                folders.forEach(folder => {
+                    const pr = prs.find(p => p.head.ref === folder.name), url = `${BASE_URL}/${folder.name}/`;
                     const card = document.createElement('div');
-                    card.className = 'bg-white dark:bg-slate-900 rounded-xl border border-slate-200 dark:border-slate-800 p-5 sm:p-6 shadow-sm hover:shadow-md transition-all duration-200 flex flex-col sm:flex-row justify-between items-start sm:items-center gap-5 hover:border-blue-300 dark:hover:border-blue-700';
-
-                    let titleHtml = '';
-                    let badgeHtml = '';
-
-                    if (pr) {
-                        titleHtml = `
-                            <a href="${pr.html_url}" target="_blank" rel="noopener noreferrer" class="text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 hover:underline font-semibold text-lg sm:text-xl flex items-center gap-2 group transition-colors line-clamp-1">
-                                ${ICONS.pr}
-                                <span class="truncate">PR #${pr.number}: ${escapeHtml(pr.title)}</span>
-                            </a>`;
-                        badgeHtml = `<span class="bg-blue-50 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400 text-xs font-semibold px-2.5 py-1 rounded-full whitespace-nowrap border border-blue-200 dark:border-blue-800">Open PR</span>`;
-                    } else {
-                        titleHtml = `
-                            <div class="text-slate-800 dark:text-slate-200 font-semibold text-lg sm:text-xl flex items-center gap-2">
-                                ${ICONS.branch}
-                                <span>Deployed Branch</span>
-                            </div>`;
-                        badgeHtml = `<span class="bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-400 text-xs font-semibold px-2.5 py-1 rounded-full whitespace-nowrap border border-slate-200 dark:border-slate-700">Inactive / Merged</span>`;
-                    }
-
+                    card.className = 'bg-white dark:bg-slate-900 rounded-xl border border-slate-200 dark:border-slate-800 p-5 sm:p-6 shadow-sm hover:shadow-md transition-all flex flex-col sm:flex-row justify-between items-start sm:items-center gap-5 hover:border-blue-300 dark:hover:border-blue-700';
+                    const badge = pr
+                        ? `<span class="bg-blue-50 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400 text-xs font-semibold px-2.5 py-1 rounded-full border border-blue-200 dark:border-blue-800">Open PR</span>`
+                        : `<span class="bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-400 text-xs font-semibold px-2.5 py-1 rounded-full border border-slate-200 dark:border-slate-700">Inactive / Merged</span>`;
                     card.innerHTML = `
                         <div class="flex-1 min-w-0 w-full">
                             <div class="flex flex-col sm:flex-row sm:items-center gap-3 mb-3">
-                                ${titleHtml}
-                                <div class="hidden sm:block">${badgeHtml}</div>
+                                ${pr ? `<a href="${pr.html_url}" target="_blank" rel="noopener" class="text-blue-600 dark:text-blue-400 hover:underline font-semibold text-lg sm:text-xl flex items-center gap-2 truncate">${ICONS.pr} PR #${pr.number}: ${escapeHtml(pr.title)}</a>` : `<div class="text-slate-800 dark:text-slate-200 font-semibold text-lg sm:text-xl flex items-center gap-2">${ICONS.branch} Deployed Branch</div>`}
+                                <div class="hidden sm:block">${badge}</div>
                             </div>
-                            <div class="flex items-center gap-2">
-                                <span class="text-sm bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-400 font-mono px-2 py-1 rounded border border-slate-200 dark:border-slate-700 truncate max-w-full inline-block">
-                                    ${escapeHtml(folder.name)}
-                                </span>
-                                <div class="sm:hidden">${badgeHtml}</div>
-                            </div>
+                            <div class="flex items-center gap-2"><span class="text-sm bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-400 font-mono px-2 py-1 rounded border border-slate-200 dark:border-slate-700 truncate">${escapeHtml(folder.name)}</span><div class="sm:hidden">${badge}</div></div>
                         </div>
-
-                        <a href="${url}" target="_blank" rel="noopener noreferrer" class="shrink-0 w-full sm:w-auto bg-slate-900 hover:bg-slate-800 dark:bg-blue-600 dark:hover:bg-blue-500 text-white font-medium py-2.5 px-5 rounded-lg transition-colors flex items-center justify-center gap-2 shadow-sm outline-none focus:ring-2 focus:ring-offset-2 focus:ring-slate-900 dark:focus:ring-blue-600 dark:focus:ring-offset-slate-900">
-                            View Deployment
-                            ${ICONS.external}
-                        </a>
-                    `;
-
+                        <a href="${url}" target="_blank" rel="noopener" class="w-full sm:w-auto bg-slate-900 dark:bg-blue-600 text-white font-medium py-2.5 px-5 rounded-lg flex items-center justify-center gap-2 shadow-sm">View Deployment ${ICONS.external}</a>`;
                     grid.appendChild(card);
                 });
-
             } catch (err) {
                 loading.style.display = 'none';
-                errorMsg.textContent = err.message;
+                document.getElementById('error-msg').textContent = err.message;
                 errorAlert.classList.remove('hidden');
             }
         }
-
-        function escapeHtml(unsafe) {
-            return unsafe
-                 .replace(/&/g, "&amp;")
-                 .replace(/</g, "&lt;")
-                 .replace(/>/g, "&gt;")
-                 .replace(/"/g, "&quot;")
-                 .replace(/'/g, "&#039;");
-        }
-
         init();
     </script>
 </body>


### PR DESCRIPTION
This PR implements a robust system for managing and indexing branch preview deployments on GitHub Pages.

Key changes:
1.  **Preview Dashboard:** A new standalone dashboard at `/previews/index.html` that dynamically queries the GitHub API to list all active branch deployments and enrich them with open PR data. This eliminates the need for complex static HTML generation in CI.
2.  **Deployment Integration:** The `deploy.yml` workflow now ensures the latest version of the dashboard is always available on the `gh-pages` branch.
3.  **Enhanced Cleanup:** The `cleanup-preview.yml` workflow is updated for better reliability when removing branch folders upon branch deletion.
4.  **Scheduled Pruning:** A new daily workflow `prune-stale-previews.yml` automatically cleans up "orphaned" folders from the `gh-pages` branch if a branch was deleted without triggering the cleanup hook (e.g., deleted via API or from another machine).

These changes ensure that the list of active previews is always accurate and that the `gh-pages` branch remains clean and manageable.

Fixes #226

---
*PR created automatically by Jules for task [2762231969457972883](https://jules.google.com/task/2762231969457972883) started by @arii*