### PR TITLE
Update dev-tools with CI checks and re-review tracking

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -94,9 +94,15 @@ jobs:
             find . -maxdepth 3 -name "index.html" | while read -r index_file; do
               DIR=$(dirname "$index_file" | sed 's|^\./||')
               [[ "$DIR" =~ ^(\.|\.\.|assets|tmp|previews)$ ]] && continue
-              TS=$(cat "$DIR/.timestamp" 2>/dev/null || git log -1 --format=%ct -- "$DIR" || date +%s)
+              TS=$(cat "$DIR/.timestamp" 2>/dev/null)
+              if [ -z "$TS" ]; then
+                TS=$(git log -1 --format=%ct -- "$DIR" 2>/dev/null)
+              fi
+              if [ -z "$TS" ]; then
+                TS=$(date +%s)
+              fi
               echo "$DIR $TS"
-            done | jq -R -n '[inputs | split(" ") | {(.[0]): (.[1] | tonumber)}] | add // {}' > previews/data.json
+            done | jq -R -n '[inputs | select(length > 0) | split(" ") | select(length == 2 and .[1] != "") | {(.[0]): (.[1] | tonumber)}] | add // {}' > previews/data.json
 
             # Use the latest dashboard UI
             cp "$DEST_DIR/previews/index.html" previews/index.html

--- a/dev-tools/fetch_pr_review_data.py
+++ b/dev-tools/fetch_pr_review_data.py
@@ -29,9 +29,73 @@ def main():
 
     g = Github(token)
     try:
+<<<<<<< HEAD
         repo = g.get_repo(repo_name)
         pr = repo.get_pull(pr_num)
     except GithubException as e:
+=======
+        pr_url = f"https://api.github.com/repos/{repo}/pulls/{pr_num}"
+        pr_resp = requests.get(pr_url, headers=headers)
+        pr_resp.raise_for_status()
+        pr_data = pr_resp.json()
+
+        # If base_override is provided, we use 'gh pr diff' to get the custom patch
+        # otherwise we use the standard file list from the API
+        files_url = f"{pr_url}/files"
+        files_resp = requests.get(files_url, headers=headers).json()
+
+        # Fetch last commit time and SHA
+        commits_url = f"{pr_url}/commits"
+        commits_resp = requests.get(commits_url, headers=headers).json()
+        last_commit_time = "Unknown"
+        head_sha = None
+        if commits_resp and len(commits_resp) > 0:
+            last_commit = commits_resp[-1]
+            last_commit_time = last_commit.get('commit', {}).get('author', {}).get('date', 'Unknown')
+            head_sha = last_commit.get('sha')
+
+        # ── Fetch CI Status ───────────────────────────────────────────────────
+        ci_summary = "Unknown"
+        if head_sha:
+            try:
+                # 1. Check Runs (GitHub Actions etc.)
+                checks_url = f"https://api.github.com/repos/{repo}/commits/{head_sha}/check-runs"
+                checks_resp = requests.get(checks_url, headers=headers).json()
+
+                # 2. Combined Status (Legacy CI systems)
+                status_url = f"https://api.github.com/repos/{repo}/commits/{head_sha}/status"
+                status_resp = requests.get(status_url, headers=headers).json()
+
+                failed_runs = []
+                in_progress = 0
+
+                if 'check_runs' in checks_resp:
+                    for run in checks_resp['check_runs']:
+                        if run.get('conclusion') == 'failure':
+                            failed_runs.append(run.get('name'))
+                        elif run.get('status') in ['in_progress', 'queued']:
+                            in_progress += 1
+
+                if status_resp.get('state') == 'failure':
+                    for s in status_resp.get('statuses', []):
+                        if s.get('state') == 'failure':
+                            failed_runs.append(s.get('context'))
+                elif status_resp.get('state') in ['pending']:
+                    in_progress += 1
+
+                if failed_runs:
+                    ci_summary = f"🔴 FAILURE (Failed: {', '.join(set(failed_runs))})"
+                elif in_progress > 0:
+                    ci_summary = f"🟡 PENDING ({in_progress} runs in progress)"
+                elif (checks_resp.get('total_count', 0) > 0 or status_resp.get('total_count', 0) > 0):
+                    ci_summary = "🟢 SUCCESS (All checks passed)"
+                else:
+                    ci_summary = "⚪ No checks found"
+            except Exception as e:
+                ci_summary = f"⚠️ Error fetching CI: {str(e)}"
+
+    except requests.exceptions.RequestException as e:
+>>>>>>> cf016d3 (feat(dev-tools): add CI check monitoring and commit-aware re-review tracking)
         print(f"❌ Failed to fetch PR data: {e}")
         sys.exit(1)
 

--- a/dev-tools/fetch_pr_review_data.py
+++ b/dev-tools/fetch_pr_review_data.py
@@ -113,37 +113,13 @@ def main():
     context_content = "\n".join(context_lines)
 
     # ── Generate Review Template (Writeable) ──────────────────────────────────
-    review_template = f"""# PR Review: #{pr_num}
-    
-## Context
-- **Last Commit Tracked (SHA):** {head_sha}
-
-## Audit Checklist
-For EVERY changed file, verify against these standards. Mark as `- [x]` when verified.
-- [ ] Dead abstractions: No new class, context, or hook that a simpler primitive handles.
-- [ ] Unnecessary indirection: No layer of wrapping where a direct function call suffices.
-- [ ] Responsibility creep: Component does not take on state/logic belonging in parent/hook.
-- [ ] Import bloat: No unnecessary `import React from 'react'` (React 17+).
-- [ ] Token compliance: Uses established design tokens (no raw Tailwind values or inline styles).
-- [ ] Audit ratio: If > 100 lines added, identified at least 10 lines to refactor/remove.
-
-## Output JSON
-Provide your findings and inline comments in the JSON block below.
-DO NOT REMOVE THE BACKTICKS.
-
-```json
-{{
-  "body": "## ANTI-AI-SLOP\\n<findings>\\n\\n## FINDINGS\\n<summary>\\n\\n## FINAL RECOMMENDATION\\n<Approved | Approved with Minor Changes | Not Approved>",
-  "comments": [
-    {{
-      "path": "<filename>",
-      "line": 1,
-      "body": "<feedback>"
-    }}
-  ]
-}}
-```
-"""
+    template_path = os.path.join(os.path.dirname(__file__), "review_template.md")
+    if os.path.exists(template_path):
+        with open(template_path, "r") as f:
+            review_template = f.read().format(pr_num=pr_num, head_sha=head_sha)
+    else:
+        # Fallback if template file is missing
+        review_template = f"# PR Review: #{pr_num}\n- SHA: {head_sha}\n"
     repo_root = os.getcwd()
     output_dir = os.path.join(repo_root, "dev-tools", "logs", "reviews")
     os.makedirs(output_dir, exist_ok=True)

--- a/dev-tools/fetch_pr_review_data.py
+++ b/dev-tools/fetch_pr_review_data.py
@@ -12,7 +12,7 @@ import sys
 import re
 import subprocess
 from github import Github, GithubException
-from github_utils import get_github_token, get_repo_name, get_ci_status, get_ci_icon
+from github_utils import get_github_token, get_repo_name, get_ci_status, CIFormatter
 
 def main():
     if len(sys.argv) < 2:
@@ -38,7 +38,7 @@ def main():
     # ── Fetch CI Status ───────────────────────────────────────────────────
     head_sha = pr.head.sha
     ci_summary, _ = get_ci_status(repo, head_sha)
-    ci_display = f"{get_ci_icon(ci_summary)} {ci_summary}"
+    ci_display = CIFormatter.format(ci_summary)
 
     title = pr.title
     description = pr.body or '_No description provided._'

--- a/dev-tools/fetch_pr_review_data.py
+++ b/dev-tools/fetch_pr_review_data.py
@@ -29,73 +29,9 @@ def main():
 
     g = Github(token)
     try:
-<<<<<<< HEAD
         repo = g.get_repo(repo_name)
         pr = repo.get_pull(pr_num)
     except GithubException as e:
-=======
-        pr_url = f"https://api.github.com/repos/{repo}/pulls/{pr_num}"
-        pr_resp = requests.get(pr_url, headers=headers)
-        pr_resp.raise_for_status()
-        pr_data = pr_resp.json()
-
-        # If base_override is provided, we use 'gh pr diff' to get the custom patch
-        # otherwise we use the standard file list from the API
-        files_url = f"{pr_url}/files"
-        files_resp = requests.get(files_url, headers=headers).json()
-
-        # Fetch last commit time and SHA
-        commits_url = f"{pr_url}/commits"
-        commits_resp = requests.get(commits_url, headers=headers).json()
-        last_commit_time = "Unknown"
-        head_sha = None
-        if commits_resp and len(commits_resp) > 0:
-            last_commit = commits_resp[-1]
-            last_commit_time = last_commit.get('commit', {}).get('author', {}).get('date', 'Unknown')
-            head_sha = last_commit.get('sha')
-
-        # ── Fetch CI Status ───────────────────────────────────────────────────
-        ci_summary = "Unknown"
-        if head_sha:
-            try:
-                # 1. Check Runs (GitHub Actions etc.)
-                checks_url = f"https://api.github.com/repos/{repo}/commits/{head_sha}/check-runs"
-                checks_resp = requests.get(checks_url, headers=headers).json()
-
-                # 2. Combined Status (Legacy CI systems)
-                status_url = f"https://api.github.com/repos/{repo}/commits/{head_sha}/status"
-                status_resp = requests.get(status_url, headers=headers).json()
-
-                failed_runs = []
-                in_progress = 0
-
-                if 'check_runs' in checks_resp:
-                    for run in checks_resp['check_runs']:
-                        if run.get('conclusion') == 'failure':
-                            failed_runs.append(run.get('name'))
-                        elif run.get('status') in ['in_progress', 'queued']:
-                            in_progress += 1
-
-                if status_resp.get('state') == 'failure':
-                    for s in status_resp.get('statuses', []):
-                        if s.get('state') == 'failure':
-                            failed_runs.append(s.get('context'))
-                elif status_resp.get('state') in ['pending']:
-                    in_progress += 1
-
-                if failed_runs:
-                    ci_summary = f"🔴 FAILURE (Failed: {', '.join(set(failed_runs))})"
-                elif in_progress > 0:
-                    ci_summary = f"🟡 PENDING ({in_progress} runs in progress)"
-                elif (checks_resp.get('total_count', 0) > 0 or status_resp.get('total_count', 0) > 0):
-                    ci_summary = "🟢 SUCCESS (All checks passed)"
-                else:
-                    ci_summary = "⚪ No checks found"
-            except Exception as e:
-                ci_summary = f"⚠️ Error fetching CI: {str(e)}"
-
-    except requests.exceptions.RequestException as e:
->>>>>>> cf016d3 (feat(dev-tools): add CI check monitoring and commit-aware re-review tracking)
         print(f"❌ Failed to fetch PR data: {e}")
         sys.exit(1)
 
@@ -177,13 +113,37 @@ def main():
     context_content = "\n".join(context_lines)
 
     # ── Generate Review Template (Writeable) ──────────────────────────────────
-    template_path = os.path.join(os.path.dirname(__file__), "review_template.md")
-    if os.path.exists(template_path):
-        with open(template_path, "r") as f:
-            review_template = f.read().format(pr_num=pr_num, head_sha=head_sha)
-    else:
-        # Fallback if template file is missing
-        review_template = f"# PR Review: #{pr_num}\n- SHA: {head_sha}\n"
+    review_template = f"""# PR Review: #{pr_num}
+    
+## Context
+- **Last Commit Tracked (SHA):** {head_sha}
+
+## Audit Checklist
+For EVERY changed file, verify against these standards. Mark as `- [x]` when verified.
+- [ ] Dead abstractions: No new class, context, or hook that a simpler primitive handles.
+- [ ] Unnecessary indirection: No layer of wrapping where a direct function call suffices.
+- [ ] Responsibility creep: Component does not take on state/logic belonging in parent/hook.
+- [ ] Import bloat: No unnecessary `import React from 'react'` (React 17+).
+- [ ] Token compliance: Uses established design tokens (no raw Tailwind values or inline styles).
+- [ ] Audit ratio: If > 100 lines added, identified at least 10 lines to refactor/remove.
+
+## Output JSON
+Provide your findings and inline comments in the JSON block below.
+DO NOT REMOVE THE BACKTICKS.
+
+```json
+{{
+  "body": "## ANTI-AI-SLOP\\n<findings>\\n\\n## FINDINGS\\n<summary>\\n\\n## FINAL RECOMMENDATION\\n<Approved | Approved with Minor Changes | Not Approved>",
+  "comments": [
+    {{
+      "path": "<filename>",
+      "line": 1,
+      "body": "<feedback>"
+    }}
+  ]
+}}
+```
+"""
     repo_root = os.getcwd()
     output_dir = os.path.join(repo_root, "dev-tools", "logs", "reviews")
     os.makedirs(output_dir, exist_ok=True)

--- a/dev-tools/github_utils.py
+++ b/dev-tools/github_utils.py
@@ -83,9 +83,23 @@ def get_ci_status(repo: Repository, sha: str) -> Tuple[str, List[str]]:
     except Exception as e:
         return f"Error fetching CI: {str(e)}", []
 
+class CIFormatter:
+    """Encapsulates CI status icon mapping and string formatting."""
+
+    @staticmethod
+    def get_icon(summary: str) -> str:
+        """Returns a visual icon for the CI status summary."""
+        if "FAILURE" in summary: return "🔴"
+        if "PENDING" in summary: return "🟡"
+        if "SUCCESS" in summary: return "🟢"
+        return "⚪"
+
+    @classmethod
+    def format(cls, summary: str) -> str:
+        """Returns a standardized string format for CI status."""
+        icon = cls.get_icon(summary)
+        return f"{icon} {summary}"
+
 def get_ci_icon(summary: str) -> str:
-    """Returns a visual icon for the CI status summary."""
-    if "FAILURE" in summary: return "🔴"
-    if "PENDING" in summary: return "🟡"
-    if "SUCCESS" in summary: return "🟢"
-    return "⚪"
+    """Legacy wrapper for get_ci_icon."""
+    return CIFormatter.get_icon(summary)

--- a/dev-tools/github_utils.py
+++ b/dev-tools/github_utils.py
@@ -16,8 +16,6 @@ def get_github_token() -> Optional[str]:
     if token:
         return token
     try:
-        # Try to get the token from the gh cli if it is installed
-        # We avoid 'env -u' to maintain cross-platform compatibility
         result = subprocess.run(
             ["gh", "auth", "token"],
             capture_output=True,
@@ -68,38 +66,30 @@ def get_ci_status(repo: Repository, sha: str) -> Tuple[str, List[str]]:
                     failed_runs.append(s.context)
 
         if failed_runs or combined_status.state in ['failure', 'error']:
-            summary = "FAILURE"
-            if failed_runs:
-                summary += f" | FAILED: {', '.join(set(failed_runs))}"
-            else:
-                summary += f" | {combined_status.state.upper()}"
+            summary = "FAILURE | FAILED: " + ", ".join(set(failed_runs)) if failed_runs else f"FAILURE | {combined_status.state.upper()}"
             return summary, list(set(failed_runs))
-        elif in_progress > 0 or combined_status.state == 'pending':
+
+        if in_progress > 0 or combined_status.state == 'pending':
             return f"PENDING | {in_progress} runs in progress", []
-        elif total_checks > 0:
+
+        if total_checks > 0:
             return "SUCCESS | All checks passed", []
-        else:
-            return "No checks found", []
+
+        return "No checks found", []
     except Exception as e:
         return f"Error fetching CI: {str(e)}", []
 
 class CIFormatter:
     """Encapsulates CI status icon mapping and string formatting."""
 
-    @staticmethod
-    def get_icon(summary: str) -> str:
-        """Returns a visual icon for the CI status summary."""
-        if "FAILURE" in summary: return "🔴"
-        if "PENDING" in summary: return "🟡"
-        if "SUCCESS" in summary: return "🟢"
-        return "⚪"
+    ICON_MAP = {
+        "FAILURE": "🔴",
+        "PENDING": "🟡",
+        "SUCCESS": "🟢"
+    }
 
     @classmethod
     def format(cls, summary: str) -> str:
         """Returns a standardized string format for CI status."""
-        icon = cls.get_icon(summary)
+        icon = next((icon for key, icon in cls.ICON_MAP.items() if key in summary), "⚪")
         return f"{icon} {summary}"
-
-def get_ci_icon(summary: str) -> str:
-    """Legacy wrapper for get_ci_icon."""
-    return CIFormatter.get_icon(summary)

--- a/dev-tools/github_utils.py
+++ b/dev-tools/github_utils.py
@@ -2,7 +2,7 @@ import os
 import re
 import subprocess
 import sys
-from typing import Optional, Tuple, List
+from typing import Optional, Tuple, List, Dict
 try:
     from github import Github, GithubException
     from github.Repository import Repository
@@ -82,7 +82,7 @@ def get_ci_status(repo: Repository, sha: str) -> Tuple[str, List[str]]:
 class CIFormatter:
     """Encapsulates CI status icon mapping and string formatting."""
 
-    ICON_MAP = {
+    ICON_MAP: Dict[str, str] = {
         "FAILURE": "🔴",
         "PENDING": "🟡",
         "SUCCESS": "🟢"

--- a/dev-tools/github_utils.py
+++ b/dev-tools/github_utils.py
@@ -4,23 +4,29 @@ import subprocess
 import sys
 from typing import Optional, Tuple, List
 try:
-    from github import Github, GithubException, Repository
+    from github import Github, GithubException
+    from github.Repository import Repository
 except ImportError:
     print("Error: PyGithub not installed. Run 'pip install PyGithub'")
     sys.exit(1)
 
 def get_github_token() -> Optional[str]:
-    """Retrieves the GitHub token via gh CLI, falls back to env var."""
+    """Retrieves the GitHub token from environment or via gh CLI."""
+    token = os.getenv("GITHUB_TOKEN")
+    if token:
+        return token
     try:
-        out = subprocess.check_output(
-            ['env', '-u', 'GITHUB_TOKEN', 'gh', 'auth', 'token'],
-            stderr=subprocess.DEVNULL, text=True
-        ).strip()
-        if out:
-            return out
-    except Exception:
-        pass
-    return os.getenv("GITHUB_TOKEN")
+        # Try to get the token from the gh cli if it is installed
+        # We avoid 'env -u' to maintain cross-platform compatibility
+        result = subprocess.run(
+            ["gh", "auth", "token"],
+            capture_output=True,
+            text=True,
+            check=True
+        )
+        return result.stdout.strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
 
 def get_repo_name() -> Optional[str]:
     """Auto-detect repo from git remote."""
@@ -34,7 +40,7 @@ def get_repo_name() -> Optional[str]:
     except Exception:
         return os.getenv("GH_REPO")
 
-def get_ci_status(repo, sha: str) -> Tuple[str, List[str]]:
+def get_ci_status(repo: Repository, sha: str) -> Tuple[str, List[str]]:
     """
     Aggregates CI status from Check Runs and Combined Status API for a given SHA.
     Returns (status_summary, failed_runs_list).
@@ -61,8 +67,13 @@ def get_ci_status(repo, sha: str) -> Tuple[str, List[str]]:
                 if s.state in ['failure', 'error']:
                     failed_runs.append(s.context)
 
-        if failed_runs:
-            return f"FAILURE | FAILED: {', '.join(set(failed_runs))}", list(set(failed_runs))
+        if failed_runs or combined_status.state in ['failure', 'error']:
+            summary = "FAILURE"
+            if failed_runs:
+                summary += f" | FAILED: {', '.join(set(failed_runs))}"
+            else:
+                summary += f" | {combined_status.state.upper()}"
+            return summary, list(set(failed_runs))
         elif in_progress > 0 or combined_status.state == 'pending':
             return f"PENDING | {in_progress} runs in progress", []
         elif total_checks > 0:

--- a/dev-tools/github_utils.py
+++ b/dev-tools/github_utils.py
@@ -50,10 +50,10 @@ def get_ci_status(repo, sha: str) -> Tuple[str, List[str]]:
 
         for run in check_runs:
             total_checks += 1
-            if run.conclusion in ['failure', 'error', 'timed_out', 'action_required']:
-                failed_runs.append(run.name)
-            elif run.status in ['in_progress', 'queued']:
+            if run.status in ['in_progress', 'queued']:
                 in_progress += 1
+            elif run.conclusion not in ['success', 'skipped', 'neutral']:
+                failed_runs.append(f"{run.name} ({run.conclusion or 'no conclusion'})")
 
         total_checks += combined_status.total_count
         if combined_status.state in ['failure', 'error']:

--- a/dev-tools/pr_review_manager.py
+++ b/dev-tools/pr_review_manager.py
@@ -45,16 +45,16 @@ def process_pull_requests(token: str, repo_name: str, dry_run: bool, cleanup_com
         pr_title = pr.title
         latest_commit_sha = pr.head.sha
 
-        # 1. Comment Cleanup
+        # 1. Comment Cleanup - Only delete comments with the tool's marker
         if cleanup_comments:
             comments = pr.get_issue_comments()
             for comment in comments:
-                if comment.user.login == current_user_login:
+                if comment.user.login == current_user_login and "<!-- td-review-manager-comment -->" in comment.body:
                     if dry_run:
-                        logger.info(f"[DRY-RUN] Would delete comment {comment.id} on PR #{pr_number}")
+                        logger.info(f"[DRY-RUN] Would delete tool comment {comment.id} on PR #{pr_number}")
                     else:
                         comment.delete()
-                        logger.warning(f"Deleted comment {comment.id} on PR #{pr_number}")
+                        logger.warning(f"Deleted tool comment {comment.id} on PR #{pr_number}")
 
         # 2. Review State Analysis
         # Fetch reviews and find the most recent one from the current user

--- a/dev-tools/pr_review_manager.py
+++ b/dev-tools/pr_review_manager.py
@@ -10,7 +10,7 @@ import argparse
 import logging
 import sys
 from github import Github, GithubException
-from github_utils import get_github_token, get_repo_name, get_ci_status
+from github_utils import get_github_token, get_repo_name, get_ci_status, get_ci_icon
 
 # Setup Logging
 logging.basicConfig(
@@ -73,10 +73,11 @@ def process_pull_requests(token: str, repo_name: str, dry_run: bool, cleanup_com
 
         # 3. CI Check Outcomes
         ci_summary, _ = get_ci_status(repo, latest_commit_sha)
+        ci_icon = get_ci_icon(ci_summary)
 
         print(f"[PR #{pr_number}] {pr_title}")
         print(f"  ├── {status}")
-        print(f"  └── CI: {ci_summary}\n")
+        print(f"  └── CI: {ci_icon} {ci_summary}\n")
 
     if not found_any:
         logger.info("No open pull requests found.")

--- a/dev-tools/pr_review_manager.py
+++ b/dev-tools/pr_review_manager.py
@@ -10,7 +10,7 @@ import argparse
 import logging
 import sys
 from github import Github, GithubException
-from github_utils import get_github_token, get_repo_name, get_ci_status, get_ci_icon
+from github_utils import get_github_token, get_repo_name, get_ci_status, CIFormatter
 
 # Setup Logging
 logging.basicConfig(
@@ -73,11 +73,11 @@ def process_pull_requests(token: str, repo_name: str, dry_run: bool, cleanup_com
 
         # 3. CI Check Outcomes
         ci_summary, _ = get_ci_status(repo, latest_commit_sha)
-        ci_icon = get_ci_icon(ci_summary)
+        ci_display = CIFormatter.format(ci_summary)
 
         print(f"[PR #{pr_number}] {pr_title}")
         print(f"  ├── {status}")
-        print(f"  └── CI: {ci_icon} {ci_summary}\n")
+        print(f"  └── CI: {ci_display}\n")
 
     if not found_any:
         logger.info("No open pull requests found.")

--- a/dev-tools/pr_review_manager.py
+++ b/dev-tools/pr_review_manager.py
@@ -2,7 +2,7 @@
 """
 PR Review Manager
 Automatically determines PR review state (Needs Review, Needs Re-Review, Up-to-Date)
-includes CI check outcomes, and cleans up previous bot/user comments on PRs to reduce spam.
+includes CI check outcomes, and cleans up previous tool comments on PRs to reduce spam.
 Uses PyGithub for cross-platform compatibility.
 """
 
@@ -58,8 +58,13 @@ def process_pull_requests(token: str, repo_name: str, dry_run: bool, cleanup_com
 
         # 2. Review State Analysis
         # Fetch reviews and find the most recent one from the current user
+<<<<<<< HEAD
         # Utilizes .reversed property on the paginated list for efficiency
         last_review = next((r for r in pr.get_reviews().reversed if r.user.login == current_user_login), None)
+=======
+        # reversed(pr.get_reviews()) is an efficient way to find the latest review with PyGithub's PaginatedList
+        last_review = next((r for r in reversed(pr.get_reviews()) if r.user.login == current_user_login), None)
+>>>>>>> 2e4fd95 (final refactor of dev-tools with ci health and re-review tracking)
 
         if not last_review:
             status = "ACTION: Needs Initial Review"
@@ -87,12 +92,12 @@ def main():
     parser.add_argument(
         "--execute",
         action="store_true",
-        help="WARNING: Disables dry-run and permanently deletes previous comments."
+        help="WARNING: Disables dry-run and permanently deletes previous tool comments."
     )
     parser.add_argument(
         "--skip-cleanup",
         action="store_true",
-        help="Skip analyzing and deleting old comments entirely."
+        help="Skip analyzing and deleting old tool comments entirely."
     )
     parser.add_argument(
         "--repo",

--- a/dev-tools/pr_review_manager.py
+++ b/dev-tools/pr_review_manager.py
@@ -58,13 +58,8 @@ def process_pull_requests(token: str, repo_name: str, dry_run: bool, cleanup_com
 
         # 2. Review State Analysis
         # Fetch reviews and find the most recent one from the current user
-<<<<<<< HEAD
         # Utilizes .reversed property on the paginated list for efficiency
         last_review = next((r for r in pr.get_reviews().reversed if r.user.login == current_user_login), None)
-=======
-        # reversed(pr.get_reviews()) is an efficient way to find the latest review with PyGithub's PaginatedList
-        last_review = next((r for r in reversed(pr.get_reviews()) if r.user.login == current_user_login), None)
->>>>>>> 2e4fd95 (final refactor of dev-tools with ci health and re-review tracking)
 
         if not last_review:
             status = "ACTION: Needs Initial Review"

--- a/dev-tools/review_template.md
+++ b/dev-tools/review_template.md
@@ -18,7 +18,7 @@ DO NOT REMOVE THE BACKTICKS.
 
 ```json
 {{
-  "body": "## ANTI-AI-SLOP\\n<findings>\\n\\n## FINDINGS\\n<summary>\\n\\n## FINAL RECOMMENDATION\\n<Approved | Approved with Minor Changes | Not Approved>",
+  "body": "## ANTI-AI-SLOP\\n<findings>\\n\\n## FINDINGS\\n<summary>\\n\\n## FINAL RECOMMENDATION\\n<Approved | Approved with Minor Changes | Not Approved>\\n\\n<!-- td-review-manager-comment -->",
   "comments": [
     {{
       "path": "<filename>",


### PR DESCRIPTION
This update expands the `dev-tools` suite with a new `pr_review_manager.py` tool that provides a high-level overview of open PRs, their review status (Needs Review, Needs Re-Review, or Up-to-Date), and their current CI health. It also includes a mechanism to clean up previous review comments to reduce PR noise. Additionally, `fetch_pr_review_data.py` now includes CI status in its generated context files to provide reviewers with immediate visibility into build outcomes.

Fixes #239

---
*PR created automatically by Jules for task [15637729022473842211](https://jules.google.com/task/15637729022473842211) started by @arii*