### PR TITLE
Cleanup legacy TypeScript decorator flags

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -4,8 +4,6 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "strict": false,
-    "experimentalDecorators": true,
-    "useDefineForClassFields": false,
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
     "esModuleInterop": true,


### PR DESCRIPTION
This change removes legacy TypeScript decorator flags (`experimentalDecorators` and `useDefineForClassFields`) from the base TypeScript configuration. Removing these flags aligns the project with modern ECMAScript decorator standards and ensures that class fields behave as expected in ES2022+. 

Comprehensive verification was performed, including:
- Type checking (`pnpm run type-check`)
- Linting (`pnpm run lint`)
- UI audit (`pnpm run audit`)
- Production build (`pnpm run build`)
- E2E tests (`pnpm test:e2e`)

All checks passed, confirming that the codebase and its dependencies do not require legacy decorator support.

Fixes #81

---
*PR created automatically by Jules for task [13264745500430311363](https://jules.google.com/task/13264745500430311363) started by @arii*