### PR TITLE
Refactor ResearchAnalytics Tokens and Arbitrary Values

### DIFF
--- a/src/features/research/ResearchAnalytics.tsx
+++ b/src/features/research/ResearchAnalytics.tsx
@@ -25,7 +25,7 @@ export default function ResearchAnalytics() {
         />
 
         <Stack gap={8}>
-          <Box paddingBottom={4} display="flex" justify="between" align="end" className="border-b border-slate-200">
+          <Box paddingBottom={4} display="flex" justify="between" align="end" className="border-b border-line">
             <Text variant="display" size="2xl" weight="font-black" className="text-accent-navy">Tools Ecosystem</Text>
             <Text variant="mono" size="xs" color="dim" weight="font-semibold" className="tracking-widest">{tools.length} TOOLS</Text>
           </Box>
@@ -39,22 +39,22 @@ export default function ResearchAnalytics() {
                 border
                 padding="card"
                 cursor="pointer"
-                className="group hover:border-accent-brand transition-all text-left"
+                className="group hover:border-accent transition-all text-left"
               >
                 <Stack gap={6} height="full" justify="between">
                   <Stack gap={4}>
                     <Box display="flex" justify="between" align="start">
-                      <Box width={10} height={10} surface="muted" border display="flex" align="center" justify="center" color="dim" className="group-hover:text-accent-brand transition-colors">
+                      <Box width={10} height={10} surface="muted" border display="flex" align="center" justify="center" color="dim" className="group-hover:text-accent transition-colors">
                         <Search className="w-5 h-5" />
                       </Box>
                       <Text variant="mono" size="micro" color="brand" weight="font-bold">{tool.status.toUpperCase()}</Text>
                     </Box>
                     <Stack gap={2}>
-                      <Text variant="display" size="xl" className="group-hover:text-accent-brand transition-colors">{tool.name}</Text>
+                      <Text variant="display" size="xl" className="group-hover:text-accent transition-colors">{tool.name}</Text>
                       <Text variant="body" size="sm" color="dim" className="line-clamp-2">{tool.layman}</Text>
                     </Stack>
                   </Stack>
-                  <Box display="flex" align="center" gap={2} color="dim" className="group-hover:text-accent-brand transition-colors">
+                  <Box display="flex" align="center" gap={2} color="dim" className="group-hover:text-accent transition-colors">
                     <Text variant="mono" size="micro" weight="font-bold">Launch Console</Text>
                     <ArrowRight className="w-3 h-3" />
                   </Box>
@@ -65,7 +65,7 @@ export default function ResearchAnalytics() {
         </Stack>
 
         <Stack gap={8}>
-          <Box paddingBottom={4} display="flex" justify="between" align="end" className="border-b border-slate-200">
+          <Box paddingBottom={4} display="flex" justify="between" align="end" className="border-b border-line">
             <Text variant="display" size="2xl" weight="font-black" className="text-accent-navy">Studies</Text>
             <Text variant="mono" size="xs" color="dim" weight="font-semibold" className="tracking-widest">{studies.length} ARTICLES</Text>
           </Box>
@@ -79,7 +79,7 @@ export default function ResearchAnalytics() {
                       <Text variant="mono" size="micro" color="brand" uppercase>{study.category}</Text>
                       <Text variant="mono" size="micro" color="dim">{study.date}</Text>
                     </Box>
-                    <Text variant="display" size="2xl" className="group-hover:text-accent-brand transition-colors">
+                    <Text variant="display" size="2xl" className="group-hover:text-accent transition-colors">
                       {study.title}
                     </Text>
                     <Text variant="body" size="sm" color="dim" className="line-clamp-3">
@@ -92,7 +92,7 @@ export default function ResearchAnalytics() {
                       align="center"
                       gap={2}
                       color="dim"
-                      className="group-hover:text-accent-brand transition-colors"
+                      className="group-hover:text-accent transition-colors"
                     >
                       <Text variant="mono" size="xs" weight="font-bold">Read Study</Text>
                       <FileText className="w-4 h-4" />
@@ -104,10 +104,10 @@ export default function ResearchAnalytics() {
           ) : (
             <Box border padding={12} surface="muted" emphasis="low">
               <Stack align="center" gap={4} className="text-center">
-                <Database className="w-12 h-12 text-slate-300" />
+                <Database className="w-12 h-12 text-line" />
                 <Stack gap={2}>
                   <Text variant="display" size="xl">Pipeline Synchronizing...</Text>
-                  <Text variant="body" size="sm" color="dim" className="max-w-[40ch]">
+                  <Text variant="body" size="sm" color="dim" maxWidth="prose">
                     Research studies are automatically ingested via the ETL pipeline.
                     New analysis runs weekly—check back soon for recent data.
                   </Text>


### PR DESCRIPTION
Refactored `src/features/research/ResearchAnalytics.tsx` to replace arbitrary Tailwind values and non-token colors with approved design system tokens. Specifically:
- Updated lines 47, 53, 57, 82, and 95 to use `group-hover:text-accent` instead of `group-hover:text-accent-brand`.
- Updated line 42 to use `hover:border-accent` instead of `hover:border-accent-brand`.
- Updated line 107 to use `text-line` instead of `text-slate-300` for the Database icon.
- Updated line 110 to use the `maxWidth="prose"` prop on the `Text` component instead of the arbitrary `max-w-[40ch]` class.
- Updated lines 28 and 68 to use `border-line` instead of `border-slate-200` for consistent semantic token usage.

Verification included:
- Running `node scripts/detect-antipatterns.mjs` to ensure the file is clean.
- Running `pnpm run lint` and `pnpm run test:e2e` to ensure no regressions.
- Visual verification via Playwright screenshot.

Fixes #323

---
*PR created automatically by Jules for task [11332753828433583923](https://jules.google.com/task/11332753828433583923) started by @arii*