### PR TITLE
Add .github/conflict-resolver.yml for PNG conflicts

### DIFF
--- a/.github/conflict-resolver.yml
+++ b/.github/conflict-resolver.yml
@@ -1,0 +1,3 @@
+rules:
+  - paths: '*.png'
+    strategy: 'theirs'


### PR DESCRIPTION
Adds missing configuration for the Auto Conflict Resolver workflow to correctly resolve merge conflicts in .png files using the 'theirs' strategy.