### PR TITLE
Centralize UI Animation System

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,10 +40,7 @@ export function RootLayout() {
           <Box
             as={motion.div}
             key={location.pathname}
-            initial={motionTokens.page.initial}
-            animate={motionTokens.page.animate}
-            exit={motionTokens.page.exit}
-            transition={motionTokens.page.transition}
+            {...motionTokens.page}
             height="full"
           >
             <Suspense fallback={<PageSkeleton />}>

--- a/src/components/ui/FolioGrid.tsx
+++ b/src/components/ui/FolioGrid.tsx
@@ -83,10 +83,10 @@ export default function FolioGrid({
           <motion.div
             key="card-view"
             variants={motionTokens.staggerContainer}
-            initial="initial"
-            whileInView="animate"
+            initial="hidden"
+            whileInView="show"
             viewport={{ once: true, margin: "-50px" }}
-            exit="initial"
+            exit="exit"
           >
             <Grid cols={{ base: 1, md: 2, xl: 3, "2xl": 4 }} gap={0} border="t" className="border-l border-line mt-8">
               {filteredItems.map((item, index) => (

--- a/src/components/ui/FolioGrid.tsx
+++ b/src/components/ui/FolioGrid.tsx
@@ -8,6 +8,7 @@ import { ListRow } from '@/components/ui/ListRow';
 import { ContentItem } from '@/lib/content';
 import { motion, AnimatePresence } from 'motion/react';
 import { motionTokens } from '@/styles/motion';
+import { fadeIn } from '@/lib/animations';
 
 interface FolioGridProps {
   items: ContentItem[];
@@ -110,10 +111,7 @@ export default function FolioGrid({
         ) : (
           <motion.div
             key="list-view"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            transition={{ duration: 0.2 }}
+            {...fadeIn}
           >
             <Stack gap={0} border="t" className="border-line mt-8">
               {filteredItems.map((item) => (

--- a/src/features/dashboard/Dashboard.tsx
+++ b/src/features/dashboard/Dashboard.tsx
@@ -9,6 +9,7 @@ import PathSelector from '@/components/ui/PathSelector';
 import { ContentCard } from '@/components/ui/ContentCard';
 import { EventCard } from './EventCard';
 import { motionTokens } from '@/styles/motion';
+import { fadeInUp } from '@/lib/animations';
 
 export default function Home() {
   const { recentPosts, upcomingEvents } = useHome();
@@ -24,8 +25,7 @@ export default function Home() {
           <Stack gap={4}>
             <Text 
               as={motion.h1}
-              initial={{ opacity: 0, y: 20 }}
-              animate={{ opacity: 1, y: 0 }}
+              {...fadeInUp}
               variant="headline" 
               size="fluid-7"
               className="text-accent-navy leading-tight tracking-tight max-w-4xl"
@@ -63,8 +63,8 @@ export default function Home() {
             gap={4}
             as={motion.div}
             variants={motionTokens.staggerContainer}
-            initial="initial"
-            whileInView="animate"
+            initial="hidden"
+            whileInView="show"
             viewport={{ once: true, margin: "-50px" }}
           >
             {recentPosts.map((post) => (

--- a/src/lib/animations.ts
+++ b/src/lib/animations.ts
@@ -1,0 +1,57 @@
+/**
+ * Standard Animation Variants for the Portfolio.
+ * Ensures consistent motion across the entire application shell.
+ */
+
+export const easeOutExpo = [0.16, 1, 0.3, 1] as [number, number, number, number];
+
+export const fadeIn = {
+  initial: { opacity: 0 },
+  animate: { opacity: 1 },
+  exit: { opacity: 0 },
+  transition: { duration: 0.3 }
+};
+
+export const fadeInUp = {
+  initial: { opacity: 0, y: 20 },
+  animate: { opacity: 1, y: 0 },
+  exit: { opacity: 0, y: -20 },
+  transition: { duration: 0.5, ease: easeOutExpo }
+};
+
+export const staggerContainer = {
+  hidden: { opacity: 0 },
+  show: {
+    opacity: 1,
+    transition: {
+      staggerChildren: 0.1,
+      delayChildren: 0.1
+    }
+  },
+  exit: {
+    opacity: 0,
+    transition: {
+      staggerChildren: 0.05,
+      staggerDirection: -1
+    }
+  }
+};
+
+export const staggerItem = {
+  hidden: { opacity: 0, y: 20 },
+  show: {
+    opacity: 1,
+    y: 0,
+    transition: {
+      duration: 0.6,
+      ease: easeOutExpo
+    }
+  },
+  exit: {
+    opacity: 0,
+    y: -20,
+    transition: {
+      duration: 0.3
+    }
+  }
+};

--- a/src/styles/motion.ts
+++ b/src/styles/motion.ts
@@ -1,17 +1,11 @@
+import { fadeInUp, staggerContainer, staggerItem } from "@/lib/animations";
+
 /**
  * Standardized Motion Tokens.
  * Ensures consistent transitions across the entire application shell.
  */
 export const motionTokens = {
-  page: {
-    initial: { opacity: 0, y: 8 },
-    animate: { opacity: 1, y: 0 },
-    exit: { opacity: 0 },
-    transition: { 
-      duration: 0.3, 
-      ease: [0.22, 1, 0.36, 1] as [number, number, number, number] 
-    }
-  },
+  page: fadeInUp,
   overlay: {
     initial: { y: 100 },
     animate: { y: 0 },
@@ -22,25 +16,6 @@ export const motionTokens = {
     scale: 1.02,
     transition: { duration: 0.2 }
   },
-  staggerContainer: {
-    initial: { opacity: 0 },
-    animate: {
-      opacity: 1,
-      transition: {
-        staggerChildren: 0.05,
-        delayChildren: 0.1
-      }
-    }
-  },
-  staggerItem: {
-    initial: { opacity: 0, y: 10 },
-    animate: {
-      opacity: 1,
-      y: 0,
-      transition: {
-        duration: 0.4,
-        ease: [0.25, 1, 0.5, 1] as [number, number, number, number]
-      }
-    }
-  }
+  staggerContainer,
+  staggerItem
 };


### PR DESCRIPTION
This PR centralizes the UI animation system into `src/lib/animations.ts` as requested. It standardizes timing, stagger delays, and bezier curves across the application shell.

Key changes:
- New `src/lib/animations.ts` containing `easeOutExpo`, `fadeIn`, `fadeInUp`, `staggerContainer`, and `staggerItem`.
- `motionTokens` in `src/styles/motion.ts` now re-exports these standard variants.
- Page transitions in `App.tsx` now use the centralized `fadeInUp` token.
- `FolioGrid` and `Dashboard` grids now use the centralized stagger variants. Note: `staggerContainer` and `staggerItem` now use `hidden` and `show` as variant keys.
- Dashboard's main headline now uses the centralized `fadeInUp` animation.

Fixes #173

---
*PR created automatically by Jules for task [3673595245809827397](https://jules.google.com/task/3673595245809827397) started by @arii*