### PR TITLE
Fix linting errors in validate-links.ts

### DIFF
--- a/scripts/validate-links.ts
+++ b/scripts/validate-links.ts
@@ -83,9 +83,7 @@ async function main() {
   });
 
   // Validate external links and images
-  const externalToValidate = [
-    ...extractedLinks.filter(l => l.type === 'external' || (l.type === 'image' && l.url.startsWith('http')))
-  ];
+  const externalToValidate = extractedLinks.filter(l => l.type === 'external' || (l.type === 'image' && l.url.startsWith('http')));
 
   const localImagesToValidate = extractedLinks.filter(l => l.type === 'image' && !l.url.startsWith('http'));
 
@@ -100,9 +98,8 @@ async function main() {
   console.log(`Validating ${externalToValidate.length} external links...`);
 
   for (const link of externalToValidate) {
-    let urlObj: URL;
     try {
-      urlObj = new URL(link.url);
+      new URL(link.url);
     } catch (err) {
       brokenLinks.push({ ...link, reason: `Invalid URL: ${err instanceof Error ? err.message : String(err)}` });
       continue;


### PR DESCRIPTION
Resolved a `no-unused-vars` warning and a `no-useless-spread` warning in `scripts/validate-links.ts` that were causing the `pnpm run lint` script to fail during CI.

- Removed the useless spread operator since `filter` naturally returns a new array.
- Avoided assigning a new URL to an unused variable, only calling `new URL()` to check if it parses successfully without throwing.

---
*PR created automatically by Jules for task [2102443159287807558](https://jules.google.com/task/2102443159287807558) started by @arii*