### PR TITLE
Remove redundant React imports

### DIFF
--- a/src/components/layout/DetailElements.tsx
+++ b/src/components/layout/DetailElements.tsx
@@ -1,3 +1,4 @@
+import { type ReactNode } from 'react';
 import { Box, Stack, Text } from '@/layouts/Primitives';
 import { LucideIcon, Shield } from 'lucide-react';
 
@@ -21,7 +22,7 @@ export function ScoreItem({ label, value, icon: Icon, color, intent }: ScoreItem
   );
 }
 
-export function ScoreGrid({ children }: { children: React.ReactNode }) {
+export function ScoreGrid({ children }: { children: ReactNode }) {
   return (
     <Box
       border="y"

--- a/src/components/layout/DetailLayout.tsx
+++ b/src/components/layout/DetailLayout.tsx
@@ -1,3 +1,4 @@
+import { type ReactNode } from 'react';
 import { motion } from 'motion/react';
 import { ArrowLeft } from 'lucide-react';
 import { Box, Stack, Text, Grid } from '@/layouts/Primitives';
@@ -12,10 +13,10 @@ interface DetailLayoutProps {
   image?: string;
   onBack: () => void;
   backLabel: string;
-  sidebar?: React.ReactNode;
-  children?: React.ReactNode;
-  headerExtras?: React.ReactNode;
-  relatedContent?: React.ReactNode;
+  sidebar?: ReactNode;
+  children?: ReactNode;
+  headerExtras?: ReactNode;
+  relatedContent?: ReactNode;
 }
 
 export function DetailLayout({

--- a/src/components/ui/FolioGrid.tsx
+++ b/src/components/ui/FolioGrid.tsx
@@ -1,3 +1,4 @@
+import { type ReactNode, type ChangeEvent } from 'react';
 import { useSearchParam } from '@/hooks/useSearchParam';
 import { ContentCard } from '@/components/ui/ContentCard';
 import { PageHeader } from '@/components/ui/PageHeader';
@@ -15,7 +16,7 @@ interface FolioGridProps {
   basePath: string;
   label?: string;
   description?: string;
-  children?: React.ReactNode;
+  children?: ReactNode;
   view?: ViewMode;
   onViewChange?: (v: ViewMode) => void;
   as?: keyof JSX.IntrinsicElements;
@@ -69,7 +70,7 @@ export default function FolioGrid({
               size="sm"
               className="focus:border-accent outline-none focus:ring-0"
               value={search}
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setSearch(e.target.value)}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => setSearch(e.target.value)}
             />
           </Box>
           {onViewChange && (

--- a/src/components/ui/PageHeader.tsx
+++ b/src/components/ui/PageHeader.tsx
@@ -1,3 +1,4 @@
+import { type ReactNode } from 'react';
 import { Box, Stack, Text } from '@/layouts/Primitives';
 import type { BaseProps } from '@/layouts/Box';
 
@@ -41,7 +42,7 @@ export function PageHeader({ label, title, description, as = "h1", paddingBottom
   );
 }
 
-export function SectionHeader({ label, title, children }: { label: string; title: string; children?: React.ReactNode }) {
+export function SectionHeader({ label, title, children }: { label: string; title: string; children?: ReactNode }) {
   return (
     <Box display="flex" justify="between" align="end" border="b" paddingBottom={4} className="border-slate-200">
       <Stack gap={1}>

--- a/src/components/ui/ScrollToTopButton.tsx
+++ b/src/components/ui/ScrollToTopButton.tsx
@@ -1,11 +1,11 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, type RefObject } from 'react';
 import { ArrowUp } from 'lucide-react';
 import { motion, AnimatePresence } from 'motion/react';
 import { Button } from '@/layouts/Primitives';
 import { iconSizes } from '@/styles/design-tokens';
 
 interface ScrollToTopButtonProps {
-  scrollRef: React.RefObject<HTMLElement | null>;
+  scrollRef: RefObject<HTMLElement | null>;
 }
 
 export function ScrollToTopButton({ scrollRef }: ScrollToTopButtonProps) {

--- a/src/features/contact/components/ContactFormView.tsx
+++ b/src/features/contact/components/ContactFormView.tsx
@@ -3,7 +3,7 @@ import { Box, Stack, Text, Grid, Button } from '@/layouts/Primitives';
 import { PageHeader } from '@/components/ui/PageHeader';
 import { FormField } from './FormField';
 import { cn } from '@/lib/utils';
-import React from 'react';
+import type { BaseSyntheticEvent } from 'react';
 import { UseFormRegister, FieldErrors } from 'react-hook-form';
 
 interface ContactFormData {
@@ -17,7 +17,7 @@ interface ContactFormViewProps {
   register: UseFormRegister<ContactFormData>;
   errors: FieldErrors<ContactFormData>;
   isSubmitting: boolean;
-  onSubmit: (e?: React.BaseSyntheticEvent) => Promise<void>;
+  onSubmit: (e?: BaseSyntheticEvent) => Promise<void>;
 }
 
 const inputClasses = "w-full min-h-12 bg-bg border px-4 py-3 text-base sm:text-sm font-sans rounded-lg transition-all focus:outline-none focus:border-accent focus:ring-2 focus:ring-accent/20 placeholder:text-text-dim/50";

--- a/src/features/contact/components/FormField.tsx
+++ b/src/features/contact/components/FormField.tsx
@@ -1,10 +1,10 @@
-import React, { useId } from 'react';
+import { useId, cloneElement, type ReactElement } from 'react';
 import { Box, Stack, Text } from '@/layouts/Primitives';
 
 interface FormFieldProps {
   label: string;
   error?: string;
-  children: React.ReactElement;
+  children: ReactElement;
 }
 
 export function FormField({ label, error, children }: FormFieldProps) {
@@ -23,7 +23,7 @@ export function FormField({ label, error, children }: FormFieldProps) {
           </Text>
         )}
       </Box>
-      {React.cloneElement(children, {
+      {cloneElement(children, {
         id,
         'aria-describedby': error ? errorId : undefined,
         'aria-invalid': !!error

--- a/src/features/email-capture/EmailForm.tsx
+++ b/src/features/email-capture/EmailForm.tsx
@@ -1,3 +1,4 @@
+import { type FormEvent, type ChangeEvent } from 'react';
 import { Stack, Box, Text, Button } from '@/layouts/Primitives';
 import { motion, AnimatePresence } from 'motion/react';
 import { ArrowRight, Loader2, Check } from 'lucide-react';
@@ -7,7 +8,7 @@ import { useEmailForm } from './useEmailForm';
 export function EmailForm() {
   const { status, email, setEmail, submitForm } = useEmailForm();
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = (e: FormEvent) => {
     e.preventDefault();
     submitForm(email);
   };
@@ -20,7 +21,7 @@ export function EmailForm() {
           type="email"
           placeholder="Email Address"
           value={email}
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEmail(e.target.value)}
+          onChange={(e: ChangeEvent<HTMLInputElement>) => setEmail(e.target.value)}
           required
           disabled={status === 'loading' || status === 'success'}
           className={inputs.base}

--- a/src/features/lab/Toolbox.tsx
+++ b/src/features/lab/Toolbox.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, type ChangeEvent } from 'react';
 import { Box, Grid, Text, Stack } from '@/layouts/Primitives';
 import { SEO } from '@/components/SEO';
 import { useToolbox } from './useToolbox';
@@ -45,7 +45,7 @@ export default function Toolbox() {
               paddingRight={4}
               paddingY={3}
               className="bg-surface border border-line rounded-none focus:ring-4 focus:ring-accent/10 outline-none transition-all text-base md:text-sm"
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setSearchTerm(e.target.value)}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => setSearchTerm(e.target.value)}
               value={searchTerm}
             />
             <svg

--- a/src/hooks/useHotkeys.ts
+++ b/src/hooks/useHotkeys.ts
@@ -1,8 +1,8 @@
-import { useEffect } from 'react';
+import { useEffect, type DependencyList } from 'react';
 
 type HotkeyHandler = (event: KeyboardEvent) => void;
 
-export function useHotkeys(key: string, handler: HotkeyHandler, deps: React.DependencyList = []) {
+export function useHotkeys(key: string, handler: HotkeyHandler, deps: DependencyList = []) {
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === key) {
@@ -15,7 +15,7 @@ export function useHotkeys(key: string, handler: HotkeyHandler, deps: React.Depe
   }, [key, ...deps]);
 }
 
-export function useCommandKey(key: string, handler: HotkeyHandler, deps: React.DependencyList = []) {
+export function useCommandKey(key: string, handler: HotkeyHandler, deps: DependencyList = []) {
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === key.toLowerCase()) {

--- a/src/layouts/Box.tsx
+++ b/src/layouts/Box.tsx
@@ -1,4 +1,4 @@
-import * as React from "react"
+import { forwardRef, type HTMLAttributes, type ElementType } from "react"
 import { cn, composeStyles } from "@/lib/utils"
 import { spacing, layout as layoutTokens, shadows, zIndex as zIndexTokens } from "@/styles/design-tokens"
 import { variants } from "@/lib/variants"
@@ -59,12 +59,12 @@ export interface BaseProps {
   left?: ResponsiveProp<keyof typeof spacing | number | string>
 }
 
-export interface BoxProps extends BaseProps, React.HTMLAttributes<HTMLDivElement> {
-  as?: React.ElementType
+export interface BoxProps extends BaseProps, HTMLAttributes<HTMLDivElement> {
+  as?: ElementType
   [key: string]: unknown
 }
 
-export const Box = React.forwardRef<HTMLDivElement, BoxProps>(
+export const Box = forwardRef<HTMLDivElement, BoxProps>(
   ({ 
     className, 
     as: Component = "div", 

--- a/src/layouts/Button.tsx
+++ b/src/layouts/Button.tsx
@@ -1,4 +1,4 @@
-import * as React from "react"
+import { forwardRef, type ElementType, type ButtonHTMLAttributes, type Ref } from "react"
 import { cn } from "@/lib/utils"
 import { buttonVariants } from "@/lib/variants"
 import { type VariantProps } from "class-variance-authority"
@@ -6,19 +6,19 @@ import { Box, BaseProps } from "./Box"
 
 interface ButtonProps
   extends BaseProps,
-    Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'color'>,
+    Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'color'>,
     VariantProps<typeof buttonVariants> {
-  as?: React.ElementType
+  as?: ElementType
   href?: string
   loading?: boolean
 }
 
-export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, as = "button", variant, intent, size, fullWidth, loading: _loading, children, ...props }, ref) => {
     return (
       <Box
         as={as}
-        ref={ref as React.Ref<HTMLDivElement>}
+        ref={ref as Ref<HTMLDivElement>}
         cursor="pointer"
         className={cn(buttonVariants({ variant, intent, size, fullWidth }), className)}
         {...props}

--- a/src/layouts/Grid.tsx
+++ b/src/layouts/Grid.tsx
@@ -1,4 +1,4 @@
-import * as React from "react"
+import { forwardRef } from "react"
 import { composeStyles } from "@/lib/utils"
 import { Box, BoxProps } from "./Box"
 import { ResponsiveProp, getResponsiveClasses } from "./system-utils"
@@ -8,7 +8,7 @@ interface GridProps extends BoxProps {
   rows?: ResponsiveProp<number | string>
 }
 
-export const Grid = React.forwardRef<HTMLDivElement, GridProps>(
+export const Grid = forwardRef<HTMLDivElement, GridProps>(
   ({ className, cols = 12, rows, ...props }, ref) => {
     return (
       <Box

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -1,4 +1,4 @@
-import { useRef, useLayoutEffect } from 'react';
+import { useRef, useLayoutEffect, type ReactNode } from 'react';
 import { useLocation, useNavigationType } from 'react-router-dom';
 import { Box, Stack } from '@/layouts/Primitives';
 import Navigation from '@/components/Navigation';
@@ -7,7 +7,7 @@ import { GlobalSearch } from '@/components/GlobalSearch';
 import { useEmailStore } from '@/features/email-capture/emailStore';
 import { ScrollToTopButton } from '@/components/ui/ScrollToTopButton';
 
-export function MainLayout({ children }: { children: React.ReactNode }) {
+export function MainLayout({ children }: { children: ReactNode }) {
   const showEmailBar = useEmailStore((state) => state.showEmailBar);
   const scrollRef = useRef<HTMLElement | null>(null);
   const { pathname, key } = useLocation();

--- a/src/layouts/Stack.tsx
+++ b/src/layouts/Stack.tsx
@@ -1,4 +1,4 @@
-import * as React from "react"
+import { forwardRef } from "react"
 import { composeStyles } from "@/lib/utils"
 import { Box, BoxProps } from "./Box"
 import { ResponsiveProp, getResponsiveClasses } from "./system-utils"
@@ -9,7 +9,7 @@ interface StackProps extends Omit<BoxProps, "align" | "justify"> {
   justify?: ResponsiveProp<"start" | "center" | "end" | "between" | "around" | "evenly">
 }
 
-export const Stack = React.forwardRef<HTMLDivElement, StackProps>(
+export const Stack = forwardRef<HTMLDivElement, StackProps>(
   ({ className, direction = "col", gap = 4, align, justify, ...props }, ref) => {
     const directionMapper = (d: string) => d === "col" ? "flex-col" : "flex-row"
     const alignMapper = (a: string) => {

--- a/src/layouts/Text.tsx
+++ b/src/layouts/Text.tsx
@@ -1,12 +1,12 @@
-import * as React from "react"
+import { forwardRef, type ElementType, type HTMLAttributes, type Ref } from "react"
 import { composeStyles } from "@/lib/utils"
 import { typography, typeSizes, tracking as trackingTokens } from "@/styles/design-tokens"
 import { variants } from "@/lib/variants"
 import { Box, BaseProps } from "./Box"
 import { getResponsiveClasses, type ResponsiveProp } from "./system-utils"
 
-export interface TextProps extends Omit<BaseProps, "align">, Omit<React.HTMLAttributes<HTMLElement>, "color"> {
-  as?: React.ElementType
+export interface TextProps extends Omit<BaseProps, "align">, Omit<HTMLAttributes<HTMLElement>, "color"> {
+  as?: ElementType
   className?: string
   variant?: keyof typeof typography
   intent?: keyof typeof variants.intent
@@ -21,7 +21,7 @@ export interface TextProps extends Omit<BaseProps, "align">, Omit<React.HTMLAttr
   [key: string]: unknown
 }
 
-export const Text = React.forwardRef<HTMLElement, TextProps>(
+export const Text = forwardRef<HTMLElement, TextProps>(
   ({ 
     className, as: Component = "span", 
     variant, intent, color = "main", size, weight, align, tracking, 
@@ -31,7 +31,7 @@ export const Text = React.forwardRef<HTMLElement, TextProps>(
     return (
       <Box
         as={Component}
-        ref={ref as React.Ref<HTMLDivElement>}
+        ref={ref as Ref<HTMLDivElement>}
         className={composeStyles(
           variant && typography[variant],
           intent && variants.intent[intent],

--- a/src/layouts/system-utils.ts
+++ b/src/layouts/system-utils.ts
@@ -1,4 +1,4 @@
-import React from "react"
+import { isValidElement } from "react"
 import { cn } from "@/lib/utils"
 
 export type ResponsiveProp<T> = T | { base?: T, sm?: T, md?: T, lg?: T, xl?: T }
@@ -9,7 +9,7 @@ export function getResponsiveClasses(
   mapper?: (val: string | number | boolean | undefined | null) => string | number | undefined
 ) {
   if (prop === undefined || prop === null) return ""
-  if (typeof prop !== "object" || React.isValidElement(prop)) {
+  if (typeof prop !== "object" || isValidElement(prop)) {
     const val = mapper ? mapper(prop) : prop
     return val ? `${classPrefix}${val}` : ""
   }

--- a/src/pages/UXAuditor.tsx
+++ b/src/pages/UXAuditor.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState, useEffect } from 'react';
 import type { ChangeEvent } from 'react';
 import {
   Camera, CheckCircle, RefreshCw,
@@ -20,7 +20,7 @@ function CopyPromptButton({ suggestion }: { suggestion: string }) {
   const [copied, setCopied] = useState(false);
   const [isCopying, setIsCopying] = useState(false);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (!copied) return;
     const timer = setTimeout(() => {
       if (document.startViewTransition) {


### PR DESCRIPTION
This PR removes redundant React imports from the codebase. With the introduction of the new JSX transform in React 17+, explicitly importing React in every file that uses JSX is no longer necessary.

Summary of changes:
- Removed `import React from 'react'` and `import * as React from 'react'` from various files.
- Replaced `React.` prefixed usages with direct named imports for:
  - Hooks: `useState`, `useEffect`, `useId`.
  - Utilities: `isValidElement`, `cloneElement`, `forwardRef`.
  - Types: `ElementType`, `ButtonHTMLAttributes`, `HTMLAttributes`, `Ref`, `ReactElement`, `BaseSyntheticEvent`.
- Updated core layout primitives and feature components to follow these modern React standards.
- Verified that all changes pass linting and E2E tests.

Fixes #247

---
*PR created automatically by Jules for task [7079650658155057364](https://jules.google.com/task/7079650658155057364) started by @arii*