### PR TITLE
Remove link to non-existent resources page

### DIFF
--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -16,7 +16,6 @@ export const routes: RouteConfig[] = [
   { path: '/blog', label: 'Blog Posts', icon: BookOpen },
   { path: '/gear', label: 'Gear Reviews', icon: ShoppingBag },
   { path: '/research', label: 'Data & Development Lab', icon: Database },
-  { path: '/resources', label: 'Resources', icon: BookOpen },
   { path: '/about', label: 'About', icon: User },
   { path: '/contact', label: 'Contact', icon: Send },
 ];

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -30,7 +30,6 @@ export default defineConfig(({mode}) => {
     '/blog',
     '/gear',
     '/research',
-    '/resources',
     '/about',
     '/contact',
     ...getContentSlugs('content/posts', '/blog'),


### PR DESCRIPTION
Removed the link to the non-existent 'Resources' page from the sidebar navigation and build configuration. The content in `content/resources` remains as it is used by the Gear Reviews section.

Fixes #244

---
*PR created automatically by Jules for task [16688759522163415446](https://jules.google.com/task/16688759522163415446) started by @arii*