### PR TITLE
fix: add missing strategy for png files in conflict resolver

### DIFF
--- a/.github/conflict-resolver.yml
+++ b/.github/conflict-resolver.yml
@@ -1,4 +1,5 @@
 rules:
   - paths: '*.png'
+    strategy: 'theirs'
   - paths: 'pnpm-lock.yaml'
     strategy: 'theirs'

--- a/.github/conflict-resolver.yml
+++ b/.github/conflict-resolver.yml
@@ -1,0 +1,3 @@
+rules:
+  - paths: '*.png'
+    strategy: 'theirs'


### PR DESCRIPTION
This PR adds missing configuration for the Auto Conflict Resolver workflow to correctly resolve merge conflicts in `.png` files using the `theirs` strategy, as identified in issue #384. This patch fulfills the original developer intent without introducing any additional abstractions. All tests and checks passed.

---
*PR created automatically by Jules for task [5006460519245726046](https://jules.google.com/task/5006460519245726046) started by @arii*