### PR TITLE
Refactor WCS scraper logic and research UI

### DIFF
--- a/etl/scraper.py
+++ b/etl/scraper.py
@@ -21,15 +21,10 @@ logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
 BASE_URL = "https://scoring.dance"
 USER_AGENT = "TechDancer-WCS-Scraper/1.0 (+https://github.com/arii/tech-dancer)"
 
-class RateLimiter:
+async def ethical_throttle(base_delay=1.0, jitter_range=(0.0, 2.0)):
     """Handles ethical rate limiting with jitter."""
-    def __init__(self, base_delay=1.0, jitter_range=(0.0, 2.0)):
-        self.base_delay = base_delay
-        self.jitter_range = jitter_range
-
-    async def throttle(self):
-        delay = self.base_delay + random.uniform(*self.jitter_range)
-        await asyncio.sleep(delay)
+    delay = base_delay + random.uniform(*jitter_range)
+    await asyncio.sleep(delay)
 
 POINTS_MAPPING = {
     'Yes': 10.0, 'Alt1': 4.5, 'Alt2': 4.3, 'Alt3': 4.2, 'No': 0.0,
@@ -272,7 +267,6 @@ class ETLPipeline:
         self.crawler = crawler
         self.parser = parser
         self.output_manager = output_manager
-        self.limiter = RateLimiter()
 
     @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=4, max=10))
     async def _fetch_page(self, browser_context, url):
@@ -321,7 +315,7 @@ class ETLPipeline:
                             raw_df = self.parser.parse_results(content, res_url)
                             ledger_df = process_for_ledger(raw_df)
                             self.output_manager.update_ledger(ledger_df)
-                            await self.limiter.throttle()
+                            await ethical_throttle()
                         except Exception as e:
                             logging.error(f"Failed to process {res_url}: {e}")
                 except Exception as e:

--- a/src/features/research/components/WCSScraperTool.tsx
+++ b/src/features/research/components/WCSScraperTool.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   Search,
   Download,
@@ -14,8 +13,124 @@ import {
   Button
 } from '@/layouts/Primitives';
 import { useExport } from '../hooks/useExport';
-import { useWCSData } from '../hooks/useWCSData';
+import { useWCSData, WCSRecord } from '../hooks/useWCSData';
 import { ScoreDistributionChart, AvgScoreTrendChart } from './WCSChartContainers';
+
+function WCSDataTable({ data }: { data: WCSRecord[] }) {
+  return (
+    <div className="border border-line bg-surface">
+      <div className="p-4 border-b border-line flex justify-between items-center">
+        <Text variant="mono" size="xs" weight="font-bold" uppercase>Live Dataset</Text>
+        <Text variant="mono" size="micro" color="dim">{data.length} RECORDS FOUND</Text>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="w-full text-left border-collapse">
+          <thead>
+            <tr className="border-b border-line">
+              <th className="p-4 text-xs font-mono text-dim uppercase font-normal">Date</th>
+              <th className="p-4 text-xs font-mono text-dim uppercase font-normal">Competitor</th>
+              <th className="p-4 text-xs font-mono text-dim uppercase font-normal">Event</th>
+              <th className="p-4 text-xs font-mono text-dim uppercase font-normal">Score</th>
+              <th className="p-4 text-xs font-mono text-dim uppercase font-normal">Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.slice(0, 20).map((record, i) => (
+              <tr key={`${record.Dancer_ID}-${record.result_id}-${i}`} className="border-b border-line/50 transition-colors">
+                <td className="p-4 font-mono text-xs text-dim">{record.event_date}</td>
+                <td className="p-4">
+                  <div className="flex flex-col">
+                    <Text variant="body" size="xs" weight="font-bold">{record.competitor_name}</Text>
+                    <Text variant="mono" size="micro" color="dim">#{record.Dancer_ID}</Text>
+                  </div>
+                </td>
+                <td className="p-4 text-xs text-dim">{record.event_title}</td>
+                <td className="p-4 font-mono text-xs">{record.Registry_Points_Sum.toFixed(1)}</td>
+                <td className="p-4">
+                  <div className={`px-2 py-0.5 inline-block text-xs font-black uppercase tracking-widest ${record.Promoted ? 'bg-accent text-accent-navy' : 'bg-muted text-dim opacity-50'}`}>
+                    {record.Promoted ? 'Promoted' : 'Held'}
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      {data.length > 20 && (
+        <div className="p-4 text-center border-t border-line">
+          <Text variant="mono" size="micro" color="dim">AND {data.length - 20} MORE RECORDS...</Text>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function WCSExportConsole({ data }: { data: WCSRecord[] }) {
+  const { exportCSV, exportPDF } = useExport();
+
+  return (
+    <div className="border border-line bg-surface p-6">
+      <div className="flex flex-col gap-6">
+        <div className="flex items-center gap-3">
+          <Download className="w-5 h-5 text-accent" />
+          <Text variant="mono" size="xs" weight="font-bold" uppercase>Export Console</Text>
+        </div>
+        <div className="flex flex-col gap-3">
+          <Button
+            variant="secondary"
+            className="w-full"
+            onClick={() => exportCSV(data)}
+          >
+            <div className="flex items-center gap-3 w-full text-left">
+              <FileJson className="w-4 h-4 shrink-0" />
+              <div className="flex flex-col">
+                <Text variant="mono" size="micro" weight="font-bold">EXPORT_CSV</Text>
+                <Text variant="body" size="micro" color="dim">Raw machine-readable data</Text>
+              </div>
+            </div>
+          </Button>
+          <Button
+            variant="secondary"
+            className="w-full"
+            onClick={() => exportPDF(data)}
+          >
+            <div className="flex items-center gap-3 w-full text-left">
+              <FileText className="w-4 h-4 shrink-0" />
+              <div className="flex flex-col">
+                <Text variant="mono" size="micro" weight="font-bold">EXPORT_PDF_REPORT</Text>
+                <Text variant="body" size="micro" color="dim">Formatted analytical brief</Text>
+              </div>
+            </div>
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function WCSScraperStats() {
+  return (
+    <div className="border border-line bg-muted p-6">
+      <div className="flex flex-col gap-4">
+        <Text variant="mono" size="micro" color="dim" uppercase weight="font-bold">Scraper Intelligence</Text>
+        <div className="flex flex-col gap-3">
+          <div className="flex justify-between items-center">
+            <Text variant="body" size="xs" color="dim">Success Rate</Text>
+            <Text variant="mono" size="xs" color="brand" weight="font-bold">99.8%</Text>
+          </div>
+          <div className="flex justify-between items-center">
+            <Text variant="body" size="xs" color="dim">Avg Latency</Text>
+            <Text variant="mono" size="xs" color="brand" weight="font-bold">1.2s</Text>
+          </div>
+          <div className="flex justify-between items-center">
+            <Text variant="body" size="xs" color="dim">Ethical Backoff</Text>
+            <Text variant="mono" size="xs" color="brand" weight="font-bold">ACTIVE</Text>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
 
 export function WCSScraperTool() {
   const {
@@ -29,36 +144,14 @@ export function WCSScraperTool() {
     trendData
   } = useWCSData();
 
-  const { exportCSV, exportPDF } = useExport();
-
-  const handleExportCSV = () => {
-    exportCSV(filteredData, 'wcs_prelims');
-  };
-
-  const handleExportPDF = () => {
-    const tableData = filteredData.map(r => [
-      r.event_date,
-      r.competitor_name,
-      r.event_title,
-      r.Registry_Points_Sum.toFixed(1),
-      r.Promoted ? 'YES' : 'NO'
-    ]);
-
-    exportPDF(tableData, {
-      filename: 'wcs_prelims',
-      title: 'WCS Prelim Scoring Analysis',
-      headers: ['Date', 'Competitor', 'Event', 'Score', 'Promoted']
-    });
-  };
-
   if (isLoading) {
     return (
-      <Box padding={12} display="flex" justify="center" align="center">
-        <Stack align="center" gap={4}>
+      <div className="p-12 flex justify-center items-center">
+        <div className="flex flex-col items-center gap-4">
           <Loader2 className="w-8 h-8 text-accent animate-spin" />
           <Text variant="mono" size="xs">INGESTING DATASET...</Text>
-        </Stack>
-      </Box>
+        </div>
+      </div>
     );
   }
 
@@ -108,115 +201,12 @@ export function WCSScraperTool() {
             <ScoreDistributionChart data={scoreDistribution} />
             <AvgScoreTrendChart data={trendData} />
           </Grid>
-
-          <Box border surface="default">
-            <Box padding="compact" borderBottom display="flex" justify="between" align="center">
-              <Text variant="mono" size="xs" weight="font-bold" uppercase>Live Dataset</Text>
-              <Text variant="mono" size="micro" color="dim">{filteredData.length} RECORDS FOUND</Text>
-            </Box>
-            <Box className="overflow-x-auto">
-              <table className="w-full text-left border-collapse">
-                <thead>
-                  <tr className="border-b border-line">
-                    <Box as="th" padding={4} className="text-xs font-mono text-dim uppercase font-normal">Date</Box>
-                    <Box as="th" padding={4} className="text-xs font-mono text-dim uppercase font-normal">Competitor</Box>
-                    <Box as="th" padding={4} className="text-xs font-mono text-dim uppercase font-normal">Event</Box>
-                    <Box as="th" padding={4} className="text-xs font-mono text-dim uppercase font-normal">Score</Box>
-                    <Box as="th" padding={4} className="text-xs font-mono text-dim uppercase font-normal">Status</Box>
-                  </tr>
-                </thead>
-                <tbody>
-                  {filteredData.slice(0, 20).map((record, i) => (
-                    <tr key={`${record.Dancer_ID}-${record.result_id}-${i}`} className="border-b border-line/50 transition-colors">
-                      <Box as="td" padding={4} className="font-mono text-xs text-dim">{record.event_date}</Box>
-                      <Box as="td" padding={4}>
-                        <Stack gap={0}>
-                          <Text variant="body" size="xs" weight="font-bold">{record.competitor_name}</Text>
-                          <Text variant="mono" size="micro" color="dim">#{record.Dancer_ID}</Text>
-                        </Stack>
-                      </Box>
-                      <Box as="td" padding={4} className="text-xs text-dim">{record.event_title}</Box>
-                      <Box as="td" padding={4} className="font-mono text-xs">{record.Registry_Points_Sum.toFixed(1)}</Box>
-                      <Box as="td" padding={4}>
-                        <Box
-                          paddingX={2}
-                          paddingY={0.5}
-                          surface={record.Promoted ? 'accent' : 'muted'}
-                          className={`inline-block text-xs font-black uppercase tracking-widest ${record.Promoted ? 'text-accent-navy' : 'text-dim opacity-50'}`}
-                        >
-                          {record.Promoted ? 'Promoted' : 'Held'}
-                        </Box>
-                      </Box>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </Box>
-            {filteredData.length > 20 && (
-              <Box padding="compact" textAlign="center" borderTop>
-                <Text variant="mono" size="micro" color="dim">AND {filteredData.length - 20} MORE RECORDS...</Text>
-              </Box>
-            )}
-          </Box>
+          <WCSDataTable data={filteredData} />
         </Stack>
 
         <Stack gap={8}>
-          <Box border surface="default" padding="card">
-            <Stack gap={6}>
-              <Box display="flex" align="center" gap={3}>
-                <Download className="w-5 h-5 text-accent" />
-                <Text variant="mono" size="xs" weight="font-bold" uppercase>Export Console</Text>
-              </Box>
-              <Stack gap={3}>
-                <Button
-                  variant="secondary"
-                  className="w-full"
-                  onClick={handleExportCSV}
-                >
-                  <Box display="flex" align="center" gap={3} width="full" className="text-left">
-                    <FileJson className="w-4 h-4 shrink-0" />
-                    <Stack gap={0}>
-                      <Text variant="mono" size="micro" weight="font-bold">EXPORT_CSV</Text>
-                      <Text variant="body" size="micro" color="dim">Raw machine-readable data</Text>
-                    </Stack>
-                  </Box>
-                </Button>
-                <Button
-                  variant="secondary"
-                  className="w-full"
-                  onClick={handleExportPDF}
-                >
-                  <Box display="flex" align="center" gap={3} width="full" className="text-left">
-                    <FileText className="w-4 h-4 shrink-0" />
-                    <Stack gap={0}>
-                      <Text variant="mono" size="micro" weight="font-bold">EXPORT_PDF_REPORT</Text>
-                      <Text variant="body" size="micro" color="dim">Formatted analytical brief</Text>
-                    </Stack>
-                  </Box>
-                </Button>
-              </Stack>
-            </Stack>
-          </Box>
-
-          <Box border surface="muted" padding="card">
-            <Stack gap={4}>
-              <Text variant="mono" size="micro" color="dim" uppercase weight="font-bold">Scraper Intelligence</Text>
-              <Stack gap={3}>
-                <Box display="flex" justify="between" align="center">
-                  <Text variant="body" size="xs" color="dim">Success Rate</Text>
-                  <Text variant="mono" size="xs" color="brand" weight="font-bold">99.8%</Text>
-                </Box>
-                <Box display="flex" justify="between" align="center">
-                  <Text variant="body" size="xs" color="dim">Avg Latency</Text>
-                  <Text variant="mono" size="xs" color="brand" weight="font-bold">1.2s</Text>
-                </Box>
-                <Box display="flex" justify="between" align="center">
-                  <Text variant="body" size="xs" color="dim">Ethical Backoff</Text>
-                  <Text variant="mono" size="xs" color="brand" weight="font-bold">ACTIVE</Text>
-                </Box>
-              </Stack>
-            </Stack>
-          </Box>
+          <WCSExportConsole data={filteredData} />
+          <WCSScraperStats />
         </Stack>
       </Grid>
     </Stack>

--- a/src/features/research/hooks/useExport.ts
+++ b/src/features/research/hooks/useExport.ts
@@ -1,52 +1,43 @@
 import Papa from 'papaparse';
 import { jsPDF } from 'jspdf';
-import 'jspdf-autotable';
-
-declare module 'jspdf' {
-  interface jsPDF {
-    autoTable: (options: unknown) => jsPDF;
-  }
-}
-
-interface ExportConfig {
-  filename: string;
-  title: string;
-  headers: string[];
-}
+import autoTable from 'jspdf-autotable';
+import { WCSRecord } from './useWCSData';
 
 export function useExport() {
-  const exportCSV = <T,>(data: T[], filename: string) => {
+  const exportCSV = (data: WCSRecord[], filename: string = 'wcs_prelims') => {
     const csv = Papa.unparse(data);
     const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
-    const link = document.createElement('a');
     const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
 
     link.setAttribute('href', url);
     link.setAttribute('download', `${filename}_${new Date().toISOString().split('T')[0]}.csv`);
-    link.style.visibility = 'hidden';
-    document.body.appendChild(link);
     link.click();
-    document.body.removeChild(link);
   };
 
-  const exportPDF = (
-    data: (string | number | boolean)[][],
-    config: ExportConfig
-  ) => {
+  const exportPDF = (data: WCSRecord[], filename: string = 'wcs_prelims') => {
     const doc = new jsPDF();
 
     doc.setFontSize(18);
-    doc.text(config.title, 14, 22);
+    doc.text('WCS Prelim Scoring Analysis', 14, 22);
 
     doc.setFontSize(11);
     doc.setTextColor(100);
     doc.text(`Generated on ${new Date().toLocaleDateString()}`, 14, 30);
     doc.text(`Records: ${data.length}`, 14, 36);
 
-    doc.autoTable({
+    const tableData = data.map(r => [
+      r.event_date,
+      r.competitor_name,
+      r.event_title,
+      r.Registry_Points_Sum.toFixed(1),
+      r.Promoted ? 'YES' : 'NO'
+    ]);
+
+    autoTable(doc, {
       startY: 45,
-      head: [config.headers],
-      body: data,
+      head: [['Date', 'Competitor', 'Event', 'Score', 'Promoted']],
+      body: tableData,
       theme: 'grid',
       // Using RGB values to avoid hex color detection and match brand-ish dark gray
       headStyles: { fillColor: [26, 43, 60], textColor: [255, 255, 255], fontSize: 10 },
@@ -57,7 +48,7 @@ export function useExport() {
       }
     });
 
-    doc.save(`${config.filename}_report_${new Date().toISOString().split('T')[0]}.pdf`);
+    doc.save(`${filename}_report_${new Date().toISOString().split('T')[0]}.pdf`);
   };
 
   return {


### PR DESCRIPTION
Refactored WCS scraper logic and research UI to address reviewer feedback.

- Refactored `RateLimiter` class in `etl/scraper.py` into a concise `ethical_throttle` async function.
- Modularized `WCSScraperTool.tsx` by splitting the "God Component" into `WCSDataTable`, `WCSExportConsole`, and `WCSScraperStats` sub-components.
- Simplified `WCSScraperTool.tsx` layout by replacing redundant `Box` and `Stack` components with standard Tailwind CSS.
- Decoupled `useExport` hook by moving PDF/CSV generation parameters and logic inside the hook.
- Fixed `useExport` to avoid manual `document.body` mutation and explicit `.d.ts` type augmentations for `jsPDF`.

---
*PR created automatically by Jules for task [12564248615167366776](https://jules.google.com/task/12564248615167366776) started by @arii*