### PR TITLE
Refactor ResearchDetail Non-token Colors and Sizes

### DIFF
--- a/TODO_ANTIPATTERNS.md
+++ b/TODO_ANTIPATTERNS.md
@@ -2,6 +2,8 @@
 
 This list is automatically generated from the `npm run audit` report. Fix these anti-patterns to adhere to the project design system.
 
+## src/features/contact/components/ContactFormView.tsx
+- [ ] Line 123: [Raw Layout/Spacing] mt-2 - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
 ## src/features/dashboard/EventCard.tsx
 - [ ] Line 14: [Raw Layout/Spacing] flex - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
 - [ ] Line 14: [Raw Layout/Spacing] flex-col - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
@@ -27,16 +29,16 @@ This list is automatically generated from the `npm run audit` report. Fix these 
 ## src/features/journal/BlogPost.tsx
 - [ ] Line 36: [Non-token Color/Size] hover:text-accent-brand - Class 'hover:text-accent-brand' uses a value that is not a recognized design token.
 ## src/features/journal/components/BlogPostDetail.tsx
-- [ ] Line 36: [Raw Layout/Spacing] flex - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
-- [ ] Line 36: [Raw Layout/Spacing] items-center - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
-- [ ] Line 36: [Raw Layout/Spacing] justify-center - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
-- [ ] Line 56: [Non-token Color/Size] hover:text-accent-brand - Class 'hover:text-accent-brand' uses a value that is not a recognized design token.
-- [ ] Line 65: [Raw Layout/Spacing] mb-8 - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
+- [ ] Line 39: [Raw Layout/Spacing] flex-1 - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
 ## src/features/lab/BlogDrafter.tsx
-- [ ] Line 26: [Non-token Color/Size] text-accent-brand - Class 'text-accent-brand' uses a value that is not a recognized design token.
-- [ ] Line 31: [Non-token Color/Size] text-accent-brand - Class 'text-accent-brand' uses a value that is not a recognized design token.
-- [ ] Line 31: [Raw Layout/Spacing] mt-1 - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
-- [ ] Line 212: [Non-token Color/Size] hover:bg-accent-brand - Class 'hover:bg-accent-brand' uses a value that is not a recognized design token.
+- [ ] Line 38: [Arbitrary Value] -[160px] - Avoid arbitrary values like -[...]. Use design tokens instead.
+- [ ] Line 38: [Raw Layout/Spacing] p-6 - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
+- [ ] Line 77: [Raw Layout/Spacing] pb-4 - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
+- [ ] Line 83: [Raw Layout/Spacing] p-2 - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
+- [ ] Line 83: [Non-token Color/Size] hover:bg-muted - Class 'hover:bg-muted' uses a value that is not a recognized design token.
+- [ ] Line 86: [Raw Layout/Spacing] p-2 - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
+- [ ] Line 86: [Non-token Color/Size] hover:bg-muted - Class 'hover:bg-muted' uses a value that is not a recognized design token.
+- [ ] Line 103: [Raw Layout/Spacing] ml-auto - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
 ## src/features/lab/GearCard.tsx
 - [ ] Line 89: [Arbitrary Value] -[1px] - Avoid arbitrary values like -[...]. Use design tokens instead.
 - [ ] Line 26: [Raw Layout/Spacing] flex - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
@@ -76,14 +78,6 @@ This list is automatically generated from the `npm run audit` report. Fix these 
 - [ ] Line 82: [Non-token Color/Size] group-hover:text-accent-brand - Class 'group-hover:text-accent-brand' uses a value that is not a recognized design token.
 - [ ] Line 95: [Non-token Color/Size] group-hover:text-accent-brand - Class 'group-hover:text-accent-brand' uses a value that is not a recognized design token.
 - [ ] Line 107: [Non-token Color/Size] text-slate-300 - Class 'text-slate-300' uses a value that is not a recognized design token.
-## src/features/research/ResearchDetail.tsx
-- [ ] Line 50: [Non-token Color/Size] hover:text-accent-brand - Class 'hover:text-accent-brand' uses a value that is not a recognized design token.
-- [ ] Line 78: [Non-token Color/Size] hover:text-accent-brand - Class 'hover:text-accent-brand' uses a value that is not a recognized design token.
-- [ ] Line 105: [Non-token Color/Size] text-accent-brand - Class 'text-accent-brand' uses a value that is not a recognized design token.
-- [ ] Line 112: [Non-token Color/Size] text-accent-brand - Class 'text-accent-brand' uses a value that is not a recognized design token.
-- [ ] Line 112: [Non-token Color/Size] text-dim - Class 'text-dim' uses a value that is not a recognized design token.
-- [ ] Line 119: [Non-token Color/Size] bg-accent-brand/5 - Class 'bg-accent-brand/5' uses a value that is not a recognized design token.
-- [ ] Line 121: [Non-token Color/Size] text-accent-brand - Class 'text-accent-brand' uses a value that is not a recognized design token.
 ## src/pages/UXAuditor.tsx
 - [ ] Line 76: [Arbitrary Value] -[var(--color-success,#16a34a)] - Avoid arbitrary values like -[...]. Use design tokens instead.
 - [ ] Line 174: [Arbitrary Value] -[var(--color-success-dim,#dcfce7)] - Avoid arbitrary values like -[...]. Use design tokens instead.

--- a/TODO_ANTIPATTERNS.md
+++ b/TODO_ANTIPATTERNS.md
@@ -2,8 +2,6 @@
 
 This list is automatically generated from the `npm run audit` report. Fix these anti-patterns to adhere to the project design system.
 
-## src/features/contact/components/ContactFormView.tsx
-- [ ] Line 123: [Raw Layout/Spacing] mt-2 - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
 ## src/features/dashboard/EventCard.tsx
 - [ ] Line 14: [Raw Layout/Spacing] flex - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
 - [ ] Line 14: [Raw Layout/Spacing] flex-col - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
@@ -29,16 +27,16 @@ This list is automatically generated from the `npm run audit` report. Fix these 
 ## src/features/journal/BlogPost.tsx
 - [ ] Line 36: [Non-token Color/Size] hover:text-accent-brand - Class 'hover:text-accent-brand' uses a value that is not a recognized design token.
 ## src/features/journal/components/BlogPostDetail.tsx
-- [ ] Line 39: [Raw Layout/Spacing] flex-1 - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
+- [ ] Line 36: [Raw Layout/Spacing] flex - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
+- [ ] Line 36: [Raw Layout/Spacing] items-center - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
+- [ ] Line 36: [Raw Layout/Spacing] justify-center - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
+- [ ] Line 56: [Non-token Color/Size] hover:text-accent-brand - Class 'hover:text-accent-brand' uses a value that is not a recognized design token.
+- [ ] Line 65: [Raw Layout/Spacing] mb-8 - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
 ## src/features/lab/BlogDrafter.tsx
-- [ ] Line 38: [Arbitrary Value] -[160px] - Avoid arbitrary values like -[...]. Use design tokens instead.
-- [ ] Line 38: [Raw Layout/Spacing] p-6 - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
-- [ ] Line 77: [Raw Layout/Spacing] pb-4 - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
-- [ ] Line 83: [Raw Layout/Spacing] p-2 - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
-- [ ] Line 83: [Non-token Color/Size] hover:bg-muted - Class 'hover:bg-muted' uses a value that is not a recognized design token.
-- [ ] Line 86: [Raw Layout/Spacing] p-2 - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
-- [ ] Line 86: [Non-token Color/Size] hover:bg-muted - Class 'hover:bg-muted' uses a value that is not a recognized design token.
-- [ ] Line 103: [Raw Layout/Spacing] ml-auto - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
+- [ ] Line 26: [Non-token Color/Size] text-accent-brand - Class 'text-accent-brand' uses a value that is not a recognized design token.
+- [ ] Line 31: [Non-token Color/Size] text-accent-brand - Class 'text-accent-brand' uses a value that is not a recognized design token.
+- [ ] Line 31: [Raw Layout/Spacing] mt-1 - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
+- [ ] Line 212: [Non-token Color/Size] hover:bg-accent-brand - Class 'hover:bg-accent-brand' uses a value that is not a recognized design token.
 ## src/features/lab/GearCard.tsx
 - [ ] Line 89: [Arbitrary Value] -[1px] - Avoid arbitrary values like -[...]. Use design tokens instead.
 - [ ] Line 26: [Raw Layout/Spacing] flex - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
@@ -78,6 +76,14 @@ This list is automatically generated from the `npm run audit` report. Fix these 
 - [ ] Line 82: [Non-token Color/Size] group-hover:text-accent-brand - Class 'group-hover:text-accent-brand' uses a value that is not a recognized design token.
 - [ ] Line 95: [Non-token Color/Size] group-hover:text-accent-brand - Class 'group-hover:text-accent-brand' uses a value that is not a recognized design token.
 - [ ] Line 107: [Non-token Color/Size] text-slate-300 - Class 'text-slate-300' uses a value that is not a recognized design token.
+## src/features/research/ResearchDetail.tsx
+- [ ] Line 50: [Non-token Color/Size] hover:text-accent-brand - Class 'hover:text-accent-brand' uses a value that is not a recognized design token.
+- [ ] Line 78: [Non-token Color/Size] hover:text-accent-brand - Class 'hover:text-accent-brand' uses a value that is not a recognized design token.
+- [ ] Line 105: [Non-token Color/Size] text-accent-brand - Class 'text-accent-brand' uses a value that is not a recognized design token.
+- [ ] Line 112: [Non-token Color/Size] text-accent-brand - Class 'text-accent-brand' uses a value that is not a recognized design token.
+- [ ] Line 112: [Non-token Color/Size] text-dim - Class 'text-dim' uses a value that is not a recognized design token.
+- [ ] Line 119: [Non-token Color/Size] bg-accent-brand/5 - Class 'bg-accent-brand/5' uses a value that is not a recognized design token.
+- [ ] Line 121: [Non-token Color/Size] text-accent-brand - Class 'text-accent-brand' uses a value that is not a recognized design token.
 ## src/pages/UXAuditor.tsx
 - [ ] Line 76: [Arbitrary Value] -[var(--color-success,#16a34a)] - Avoid arbitrary values like -[...]. Use design tokens instead.
 - [ ] Line 174: [Arbitrary Value] -[var(--color-success-dim,#dcfce7)] - Avoid arbitrary values like -[...]. Use design tokens instead.

--- a/src/features/research/ResearchDetail.tsx
+++ b/src/features/research/ResearchDetail.tsx
@@ -44,9 +44,9 @@ export default function ResearchDetail() {
     return (
       <Box padding="panel" textAlign="center">
         <Stack gap={8} align="center">
-          <Search className="w-12 h-12 opacity-20" />
+          <Search size={48} className="opacity-20" />
           <Text variant="display" size="2xl">Content Not Found</Text>
-          <Box as="button" onClick={() => navigate('/research')} className="hover:text-accent-brand transition-colors">
+          <Box as="button" onClick={() => navigate('/research')} className="hover:text-accent transition-colors">
             <Text variant="mono" size="xs">Back to Laboratory</Text>
           </Box>
         </Stack>
@@ -73,12 +73,11 @@ export default function ResearchDetail() {
           display="flex" 
           align="center" 
           gap={2}
-          color="dim"
-          className="hover:text-accent-brand transition-colors"
+          className="hover:text-accent transition-colors"
           cursor="pointer"
         >
-          <ArrowLeft className="w-4 h-4" />
-          <Text variant="mono" size="xs" weight="font-bold">Back to Lab</Text>
+          <ArrowLeft size={16} />
+          <Text variant="mono" size="xs" weight="font-bold" color="dim">Back to Lab</Text>
         </Box>
 
         <Box border surface="default" padding={{ base: 8, md: 12 }} className="rounded-none">
@@ -92,7 +91,7 @@ export default function ResearchDetail() {
                     LABORATORY_ACCESS // {tool.category.toUpperCase()}
                   </Text>
                   <Text as="h1" variant="headline" size="fluid-7">{tool.name}</Text>
-                  <Box border surface="accent" padding="compact" opacity={5} className="bg-accent/5">
+                  <Box border surface="accent" padding="compact">
                     <Text variant="body" size="lg" color="body">{tool.layman}</Text>
                   </Box>
                 </Stack>
@@ -101,23 +100,23 @@ export default function ResearchDetail() {
                   <Stack gap={4}>
                     <Text variant="mono" size="micro" color="dim" uppercase tracking="widest">System Status</Text>
                     <Box border padding="compact" display="flex" align="center" gap={3}>
-                      <Activity className="w-4 h-4 text-accent-brand" />
+                      <Activity size={16} className="text-accent" />
                       <Text variant="mono" size="xs" color="brand" weight="font-bold">{tool.status.toUpperCase()}</Text>
                     </Box>
                   </Stack>
                   <Stack gap={4}>
                     <Text variant="mono" size="micro" color="dim" uppercase tracking="widest">Database Source</Text>
                     <Box border padding="compact" display="flex" align="center" gap={3}>
-                      <Database className="w-4 h-4 text-accent-brand text-dim" />
+                      <Database size={16} className="text-text-dim" />
                       <Text variant="mono" size="xs">WSDC REGISTRY // AUTHENTICATED</Text>
                     </Box>
                   </Stack>
                 </Grid>
 
                 {tool.status === 'Coming Soon' && (
-                  <Box border surface="accent" padding="card" className="bg-accent-brand/5 border-dashed">
+                  <Box border surface="accent" padding="card" className="border-dashed">
                     <Stack gap={4} align="center" textAlign="center">
-                      <Search className="w-8 h-8 text-accent-brand opacity-50" />
+                      <Search size={32} className="text-accent opacity-50" />
                       <Stack gap={2}>
                         <Text variant="display" size="xl">Work in Progress</Text>
                         <Text variant="body" size="sm" color="dim" maxWidth="md">


### PR DESCRIPTION
Refactored `src/features/research/ResearchDetail.tsx` to align with the project's design system and pass the UI audit. Hardcoded color strings like `text-accent-brand` and `text-dim` were replaced with their tokenized equivalents (`text-accent`, `text-text-dim`). Arbitrary icon sizes were converted to the standard `size` prop. Redundant surface styles were cleaned up to reduce CSS bloat and improve maintainability. All changes were verified through static analysis (audit/lint) and functional E2E tests.

Fixes #324

---
*PR created automatically by Jules for task [16700858379020327430](https://jules.google.com/task/16700858379020327430) started by @arii*