### PR TITLE
Abstract error handling into useImage hook

### DIFF
--- a/TODO_ANTIPATTERNS.md
+++ b/TODO_ANTIPATTERNS.md
@@ -2,6 +2,8 @@
 
 This list is automatically generated from the `npm run audit` report. Fix these anti-patterns to adhere to the project design system.
 
+## src/features/contact/components/ContactFormView.tsx
+- [ ] Line 123: [Raw Layout/Spacing] mt-2 - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
 ## src/features/dashboard/EventCard.tsx
 - [ ] Line 14: [Raw Layout/Spacing] flex - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
 - [ ] Line 14: [Raw Layout/Spacing] flex-col - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
@@ -27,28 +29,16 @@ This list is automatically generated from the `npm run audit` report. Fix these 
 ## src/features/journal/BlogPost.tsx
 - [ ] Line 36: [Non-token Color/Size] hover:text-accent-brand - Class 'hover:text-accent-brand' uses a value that is not a recognized design token.
 ## src/features/journal/components/BlogPostDetail.tsx
-- [ ] Line 36: [Raw Layout/Spacing] flex - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
-- [ ] Line 36: [Raw Layout/Spacing] items-center - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
-- [ ] Line 36: [Raw Layout/Spacing] justify-center - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
-- [ ] Line 56: [Non-token Color/Size] hover:text-accent-brand - Class 'hover:text-accent-brand' uses a value that is not a recognized design token.
-- [ ] Line 65: [Raw Layout/Spacing] mb-8 - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
+- [ ] Line 39: [Raw Layout/Spacing] flex-1 - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
 ## src/features/lab/BlogDrafter.tsx
-- [ ] Line 26: [Non-token Color/Size] text-accent-brand - Class 'text-accent-brand' uses a value that is not a recognized design token.
-- [ ] Line 31: [Non-token Color/Size] text-accent-brand - Class 'text-accent-brand' uses a value that is not a recognized design token.
-- [ ] Line 31: [Raw Layout/Spacing] mt-1 - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
-- [ ] Line 212: [Non-token Color/Size] hover:bg-accent-brand - Class 'hover:bg-accent-brand' uses a value that is not a recognized design token.
-## src/features/lab/GearCard.tsx
-- [ ] Line 89: [Arbitrary Value] -[1px] - Avoid arbitrary values like -[...]. Use design tokens instead.
-- [ ] Line 26: [Raw Layout/Spacing] flex - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
-- [ ] Line 26: [Raw Layout/Spacing] flex-col - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
-- [ ] Line 41: [Non-token Color/Size] text-amber-500 - Class 'text-amber-500' uses a value that is not a recognized design token.
-- [ ] Line 52: [Raw Layout/Spacing] px-1.5 - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
-- [ ] Line 52: [Raw Layout/Spacing] py-0.5 - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
-- [ ] Line 74: [Non-token Color/Size] bg-amber-50/50 - Class 'bg-amber-50/50' uses a value that is not a recognized design token.
-- [ ] Line 74: [Raw Layout/Spacing] px-2 - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
-- [ ] Line 74: [Raw Layout/Spacing] py-0.5 - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
-- [ ] Line 75: [Non-token Color/Size] text-amber-700 - Class 'text-amber-700' uses a value that is not a recognized design token.
-- [ ] Line 90: [Raw Layout/Spacing] ml-auto - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
+- [ ] Line 38: [Arbitrary Value] -[160px] - Avoid arbitrary values like -[...]. Use design tokens instead.
+- [ ] Line 38: [Raw Layout/Spacing] p-6 - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
+- [ ] Line 77: [Raw Layout/Spacing] pb-4 - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
+- [ ] Line 83: [Raw Layout/Spacing] p-2 - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
+- [ ] Line 83: [Non-token Color/Size] hover:bg-muted - Class 'hover:bg-muted' uses a value that is not a recognized design token.
+- [ ] Line 86: [Raw Layout/Spacing] p-2 - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
+- [ ] Line 86: [Non-token Color/Size] hover:bg-muted - Class 'hover:bg-muted' uses a value that is not a recognized design token.
+- [ ] Line 103: [Raw Layout/Spacing] ml-auto - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
 ## src/features/lab/GearPost.tsx
 - [ ] Line 43: [Non-token Color/Size] hover:text-accent-brand - Class 'hover:text-accent-brand' uses a value that is not a recognized design token.
 ## src/features/lab/Toolbox.tsx
@@ -77,13 +67,13 @@ This list is automatically generated from the `npm run audit` report. Fix these 
 - [ ] Line 95: [Non-token Color/Size] group-hover:text-accent-brand - Class 'group-hover:text-accent-brand' uses a value that is not a recognized design token.
 - [ ] Line 107: [Non-token Color/Size] text-slate-300 - Class 'text-slate-300' uses a value that is not a recognized design token.
 ## src/features/research/ResearchDetail.tsx
-- [ ] Line 50: [Non-token Color/Size] hover:text-accent-brand - Class 'hover:text-accent-brand' uses a value that is not a recognized design token.
-- [ ] Line 78: [Non-token Color/Size] hover:text-accent-brand - Class 'hover:text-accent-brand' uses a value that is not a recognized design token.
-- [ ] Line 105: [Non-token Color/Size] text-accent-brand - Class 'text-accent-brand' uses a value that is not a recognized design token.
-- [ ] Line 112: [Non-token Color/Size] text-accent-brand - Class 'text-accent-brand' uses a value that is not a recognized design token.
-- [ ] Line 112: [Non-token Color/Size] text-dim - Class 'text-dim' uses a value that is not a recognized design token.
-- [ ] Line 119: [Non-token Color/Size] bg-accent-brand/5 - Class 'bg-accent-brand/5' uses a value that is not a recognized design token.
-- [ ] Line 121: [Non-token Color/Size] text-accent-brand - Class 'text-accent-brand' uses a value that is not a recognized design token.
+- [ ] Line 49: [Non-token Color/Size] hover:text-accent-brand - Class 'hover:text-accent-brand' uses a value that is not a recognized design token.
+- [ ] Line 77: [Non-token Color/Size] hover:text-accent-brand - Class 'hover:text-accent-brand' uses a value that is not a recognized design token.
+- [ ] Line 104: [Non-token Color/Size] text-accent-brand - Class 'text-accent-brand' uses a value that is not a recognized design token.
+- [ ] Line 111: [Non-token Color/Size] text-accent-brand - Class 'text-accent-brand' uses a value that is not a recognized design token.
+- [ ] Line 111: [Non-token Color/Size] text-dim - Class 'text-dim' uses a value that is not a recognized design token.
+- [ ] Line 118: [Non-token Color/Size] bg-accent-brand/5 - Class 'bg-accent-brand/5' uses a value that is not a recognized design token.
+- [ ] Line 120: [Non-token Color/Size] text-accent-brand - Class 'text-accent-brand' uses a value that is not a recognized design token.
 ## src/pages/UXAuditor.tsx
 - [ ] Line 76: [Arbitrary Value] -[var(--color-success,#16a34a)] - Avoid arbitrary values like -[...]. Use design tokens instead.
 - [ ] Line 174: [Arbitrary Value] -[var(--color-success-dim,#dcfce7)] - Avoid arbitrary values like -[...]. Use design tokens instead.

--- a/TODO_ANTIPATTERNS.md
+++ b/TODO_ANTIPATTERNS.md
@@ -2,8 +2,6 @@
 
 This list is automatically generated from the `npm run audit` report. Fix these anti-patterns to adhere to the project design system.
 
-## src/features/contact/components/ContactFormView.tsx
-- [ ] Line 123: [Raw Layout/Spacing] mt-2 - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
 ## src/features/dashboard/EventCard.tsx
 - [ ] Line 14: [Raw Layout/Spacing] flex - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
 - [ ] Line 14: [Raw Layout/Spacing] flex-col - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
@@ -29,16 +27,28 @@ This list is automatically generated from the `npm run audit` report. Fix these 
 ## src/features/journal/BlogPost.tsx
 - [ ] Line 36: [Non-token Color/Size] hover:text-accent-brand - Class 'hover:text-accent-brand' uses a value that is not a recognized design token.
 ## src/features/journal/components/BlogPostDetail.tsx
-- [ ] Line 39: [Raw Layout/Spacing] flex-1 - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
+- [ ] Line 36: [Raw Layout/Spacing] flex - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
+- [ ] Line 36: [Raw Layout/Spacing] items-center - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
+- [ ] Line 36: [Raw Layout/Spacing] justify-center - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
+- [ ] Line 56: [Non-token Color/Size] hover:text-accent-brand - Class 'hover:text-accent-brand' uses a value that is not a recognized design token.
+- [ ] Line 65: [Raw Layout/Spacing] mb-8 - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
 ## src/features/lab/BlogDrafter.tsx
-- [ ] Line 38: [Arbitrary Value] -[160px] - Avoid arbitrary values like -[...]. Use design tokens instead.
-- [ ] Line 38: [Raw Layout/Spacing] p-6 - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
-- [ ] Line 77: [Raw Layout/Spacing] pb-4 - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
-- [ ] Line 83: [Raw Layout/Spacing] p-2 - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
-- [ ] Line 83: [Non-token Color/Size] hover:bg-muted - Class 'hover:bg-muted' uses a value that is not a recognized design token.
-- [ ] Line 86: [Raw Layout/Spacing] p-2 - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
-- [ ] Line 86: [Non-token Color/Size] hover:bg-muted - Class 'hover:bg-muted' uses a value that is not a recognized design token.
-- [ ] Line 103: [Raw Layout/Spacing] ml-auto - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
+- [ ] Line 26: [Non-token Color/Size] text-accent-brand - Class 'text-accent-brand' uses a value that is not a recognized design token.
+- [ ] Line 31: [Non-token Color/Size] text-accent-brand - Class 'text-accent-brand' uses a value that is not a recognized design token.
+- [ ] Line 31: [Raw Layout/Spacing] mt-1 - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
+- [ ] Line 212: [Non-token Color/Size] hover:bg-accent-brand - Class 'hover:bg-accent-brand' uses a value that is not a recognized design token.
+## src/features/lab/GearCard.tsx
+- [ ] Line 89: [Arbitrary Value] -[1px] - Avoid arbitrary values like -[...]. Use design tokens instead.
+- [ ] Line 26: [Raw Layout/Spacing] flex - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
+- [ ] Line 26: [Raw Layout/Spacing] flex-col - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
+- [ ] Line 41: [Non-token Color/Size] text-amber-500 - Class 'text-amber-500' uses a value that is not a recognized design token.
+- [ ] Line 52: [Raw Layout/Spacing] px-1.5 - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
+- [ ] Line 52: [Raw Layout/Spacing] py-0.5 - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
+- [ ] Line 74: [Non-token Color/Size] bg-amber-50/50 - Class 'bg-amber-50/50' uses a value that is not a recognized design token.
+- [ ] Line 74: [Raw Layout/Spacing] px-2 - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
+- [ ] Line 74: [Raw Layout/Spacing] py-0.5 - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
+- [ ] Line 75: [Non-token Color/Size] text-amber-700 - Class 'text-amber-700' uses a value that is not a recognized design token.
+- [ ] Line 90: [Raw Layout/Spacing] ml-auto - Use <Box />, <Stack />, or <Grid /> primitives for layout and spacing.
 ## src/features/lab/GearPost.tsx
 - [ ] Line 43: [Non-token Color/Size] hover:text-accent-brand - Class 'hover:text-accent-brand' uses a value that is not a recognized design token.
 ## src/features/lab/Toolbox.tsx
@@ -67,13 +77,13 @@ This list is automatically generated from the `npm run audit` report. Fix these 
 - [ ] Line 95: [Non-token Color/Size] group-hover:text-accent-brand - Class 'group-hover:text-accent-brand' uses a value that is not a recognized design token.
 - [ ] Line 107: [Non-token Color/Size] text-slate-300 - Class 'text-slate-300' uses a value that is not a recognized design token.
 ## src/features/research/ResearchDetail.tsx
-- [ ] Line 49: [Non-token Color/Size] hover:text-accent-brand - Class 'hover:text-accent-brand' uses a value that is not a recognized design token.
-- [ ] Line 77: [Non-token Color/Size] hover:text-accent-brand - Class 'hover:text-accent-brand' uses a value that is not a recognized design token.
-- [ ] Line 104: [Non-token Color/Size] text-accent-brand - Class 'text-accent-brand' uses a value that is not a recognized design token.
-- [ ] Line 111: [Non-token Color/Size] text-accent-brand - Class 'text-accent-brand' uses a value that is not a recognized design token.
-- [ ] Line 111: [Non-token Color/Size] text-dim - Class 'text-dim' uses a value that is not a recognized design token.
-- [ ] Line 118: [Non-token Color/Size] bg-accent-brand/5 - Class 'bg-accent-brand/5' uses a value that is not a recognized design token.
-- [ ] Line 120: [Non-token Color/Size] text-accent-brand - Class 'text-accent-brand' uses a value that is not a recognized design token.
+- [ ] Line 50: [Non-token Color/Size] hover:text-accent-brand - Class 'hover:text-accent-brand' uses a value that is not a recognized design token.
+- [ ] Line 78: [Non-token Color/Size] hover:text-accent-brand - Class 'hover:text-accent-brand' uses a value that is not a recognized design token.
+- [ ] Line 105: [Non-token Color/Size] text-accent-brand - Class 'text-accent-brand' uses a value that is not a recognized design token.
+- [ ] Line 112: [Non-token Color/Size] text-accent-brand - Class 'text-accent-brand' uses a value that is not a recognized design token.
+- [ ] Line 112: [Non-token Color/Size] text-dim - Class 'text-dim' uses a value that is not a recognized design token.
+- [ ] Line 119: [Non-token Color/Size] bg-accent-brand/5 - Class 'bg-accent-brand/5' uses a value that is not a recognized design token.
+- [ ] Line 121: [Non-token Color/Size] text-accent-brand - Class 'text-accent-brand' uses a value that is not a recognized design token.
 ## src/pages/UXAuditor.tsx
 - [ ] Line 76: [Arbitrary Value] -[var(--color-success,#16a34a)] - Avoid arbitrary values like -[...]. Use design tokens instead.
 - [ ] Line 174: [Arbitrary Value] -[var(--color-success-dim,#dcfce7)] - Avoid arbitrary values like -[...]. Use design tokens instead.

--- a/src/components/layout/DetailLayout.tsx
+++ b/src/components/layout/DetailLayout.tsx
@@ -3,6 +3,7 @@ import { ArrowLeft } from 'lucide-react';
 import { Box, Stack, Text, Grid } from '@/layouts/Primitives';
 import { MarkdownRenderer } from '@/components/ui/MarkdownRenderer';
 import { readingTime } from '@/lib/content';
+import { useImage } from '@/hooks/useImage';
 
 interface DetailLayoutProps {
   title: string;
@@ -32,6 +33,7 @@ export function DetailLayout({
   relatedContent
 }: DetailLayoutProps) {
   const rt = readingTime(content);
+  const { imgError, handleError } = useImage(image);
 
   return (
     <Box as="article" padding="panel">
@@ -71,7 +73,7 @@ export function DetailLayout({
           </Stack>
 
           {/* Hero Image */}
-          {image && (
+          {image && !imgError && (
             <Box
               as={motion.div}
               initial={{ opacity: 0, y: 20 }}
@@ -84,6 +86,7 @@ export function DetailLayout({
               <img
                 src={image}
                 alt={title}
+                onError={handleError}
                 className="w-full h-full object-cover"
               />
             </Box>

--- a/src/components/ui/CardImagePlaceholder.tsx
+++ b/src/components/ui/CardImagePlaceholder.tsx
@@ -6,9 +6,18 @@ interface CardImagePlaceholderProps {
   category: string;
   date?: string;
   title: string;
+  onError?: () => void;
+  forcePlaceholder?: boolean;
 }
 
-export function CardImagePlaceholder({ image, category, date, title }: CardImagePlaceholderProps) {
+export function CardImagePlaceholder({
+  image,
+  category,
+  date,
+  title,
+  onError,
+  forcePlaceholder
+}: CardImagePlaceholderProps) {
   const norm = (category || '').toLowerCase();
 
   let surfaceVariant: "brand" | "accent" | "warning" | "danger" | "muted" = 'muted';
@@ -17,12 +26,13 @@ export function CardImagePlaceholder({ image, category, date, title }: CardImage
   else if (norm.includes('gear')) surfaceVariant = 'warning';
   else if (norm.includes('lifestyle')) surfaceVariant = 'danger';
 
-  if (image) {
+  if (image && !forcePlaceholder) {
     return (
       <Box className="relative w-full aspect-video max-h-[160px] overflow-hidden border-b border-line bg-bg">
         <img
           src={image}
           alt={title}
+          onError={onError}
           className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-700"
         />
         <Box className="absolute top-3 left-3">

--- a/src/components/ui/ContentCard.tsx
+++ b/src/components/ui/ContentCard.tsx
@@ -3,7 +3,7 @@ import { motion, HTMLMotionProps } from 'motion/react';
 import { Box, Stack, Text } from '@/layouts/Primitives';
 import { readingTime } from '@/lib/content';
 import { CardImagePlaceholder } from '@/components/ui/CardImagePlaceholder';
-import { CategoryPlaceholder } from '@/components/ui/CategoryPlaceholder';
+import { useImage } from '@/hooks/useImage';
 
 interface ContentCardProps extends Partial<HTMLMotionProps<"a">> {
   slug: string;
@@ -20,6 +20,7 @@ interface ContentCardProps extends Partial<HTMLMotionProps<"a">> {
 
 export function ContentCard({ slug, title, category, excerpt, date, image, basePath, content, ...motionProps }: ContentCardProps) {
   const rt = readingTime(content, excerpt);
+  const { imgError, handleError } = useImage(image);
 
   return (
     <Box 
@@ -30,40 +31,13 @@ export function ContentCard({ slug, title, category, excerpt, date, image, baseP
       className="group flex flex-col h-full bg-surface border border-line hover:border-accent hover:shadow-xl hover:-translate-y-1 transition-all duration-300 overflow-hidden"
       {...motionProps}
     >
-      {/* Visual Thumbnail */}
-      <Box className="relative aspect-video overflow-hidden border-b border-line bg-bg max-h-[160px]">
-        {image ? (
-          <img 
-            src={image} 
-            alt={title} 
-            className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-700"
-          />
-        ) : (
-          <Box className="w-full h-full flex flex-col">
-            <Box className="h-4 w-full" surface={
-              (category || '').toLowerCase().includes('tech') ? 'brand' :
-              (category || '').toLowerCase().includes('travel') || (category || '').toLowerCase().includes('wcs') ? 'accent' :
-              (category || '').toLowerCase().includes('gear') ? 'warning' :
-              (category || '').toLowerCase().includes('lifestyle') ? 'danger' : 'muted'
-            } />
-            <Box className="flex-1 flex items-center justify-center bg-muted/10">
-              <CategoryPlaceholder category={category} size="md" />
-            </Box>
-          </Box>
-        )}
-        <Box className="absolute top-4 left-4">
-          <Box className="px-3 py-1 bg-surface/90 backdrop-blur-sm border border-line rounded-sm">
-            <Text variant="mono" size="micro" weight="font-bold" className="text-accent-navy uppercase tracking-wider">
-              {category}
-            </Text>
-          </Box>
-        </Box>
-      </Box>
       <CardImagePlaceholder
         image={image}
         category={category}
         date={date}
         title={title}
+        onError={handleError}
+        forcePlaceholder={imgError}
       />
 
       {/* Content Area */}

--- a/src/features/lab/GearCard.tsx
+++ b/src/features/lab/GearCard.tsx
@@ -2,6 +2,7 @@ import { NavLink } from 'react-router-dom';
 import { Box, Stack, Text } from '@/layouts/Primitives';
 import { Resource } from '@/lib/content';
 import { CardImagePlaceholder } from '@/components/ui/CardImagePlaceholder';
+import { useImage } from '@/hooks/useImage';
 
 interface GearCardProps extends Resource {
   basePath: string;
@@ -19,17 +20,28 @@ export function GearCard({
   priceCategory,
   updatedDate
 }: GearCardProps) {
+  const { imgError, handleError } = useImage(image);
+
   return (
     <Box
       as={NavLink}
       to={`${basePath}/${slug}`}
-      className="group flex flex-col h-full bg-surface border border-line hover:border-accent transition-all duration-300 rounded-none overflow-hidden"
+      display="flex"
+      direction="col"
+      height="full"
+      surface="default"
+      border
+      radius="none"
+      overflow="hidden"
+      className="group hover:border-accent transition-all duration-300"
     >
       <CardImagePlaceholder
         image={image}
         category={category}
         date={updatedDate}
         title={title}
+        onError={handleError}
+        forcePlaceholder={imgError}
       />
 
       {/* Content Area */}
@@ -38,10 +50,10 @@ export function GearCard({
           <Box display="flex" align="center" justify="between" wrap>
             {rating && (
               <Box display="flex" align="center" gap={1}>
-                <span className="text-amber-500 text-xs">
+                <Text color="warning" size="xs">
                   {'★'.repeat(Math.floor(rating))}
                   {rating % 1 !== 0 ? '½' : ''}
-                </span>
+                </Text>
                 <Text variant="mono" size="micro" color="dim">
                   ({rating}/5)
                 </Text>
@@ -49,7 +61,7 @@ export function GearCard({
             )}
 
             {verdict && (
-              <Box surface="brand" className="px-1.5 py-0.5 rounded-none border border-line/10">
+              <Box surface="brand" paddingX={1.5} paddingY={0.5} radius="none" border className="border-line/10">
                 <Text variant="mono" size="micro" weight="font-bold" className="uppercase">
                   {verdict}
                 </Text>
@@ -71,8 +83,8 @@ export function GearCard({
           </Text>
 
           {priceCategory && (
-             <Box border className="bg-amber-50/50 px-2 py-0.5 border-amber-200/50 w-fit">
-               <Text variant="mono" size="micro" weight="font-bold" className="text-amber-700">{priceCategory}</Text>
+             <Box border surface="warning" paddingX={2} paddingY={0.5} width="fit" opacity={10} className="border-warning/20">
+               <Text variant="mono" size="micro" weight="font-bold" color="warning">{priceCategory}</Text>
              </Box>
           )}
         </Stack>
@@ -82,12 +94,12 @@ export function GearCard({
             * Affiliate links — commission earned at no cost to you.
           </Text>
 
-          <Box display="flex" align="center" gap={2} paddingTop={4} className="border-t border-line/50">
+          <Box display="flex" align="center" gap={2} paddingTop={4} border="t" className="border-line/50">
             <Text variant="mono" size="xs" weight="font-bold" className="text-accent tracking-wider">
               Read Review
             </Text>
-            <Box className="w-0 h-[1px] bg-accent group-hover:w-6 transition-all duration-500" />
-            <Box className="group-hover:translate-x-1 transition-transform duration-300 ml-auto">
+            <Box height={1} surface="accent" className="w-0 group-hover:w-6 transition-all duration-500" />
+            <Box marginLeft="auto" className="group-hover:translate-x-1 transition-transform duration-300">
               <svg
                 xmlns="http://www.w3.org/2000/svg"
                 width="14"

--- a/src/hooks/useImage.ts
+++ b/src/hooks/useImage.ts
@@ -1,0 +1,25 @@
+import { useState, useCallback } from 'react';
+
+/**
+ * Hook to manage image loading states and errors.
+ * Centralizes image error state logic to reduce component clutter.
+ */
+export function useImage(src?: string) {
+  const [imgError, setImgError] = useState(false);
+  const [prevSrc, setPrevSrc] = useState(src);
+
+  // Reset error state when src changes
+  if (src !== prevSrc) {
+    setPrevSrc(src);
+    setImgError(false);
+  }
+
+  const handleError = useCallback(() => {
+    setImgError(true);
+  }, []);
+
+  return {
+    imgError,
+    handleError
+  };
+}


### PR DESCRIPTION
Abstracted manual image error handling into a centralized `useImage` hook. This hook was applied to `ContentCard`, `GearCard`, and `DetailLayout` to simplify component logic and ensure a consistent fallback experience when images fail to load. Additionally, `GearCard` was refactored to use design system primitives, and `CardImagePlaceholder` was enhanced to support the hook's error state.

Fixes #251

---
*PR created automatically by Jules for task [1198738515988844716](https://jules.google.com/task/1198738515988844716) started by @arii*