### PR TITLE
fix: dynamically configure sitemap hostname and paths for deployment environments

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -49,8 +49,9 @@ export default defineConfig(({mode}) => {
       react(),
       tailwindcss(),
       Sitemap({
-        hostname: (env.VITE_APP_URL || 'https://arii.github.io/tech-dancer').replace(/\/$/, ''),
-        dynamicRoutes, generateRobotsTxt: false,
+        hostname: (env.VITE_APP_URL || (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : (isVercel ? 'https://tech-dancer.vercel.app' : 'https://arii.github.io/tech-dancer'))).replace(/\/$/, ''),
+        dynamicRoutes: dynamicRoutes.map(route => base === '/' ? route : base.replace(/\/$/, '') + (route.startsWith('/') ? route : '/' + route)),
+        generateRobotsTxt: false,
       }),
       ViteImageOptimizer({
         includePublic: true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,6 +22,13 @@ export default defineConfig(({mode}) => {
   // Use VITE_BASE_PATH if specified (crucial for branch deployments), otherwise fallback to standard paths
   const base = process.env.VITE_BASE_PATH || (isVercel ? '/' : (isGHAction || isProd ? '/tech-dancer/' : '/'));
 
+  const resolveHostname = () => {
+    if (env.VITE_APP_URL) return env.VITE_APP_URL;
+    if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`;
+    if (isVercel) return 'https://tech-dancer.vercel.app';
+    return 'https://arii.github.io/tech-dancer';
+  };
+
   // Automatically discover dynamic routes from config/routes.ts and content directories
   const dynamicRoutes = [
     // Static routes from config (excluding parameterized and catch-all)
@@ -49,7 +56,7 @@ export default defineConfig(({mode}) => {
       react(),
       tailwindcss(),
       Sitemap({
-        hostname: (env.VITE_APP_URL || (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : (isVercel ? 'https://tech-dancer.vercel.app' : 'https://arii.github.io/tech-dancer'))).replace(/\/$/, ''),
+        hostname: resolveHostname().replace(/\/$/, ''),
         dynamicRoutes: dynamicRoutes.map(route => base === '/' ? route : base.replace(/\/$/, '') + (route.startsWith('/') ? route : '/' + route)),
         generateRobotsTxt: false,
       }),


### PR DESCRIPTION
This update addresses the issue where `vite-plugin-sitemap` hardcoded the `hostname` to the GitHub Pages URL and failed to include the necessary repository base path. It dynamically resolves the deployment URL based on `process.env.VERCEL_URL` (for Vercel previews) or `env.VITE_APP_URL`. Additionally, the plugin configuration maps `dynamicRoutes` to correctly prefix paths with the configured Vite base path (e.g., `/tech-dancer/`), ensuring valid URLs across local, Vercel, and GitHub Pages deployments.

---
*PR created automatically by Jules for task [2364051143803177790](https://jules.google.com/task/2364051143803177790) started by @arii*