### PR TITLE
Fix: standardized PageHeader API and component tokens

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -94,7 +94,8 @@ jobs:
             find . -maxdepth 3 -name "index.html" | while read -r index_file; do
               DIR=$(dirname "$index_file" | sed 's|^\./||')
               [[ "$DIR" =~ ^(\.|\.\.|assets|tmp|previews)$ ]] && continue
-              TS=$(cat "$DIR/.timestamp" 2>/dev/null || git log -1 --format=%ct -- "$DIR" || date +%s)
+              TS=$(cat "$DIR/.timestamp" 2>/dev/null || git log -1 --format=%ct -- "$DIR" || true)
+              [ -z "$TS" ] && TS=$(date +%s)
               echo "$DIR $TS"
             done | jq -R -n '[inputs | split(" ") | {(.[0]): (.[1] | tonumber)}] | add // {}' > previews/data.json
 

--- a/src/components/layout/DetailElements.tsx
+++ b/src/components/layout/DetailElements.tsx
@@ -45,7 +45,7 @@ export function SpecsTable({ specs }: { specs?: Record<string, string> }) {
 
   return (
     <Stack gap={4}>
-      <Text variant="mono" size="tiny" weight="font-bold" color="dim" uppercase className="tracking-widest border-b border-line pb-2">Technical Specs</Text>
+      <Text variant="mono" size="tiny" weight="font-bold" color="dim" uppercase tracking="widest" className="border-b border-line pb-2">Technical Specs</Text>
       <Stack gap={3}>
         {Object.entries(specs).map(([key, value]) => (
           <Stack key={key} gap={1}>
@@ -61,7 +61,7 @@ export function SpecsTable({ specs }: { specs?: Record<string, string> }) {
 export function TOC({ headings }: { headings: string[] }) {
   return (
     <Stack gap={4}>
-      <Text variant="mono" size="tiny" weight="font-bold" color="dim" uppercase className="tracking-widest border-b border-line pb-2">In this post</Text>
+      <Text variant="mono" size="tiny" weight="font-bold" color="dim" uppercase tracking="widest" className="border-b border-line pb-2">In this post</Text>
       <Stack gap={2}>
         {headings.map((h, i) => (
           <Text key={i} variant="mono" size="tiny" className="cursor-pointer hover:text-accent transition-colors">

--- a/src/components/layout/DetailLayout.tsx
+++ b/src/components/layout/DetailLayout.tsx
@@ -63,7 +63,7 @@ export function DetailLayout({
               <Text variant="mono" size="micro" color="dim">{date} • {rt} min read</Text>
             </Box>
 
-            <Text variant="headline" size="fluid-8" className="tracking-tighter leading-none">
+            <Text variant="headline" size="fluid-8" tracking="tighter" className="leading-none">
               {title}
             </Text>
 

--- a/src/components/ui/CardImagePlaceholder.tsx
+++ b/src/components/ui/CardImagePlaceholder.tsx
@@ -27,7 +27,7 @@ export function CardImagePlaceholder({ image, category, date, title }: CardImage
         />
         <Box className="absolute top-3 left-3">
           <Box surface={surfaceVariant} className="px-2 py-0.5 border border-line/20 backdrop-blur-sm bg-opacity-90">
-            <Text variant="mono" size="micro" weight="font-bold" uppercase className="tracking-wider">
+            <Text variant="mono" size="micro" weight="font-bold" uppercase tracking="wider">
               {category}
             </Text>
           </Box>
@@ -45,13 +45,13 @@ export function CardImagePlaceholder({ image, category, date, title }: CardImage
       )}
     >
       <Box display="flex" align="center" gap={2}>
-        <Text variant="mono" size="micro" weight="font-bold" uppercase className="tracking-widest opacity-80">
+        <Text variant="mono" size="micro" weight="font-bold" uppercase tracking="widest" className="opacity-80">
           {category}
         </Text>
         {date && (
           <>
             <Box className="w-1 h-1 rounded-full bg-current opacity-30" />
-            <Text variant="mono" size="micro" uppercase className="tracking-widest opacity-60">
+            <Text variant="mono" size="micro" uppercase tracking="widest" className="opacity-60">
               {date}
             </Text>
           </>

--- a/src/components/ui/MarkdownRenderer.tsx
+++ b/src/components/ui/MarkdownRenderer.tsx
@@ -27,7 +27,7 @@ export function MarkdownRenderer({ content }: MarkdownRendererProps) {
                 tracking="wide-editorial"
                 className="block mb-2 opacity-50 before:content-[counter(section,decimal-leading-zero)] before:mr-2"
               />
-              <Text as="h2" variant="display" size="3xl" weight="font-bold" className="normal-case tracking-tight m-0" {...props} />
+              <Text as="h2" variant="display" size="3xl" weight="font-bold" tracking="tight" className="normal-case m-0" {...props} />
               <Box className="h-px w-12 bg-accent mt-4" />
             </Box>
           )

--- a/src/components/ui/PageHeader.tsx
+++ b/src/components/ui/PageHeader.tsx
@@ -1,5 +1,7 @@
 import { Box, Stack, Text } from '@/layouts/Primitives';
 import type { BaseProps } from '@/layouts/Box';
+import type { ResponsiveProp } from '@/layouts/system-utils';
+import type { typeSizes } from '@/styles/design-tokens';
 
 interface PageHeaderProps {
   label: string;
@@ -9,6 +11,7 @@ interface PageHeaderProps {
   border?: BaseProps['border'];
   descriptionMaxWidth?: BaseProps['maxWidth'];
   titleAs?: "h1" | "h2" | "h3";
+  size?: ResponsiveProp<keyof typeof typeSizes>;
 }
 
 export function PageHeader({
@@ -17,8 +20,9 @@ export function PageHeader({
   description,
   paddingBottom = 12,
   border = "b",
-  descriptionMaxWidth = "65ch",
-  titleAs = "h1"
+  descriptionMaxWidth = "prose",
+  titleAs = "h1",
+  size = { base: "4xl", lg: "6xl" }
 }: PageHeaderProps) {
   return (
     <Box
@@ -39,7 +43,7 @@ export function PageHeader({
         <Text
           as={titleAs}
           variant="headline"
-          size={{ base: "4xl", lg: "6xl" }}
+          size={size}
           weight="font-black"
           tracking="tighter"
           color="main"

--- a/src/features/contact/components/ContactFormView.tsx
+++ b/src/features/contact/components/ContactFormView.tsx
@@ -59,7 +59,7 @@ export function ContactFormView({ formData, errors, isSubmitting, onChange, onSu
                     </Box>
                     <Stack gap={1}>
                       <Text variant="sans" size="base" weight="font-bold" className="text-accent-navy">{item.label}</Text>
-                      <Text variant="mono" color="dim" size="xs" weight="font-semibold" className="tracking-widest uppercase">{item.channel}</Text>
+                      <Text variant="mono" color="dim" size="xs" weight="font-semibold" tracking="widest" uppercase>{item.channel}</Text>
                     </Stack>
                   </Box>
                 ))}

--- a/src/features/contact/components/FormField.tsx
+++ b/src/features/contact/components/FormField.tsx
@@ -14,7 +14,7 @@ export function FormField({ label, error, children }: FormFieldProps) {
   return (
     <Stack gap={2} marginBottom={6}>
       <Box display="flex" justify="between" align="center">
-        <Text as="label" htmlFor={id} variant="mono" size="xs" weight="font-semibold" color="dim" className="tracking-widest uppercase">
+        <Text as="label" htmlFor={id} variant="mono" size="xs" weight="font-semibold" color="dim" tracking="widest" uppercase>
           {label}
         </Text>
         {error && (

--- a/src/features/dashboard/Dashboard.tsx
+++ b/src/features/dashboard/Dashboard.tsx
@@ -28,7 +28,7 @@ export default function Home() {
               animate={{ opacity: 1, y: 0 }}
               variant="headline" 
               size="fluid-7"
-              className="text-accent-navy leading-tight tracking-tight max-w-4xl"
+              tracking="tight" className="text-accent-navy leading-tight max-w-4xl"
             >
               The Roboticist&apos;s Guide to the West Coast Swing
             </Text>

--- a/src/features/journal/components/BlogPostDetail.tsx
+++ b/src/features/journal/components/BlogPostDetail.tsx
@@ -62,7 +62,7 @@ export function BlogPostDetail({ post, onBack, backLabel }: BlogPostDetailProps)
 
   const relatedContent = relatedPosts.length > 0 && (
     <Box border="t" paddingTop={12} marginTop={12}>
-      <Text variant="mono" size="xs" weight="font-bold" className="mb-8 block uppercase tracking-widest">Related Posts</Text>
+      <Text variant="mono" size="xs" weight="font-bold" uppercase tracking="widest" className="mb-8 block">Related Posts</Text>
       <Grid cols={{ base: 1, md: 2 }} gap={8}>
         {relatedPosts.map(p => (
           <ContentCard key={p.slug} {...p} basePath="/blog" />

--- a/src/features/lab/GearCard.tsx
+++ b/src/features/lab/GearCard.tsx
@@ -83,7 +83,7 @@ export function GearCard({
           </Text>
 
           <Box display="flex" align="center" gap={2} paddingTop={4} className="border-t border-line/50">
-            <Text variant="mono" size="xs" weight="font-bold" className="text-accent tracking-wider">
+            <Text variant="mono" size="xs" weight="font-bold" tracking="wider" className="text-accent">
               Read Review
             </Text>
             <Box className="w-0 h-[1px] bg-accent group-hover:w-6 transition-all duration-500" />

--- a/src/features/lab/components/GearPostDetail.tsx
+++ b/src/features/lab/components/GearPostDetail.tsx
@@ -32,7 +32,7 @@ export function GearPostDetail({ post, onBack, backLabel }: GearPostDetailProps)
 
       {affiliateLinks.length > 0 && (
         <Stack gap={4} marginTop={8}>
-          <Text variant="mono" size="tiny" weight="font-bold" color="dim" uppercase className="tracking-widest border-b border-line pb-2">Where to Buy</Text>
+          <Text variant="mono" size="tiny" weight="font-bold" color="dim" uppercase tracking="widest" className="border-b border-line pb-2">Where to Buy</Text>
           {affiliateLinks.map(link => (
             <Box
               key={link.id}

--- a/src/features/research/ResearchAnalytics.tsx
+++ b/src/features/research/ResearchAnalytics.tsx
@@ -27,7 +27,7 @@ export default function ResearchAnalytics() {
         <Stack gap={8}>
           <Box paddingBottom={4} display="flex" justify="between" align="end" className="border-b border-slate-200">
             <Text variant="display" size="2xl" weight="font-black" className="text-accent-navy">Tools Ecosystem</Text>
-            <Text variant="mono" size="xs" color="dim" weight="font-semibold" className="tracking-widest">{tools.length} TOOLS</Text>
+            <Text variant="mono" size="xs" color="dim" weight="font-semibold" tracking="widest">{tools.length} TOOLS</Text>
           </Box>
           <Grid cols={{ base: 1, md: 2, lg: 3 }} gap={8}>
             {tools.map((tool) => (
@@ -67,7 +67,7 @@ export default function ResearchAnalytics() {
         <Stack gap={8}>
           <Box paddingBottom={4} display="flex" justify="between" align="end" className="border-b border-slate-200">
             <Text variant="display" size="2xl" weight="font-black" className="text-accent-navy">Studies</Text>
-            <Text variant="mono" size="xs" color="dim" weight="font-semibold" className="tracking-widest">{studies.length} ARTICLES</Text>
+            <Text variant="mono" size="xs" color="dim" weight="font-semibold" tracking="widest">{studies.length} ARTICLES</Text>
           </Box>
 
           {studies.length > 0 ? (

--- a/src/layouts/ContentDetail.tsx
+++ b/src/layouts/ContentDetail.tsx
@@ -53,7 +53,7 @@ export function ContentDetail({ post, onBack, backLabel, children }: ContentDeta
             )}
           </Box>
 
-          <Text as="h1" variant="headline" size="fluid-8" className="tracking-tighter leading-none">
+          <Text as="h1" variant="headline" size="fluid-8" tracking="tighter" className="leading-none">
             {title}
           </Text>
 


### PR DESCRIPTION
This submission finalizes the review feedback for PR #255 on branch `148-pageheader-standardization-5756109416038041320`.

The main improvements are:
1. Reverting fallback types in `PageHeader` parameters to their corresponding constrained system `BaseProps`.
2. Utilizing the single source of truth (`"prose"`) for descriptions instead of raw dimensions (`"65ch"`).
3. Utilizing a strongly-typed `size` prop directly passed down to `<Text>` elements instead of hardcoding a responsive object within `PageHeader`.
4. Updating raw CSS utility classes found across varying components (`MarkdownRenderer`, `DetailLayout`, `ContactFormView`, etc.) that dictate tracking rules into strict primitive layout tokens via `<Text tracking="...">`.

---
*PR created automatically by Jules for task [1953441378834784634](https://jules.google.com/task/1953441378834784634) started by @arii*