### PR TITLE
Refactor Data Fetching to TanStack Query

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@fontsource-variable/geist": "^5.2.8",
     "@google/genai": "^1.29.0",
     "@tailwindcss/vite": "^4.2.2",
+    "@tanstack/react-query": "^5.99.2",
     "@vitejs/plugin-react": "^5.0.4",
     "buffer": "^6.0.3",
     "class-variance-authority": "^0.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
+      '@tanstack/react-query':
+        specifier: ^5.99.2
+        version: 5.99.2(react@19.2.5)
       '@vitejs/plugin-react':
         specifier: ^5.0.4
         version: 5.2.0(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
@@ -1446,6 +1449,14 @@ packages:
     resolution: {integrity: sha512-mEiF5HO1QqCLXoNEfXVA1Tzo+cYsrqV7w9Juj2wdUFyW07JRenqMG225MvPwr3ZD9N1bFQj46X7r33iHxLUW0w==}
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
+
+  '@tanstack/query-core@5.99.2':
+    resolution: {integrity: sha512-1HunU0bXVsR1ZJMZbcOPE6VtaBJxsW809RE9xPe4Gz7MlB0GWwQvuTPhMoEmQ/hIzFKJ/DWAuttIe7BOaWx0tA==}
+
+  '@tanstack/react-query@5.99.2':
+    resolution: {integrity: sha512-vM91UEe45QUS9ED6OklsVL15i8qKcRqNwpWzPTVWvRPRSEgDudDgHpvyTjcdlwHcrKNa80T+xXYcchT2noPnZA==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@ts-morph/common@0.27.0':
     resolution: {integrity: sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ==}
@@ -4837,6 +4848,13 @@ snapshots:
       '@tailwindcss/oxide': 4.2.2
       tailwindcss: 4.2.2
       vite: 6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
+
+  '@tanstack/query-core@5.99.2': {}
+
+  '@tanstack/react-query@5.99.2(react@19.2.5)':
+    dependencies:
+      '@tanstack/query-core': 5.99.2
+      react: 19.2.5
 
   '@ts-morph/common@0.27.0':
     dependencies:

--- a/src/features/dashboard/useHome.ts
+++ b/src/features/dashboard/useHome.ts
@@ -1,6 +1,6 @@
 import { useNavigate } from 'react-router-dom';
-import { useState, useEffect } from 'react';
-import { getPosts, Post } from '@/lib/content';
+import { useQuery } from '@tanstack/react-query';
+import { getPosts } from '@/lib/content';
 import { Home as HomeIcon } from 'lucide-react';
 
 export const upcomingEvents = [
@@ -9,12 +9,10 @@ export const upcomingEvents = [
 
 export function useHome() {
   const navigate = useNavigate();
-  const [recentPosts, setRecentPosts] = useState<Post[]>([]);
-
-  useEffect(() => {
-    const allPosts = getPosts();
-    setRecentPosts(allPosts.slice(0, 3));
-  }, []);
+  const { data: recentPosts = [] } = useQuery({
+    queryKey: ['posts', 'recent'],
+    queryFn: () => getPosts().slice(0, 3),
+  });
 
   const dancerPaths = [
     { label: "Lifestyle blog posts", path: "/blog?category=Travel/Lifestyle" },

--- a/src/features/journal/BlogPost.tsx
+++ b/src/features/journal/BlogPost.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
 import { getPostBySlug } from '@/lib/content';
 import { Box, Stack, Text } from '@/layouts/Primitives';
 import { SEO } from '@/components/SEO';
@@ -8,7 +9,11 @@ import { BlogPostDetail } from './components/BlogPostDetail';
 export default function BlogPost() {
   const { slug } = useParams();
   const navigate = useNavigate();
-  const post = useMemo(() => slug ? getPostBySlug(slug) : undefined, [slug]);
+  const { data: post } = useQuery({
+    queryKey: ['posts', slug],
+    queryFn: () => slug ? getPostBySlug(slug) : undefined,
+    enabled: !!slug
+  });
 
   const structuredData = useMemo(() => {
     if (!post) return null;

--- a/src/features/journal/useBlog.ts
+++ b/src/features/journal/useBlog.ts
@@ -1,11 +1,15 @@
 import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { useSearchParam } from '@/hooks/useSearchParam';
 import { getPosts } from '@/lib/content';
 import { safeSearch } from '@/lib/utils';
 import { ViewMode } from '@/components/ui/ViewToggle';
 
 export function useBlog() {
-  const posts = useMemo(() => getPosts(), []);
+  const { data: posts = [] } = useQuery({
+    queryKey: ['posts'],
+    queryFn: getPosts,
+  });
   const [activeCategory] = useSearchParam('category', 'All');
   const [searchTerm, setSearchTerm] = useSearchParam('search');
   const [viewParam, setViewParam] = useSearchParam('view', 'card');

--- a/src/features/lab/GearPost.tsx
+++ b/src/features/lab/GearPost.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
 import { Box, Stack, Text } from '@/layouts/Primitives';
 import { getResourceBySlug } from '@/lib/content';
 import { SEO } from '@/components/SEO';
@@ -8,7 +9,11 @@ import { GearPostDetail } from './components/GearPostDetail';
 export default function GearPost() {
   const { slug } = useParams();
   const navigate = useNavigate();
-  const resource = useMemo(() => slug ? getResourceBySlug(slug) : undefined, [slug]);
+  const { data: resource } = useQuery({
+    queryKey: ['resources', slug],
+    queryFn: () => slug ? getResourceBySlug(slug) : undefined,
+    enabled: !!slug
+  });
 
   const structuredData = useMemo(() => {
     if (!resource) return null;

--- a/src/features/lab/useToolbox.ts
+++ b/src/features/lab/useToolbox.ts
@@ -1,11 +1,15 @@
 import { getResources } from '@/lib/content';
 import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { useSearchParam } from '@/hooks/useSearchParam';
 import { safeSearch } from '@/lib/utils';
 import { ViewMode } from '@/components/ui/ViewToggle';
 
 export function useToolbox() {
-  const resources = getResources();
+  const { data: resources = [] } = useQuery({
+    queryKey: ['resources'],
+    queryFn: getResources,
+  });
   const [searchTerm, setSearchTerm] = useSearchParam('search');
   const [viewParam, setViewParam] = useSearchParam('view', 'card');
 

--- a/src/features/profile/useProfile.ts
+++ b/src/features/profile/useProfile.ts
@@ -1,4 +1,3 @@
-import { useQuery } from '@tanstack/react-query';
 import { ProfileData } from './types';
 
 const PROFILE_DATA: ProfileData = {
@@ -39,10 +38,5 @@ const PROFILE_DATA: ProfileData = {
 };
 
 export function useProfile(): { bio: ProfileData } {
-  const { data: bio = PROFILE_DATA } = useQuery({
-    queryKey: ['profile'],
-    queryFn: async () => PROFILE_DATA,
-  });
-
-  return { bio };
+  return { bio: PROFILE_DATA };
 }

--- a/src/features/profile/useProfile.ts
+++ b/src/features/profile/useProfile.ts
@@ -1,7 +1,7 @@
+import { useQuery } from '@tanstack/react-query';
 import { ProfileData } from './types';
 
-export function useProfile(): { bio: ProfileData } {
-  const bio: ProfileData = {
+const PROFILE_DATA: ProfileData = {
     name: "Ariel Anders, PhD",
     role: "MIT Roboticist // WCS Tech-Dancer",
     sections: [
@@ -36,7 +36,13 @@ export function useProfile(): { bio: ProfileData } {
       { platform: 'linkedin', url: 'https://linkedin.com' },
       { platform: 'github', url: 'https://github.com' },
     ]
-  };
+};
+
+export function useProfile(): { bio: ProfileData } {
+  const { data: bio = PROFILE_DATA } = useQuery({
+    queryKey: ['profile'],
+    queryFn: async () => PROFILE_DATA,
+  });
 
   return { bio };
 }

--- a/src/features/research/useResearch.ts
+++ b/src/features/research/useResearch.ts
@@ -1,8 +1,12 @@
 import { useState } from 'react';
-import { getStudies, Study } from '@/lib/content';
+import { useQuery } from '@tanstack/react-query';
+import { getStudies } from '@/lib/content';
 
 export function useResearch() {
-  const [studies] = useState<Study[]>(() => getStudies());
+  const { data: studies = [] } = useQuery({
+    queryKey: ['studies'],
+    queryFn: getStudies,
+  });
   const [selectedTool, setSelectedTool] = useState<string | null>(null);
 
   const tools = [

--- a/src/features/ux-auditor/useUXAuditor.ts
+++ b/src/features/ux-auditor/useUXAuditor.ts
@@ -1,7 +1,8 @@
 import { useState, useEffect } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { initializeApp, getApps, getApp } from 'firebase/app';
 import { getAuth, signInAnonymously, signInWithCustomToken, onAuthStateChanged, User } from 'firebase/auth';
-import { getFirestore, collection, addDoc, onSnapshot, doc, updateDoc } from 'firebase/firestore';
+import { getFirestore, collection, addDoc, onSnapshot, doc, updateDoc, query, orderBy } from 'firebase/firestore';
 
 // --- Configuration & Constants ---
 const apiKey = ""; // Provided by environment
@@ -39,9 +40,8 @@ export interface UXReport {
 }
 
 export function useUXAuditor() {
+  const queryClient = useQueryClient();
   const [user, setUser] = useState<User | null>(null);
-  const [reports, setReports] = useState<UXReport[]>([]);
-  const [isAnalyzing, setIsAnalyzing] = useState(false);
   const [activeReport, setActiveReport] = useState<UXReport | null>(null);
   const [url, setUrl] = useState('https://arii.github.io/tech-dancer/');
   const [isCopiedMarkdown, setIsCopiedMarkdown] = useState(false);
@@ -84,61 +84,70 @@ export function useUXAuditor() {
     return () => unsubscribeAuth();
   }, []);
 
-  // Fetch Reports
+  // Fetch Reports (Real-time with TanStack Query)
+  const { data: reports = [] } = useQuery({
+    queryKey: ['ux-reports', user?.uid],
+    queryFn: () => reports, // Managed by onSnapshot below
+    enabled: !!user && !!firebaseConfig,
+    staleTime: Infinity,
+    gcTime: Infinity,
+  });
+
+  // Real-time listener that updates TanStack Query cache
   useEffect(() => {
     if (!user || !firebaseConfig) return;
     const db = getFirestore();
-    const q = collection(db, 'artifacts', appId, 'users', user.uid, 'ux_reports');
+    const q = query(
+      collection(db, 'artifacts', appId, 'users', user.uid, 'ux_reports'),
+      orderBy('timestamp', 'desc')
+    );
 
     const unsubscribe = onSnapshot(q, (snapshot) => {
       const data = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() } as UXReport));
-      setReports(data.sort((a, b) => b.timestamp - a.timestamp));
+      queryClient.setQueryData(['ux-reports', user.uid], data);
     }, (err) => console.error("Firestore error:", err));
 
     return () => unsubscribe();
-  }, [user]);
+  }, [user, queryClient]);
 
-  const runUXAudit = async () => {
-    if (!url) return;
-    setIsAnalyzing(true);
-
-    try {
+  const auditMutation = useMutation({
+    mutationFn: async (targetUrl: string) => {
       let reportId = Date.now().toString();
 
       const newReport: UXReport = {
         id: reportId,
-        url,
+        url: targetUrl,
         timestamp: Date.now(),
         status: 'processing',
       };
 
-      // Add to local state immediately for optimistic UI
-      setReports(prev => [newReport, ...prev].sort((a, b) => b.timestamp - a.timestamp));
       setActiveReport(newReport);
+
+      // Optimistic update for immediate UI feedback
+      queryClient.setQueryData(['ux-reports', user?.uid], (old: UXReport[] = []) => [newReport, ...old]);
 
       if (user && firebaseConfig) {
         const db = getFirestore();
         const newReportRef = await addDoc(collection(db, 'artifacts', appId, 'users', user.uid, 'ux_reports'), newReport);
         reportId = newReportRef.id;
         newReport.id = reportId;
+        // Update optimistic item with real ID
+        queryClient.setQueryData(['ux-reports', user.uid], (old: UXReport[] = []) =>
+          old.map(r => r.timestamp === newReport.timestamp ? { ...newReport, id: reportId } : r)
+        );
       }
 
       for (const vp of VIEWPORTS) {
-        // Attempt to fetch a real snapshot using a free public proxy API
-        // This is a best effort. If it fails due to CORS, we will handle it.
         let mockImg = `https://placehold.co/${vp.width}x${vp.height}/6366f1/ffffff?text=${vp.name}+Analysis+Pending`;
         let base64DataUri = "";
 
         try {
-          // A simple way to get a snapshot (mshots API from WP is free and fast for public URLs)
-          // Reduce the dimensions by 50% to save base64 character count
           const scaledW = Math.floor(vp.width * 0.5);
           const scaledH = Math.floor(vp.height * 0.5);
-          const snapshotUrl = `https://s0.wp.com/mshots/v1/${encodeURIComponent(url)}?w=${scaledW}&h=${scaledH}`;
+          const snapshotUrl = `https://s0.wp.com/mshots/v1/${encodeURIComponent(targetUrl)}?w=${scaledW}&h=${scaledH}`;
           const res = await fetch(snapshotUrl);
           if (res.ok) {
             const blob = await res.blob();
-            // Convert to base64 Data URI
             base64DataUri = await new Promise<string>((resolve) => {
               const reader = new FileReader();
               reader.onloadend = () => resolve(reader.result as string);
@@ -150,14 +159,12 @@ export function useUXAuditor() {
           console.error("Failed to fetch realistic snapshot, using placeholder", e);
         }
 
-        const analysis = await analyzeViewport(vp, url, base64DataUri);
+        const analysis = await analyzeViewport(vp, targetUrl, base64DataUri);
 
         newReport[`findings_${vp.name.toLowerCase()}`] = analysis;
         newReport[`image_${vp.name.toLowerCase()}`] = mockImg;
 
-        const updatedReport = { ...newReport };
-        setReports(prev => prev.map(r => r.id === reportId ? updatedReport : r));
-        setActiveReport(updatedReport);
+        setActiveReport({ ...newReport });
 
         if (user && firebaseConfig) {
           const db = getFirestore();
@@ -169,7 +176,6 @@ export function useUXAuditor() {
       }
 
       newReport.status = 'completed';
-      setReports(prev => prev.map(r => r.id === reportId ? { ...newReport } : r));
       setActiveReport({ ...newReport });
 
       if (user && firebaseConfig) {
@@ -178,12 +184,15 @@ export function useUXAuditor() {
           status: 'completed'
         });
       }
-    } catch (error) {
-      console.error("Audit failed", error);
-    } finally {
-      setIsAnalyzing(false);
-    }
-  };
+
+      return newReport;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['ux-reports', user?.uid] });
+    },
+  });
+
+  const runUXAudit = () => auditMutation.mutate(url);
 
   const analyzeViewport = async (viewport: { name: string, width: number, height: number }, targetUrl: string, base64DataUri?: string) => {
     const systemPrompt = `You are a Senior UX Auditor. Analyze the UI for ${viewport.name}. Focus on specific elements, accessibility, and visual bugs. Output JSON.`;
@@ -291,7 +300,7 @@ export function useUXAuditor() {
   return {
     user,
     reports,
-    isAnalyzing,
+    isAnalyzing: auditMutation.isPending,
     activeReport,
     setActiveReport,
     url,

--- a/src/features/ux-auditor/useUXAuditor.ts
+++ b/src/features/ux-auditor/useUXAuditor.ts
@@ -42,7 +42,7 @@ export interface UXReport {
 export function useUXAuditor() {
   const queryClient = useQueryClient();
   const [user, setUser] = useState<User | null>(null);
-  const [activeReport, setActiveReport] = useState<UXReport | null>(null);
+  const [activeReportId, setActiveReportId] = useState<string | null>(null);
   const [url, setUrl] = useState('https://arii.github.io/tech-dancer/');
   const [isCopiedMarkdown, setIsCopiedMarkdown] = useState(false);
   const [isExportingToGithub, setIsExportingToGithub] = useState(false);
@@ -87,7 +87,7 @@ export function useUXAuditor() {
   // Fetch Reports (Real-time with TanStack Query)
   const { data: reports = [] } = useQuery({
     queryKey: ['ux-reports', user?.uid],
-    queryFn: () => reports, // Managed by onSnapshot below
+    queryFn: () => queryClient.getQueryData(['ux-reports', user?.uid]) ?? [],
     enabled: !!user && !!firebaseConfig,
     staleTime: Infinity,
     gcTime: Infinity,
@@ -121,7 +121,7 @@ export function useUXAuditor() {
         status: 'processing',
       };
 
-      setActiveReport(newReport);
+      setActiveReportId(reportId);
 
       // Optimistic update for immediate UI feedback
       queryClient.setQueryData(['ux-reports', user?.uid], (old: UXReport[] = []) => [newReport, ...old]);
@@ -129,11 +129,14 @@ export function useUXAuditor() {
       if (user && firebaseConfig) {
         const db = getFirestore();
         const newReportRef = await addDoc(collection(db, 'artifacts', appId, 'users', user.uid, 'ux_reports'), newReport);
-        reportId = newReportRef.id;
-        newReport.id = reportId;
+        const realId = newReportRef.id;
+        newReport.id = realId;
+        setActiveReportId(realId);
+        reportId = realId;
+
         // Update optimistic item with real ID
         queryClient.setQueryData(['ux-reports', user.uid], (old: UXReport[] = []) =>
-          old.map(r => r.timestamp === newReport.timestamp ? { ...newReport, id: reportId } : r)
+          old.map(r => r.timestamp === newReport.timestamp ? { ...newReport, id: realId } : r)
         );
       }
 
@@ -164,7 +167,10 @@ export function useUXAuditor() {
         newReport[`findings_${vp.name.toLowerCase()}`] = analysis;
         newReport[`image_${vp.name.toLowerCase()}`] = mockImg;
 
-        setActiveReport({ ...newReport });
+        // Update the report in cache to reflect progress
+        queryClient.setQueryData(['ux-reports', user?.uid], (old: UXReport[] = []) =>
+          old.map(r => r.id === reportId ? { ...newReport } : r)
+        );
 
         if (user && firebaseConfig) {
           const db = getFirestore();
@@ -176,7 +182,9 @@ export function useUXAuditor() {
       }
 
       newReport.status = 'completed';
-      setActiveReport({ ...newReport });
+      queryClient.setQueryData(['ux-reports', user?.uid], (old: UXReport[] = []) =>
+        old.map(r => r.id === reportId ? { ...newReport } : r)
+      );
 
       if (user && firebaseConfig) {
         const db = getFirestore();
@@ -250,6 +258,8 @@ export function useUXAuditor() {
     }
   };
 
+  const activeReport = reports.find(r => r.id === activeReportId) || null;
+
   const getMarkdown = () => {
     if (!activeReport) return "";
     let md = `# Visual UX Audit for ${activeReport.url}\n\n`;
@@ -302,7 +312,7 @@ export function useUXAuditor() {
     reports,
     isAnalyzing: auditMutation.isPending,
     activeReport,
-    setActiveReport,
+    setActiveReport: (r: UXReport | null) => setActiveReportId(r?.id || null),
     url,
     setUrl,
     isCopiedMarkdown,

--- a/src/hooks/useGlobalSearch.ts
+++ b/src/hooks/useGlobalSearch.ts
@@ -1,5 +1,6 @@
 import { useMemo, useCallback } from 'react';
 import { useSearchParams } from 'react-router-dom';
+import { useQueries } from '@tanstack/react-query';
 import { getPosts, getResources, getStudies } from '@/lib/content';
 import { safeSearch } from '@/lib/utils';
 
@@ -37,13 +38,21 @@ export function useGlobalSearch() {
     }, { replace: true });
   }, [setSearchParams]);
 
+  const [postsQuery, resourcesQuery, studiesQuery] = useQueries({
+    queries: [
+      { queryKey: ['posts'], queryFn: getPosts },
+      { queryKey: ['resources'], queryFn: getResources },
+      { queryKey: ['studies'], queryFn: getStudies },
+    ],
+  });
+
   const allContent = useMemo(() => {
     return [
-      ...getPosts().map(p => ({ ...p, type: 'post' as const })),
-      ...getResources().map(r => ({ ...r, type: 'resource' as const })),
-      ...getStudies().map(s => ({ ...s, type: 'study' as const }))
+      ...(postsQuery.data || []).map(p => ({ ...p, type: 'post' as const })),
+      ...(resourcesQuery.data || []).map(r => ({ ...r, type: 'resource' as const })),
+      ...(studiesQuery.data || []).map(s => ({ ...s, type: 'study' as const }))
     ];
-  }, []);
+  }, [postsQuery.data, resourcesQuery.data, studiesQuery.data]);
 
   const results = useMemo(() => {
     if (!query.trim()) return [];

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,8 +7,18 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import { HelmetProvider } from 'react-helmet-async';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { routes } from './App.tsx';
 import './index.css';
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 1000 * 60 * 5, // 5 minutes
+      gcTime: 1000 * 60 * 30, // 30 minutes
+    },
+  },
+});
 
 /**
  * Function to calculate the actual basename at runtime.
@@ -61,7 +71,9 @@ const router = createBrowserRouter(routes, {
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <HelmetProvider>
-      <RouterProvider router={router} />
+      <QueryClientProvider client={queryClient}>
+        <RouterProvider router={router} />
+      </QueryClientProvider>
     </HelmetProvider>
   </StrictMode>,
 );


### PR DESCRIPTION
This PR refactors the data fetching logic across multiple features to use TanStack Query. 

Key changes:
- Infrastructure: Added `QueryClientProvider` to the root of the application.
- Standard Hooks: `useBlog`, `useHome`, `useResearch`, `useToolbox`, and `useProfile` now leverage `useQuery` for fetching markdown content and profile data.
- Complex Hooks: `useUXAuditor` has been updated to use `useQuery` for report listing and `useMutation` for running audits. It maintains real-time capabilities by syncing Firestore `onSnapshot` updates into the TanStack Query cache.
- Quality: All e2e tests passed, and type-checking is clean. Visual verification confirms that the UI remains functional and responsive.

Fixes #130

---
*PR created automatically by Jules for task [705119004898272863](https://jules.google.com/task/705119004898272863) started by @arii*