### PR TITLE
Fix search modal z-index layer handling

### DIFF
--- a/src/components/GlobalSearch.tsx
+++ b/src/components/GlobalSearch.tsx
@@ -50,14 +50,14 @@ export function GlobalSearch() {
     <Box
       position="fixed"
       inset="y"
-      zIndex="search"
+      zIndex={200}
       display="flex"
       justify="center"
       align="start"
       paddingTop={20}
       surface={false}
       data-testid="search-backdrop"
-      className="bg-accent/40 backdrop-blur-md left-0 right-0 lg:left-72"
+      className="bg-accent/40 backdrop-blur-md left-0 right-0 lg:left-72 !z-[200]"
       // 2. The Backdrop Escape Hatch: Clicking the background closes the search
       onClick={close}
     >

--- a/tests-e2e/functional/search.spec.ts
+++ b/tests-e2e/functional/search.spec.ts
@@ -73,7 +73,7 @@ test.describe('Search and Filter URL Persistence', () => {
 
     await page.reload();
 
-    await openSearch(page, isMobile);
+    // search should be open since ?search=true is in the URL
 
     await expect(page.getByPlaceholder(/SEARCH REPOSITORY/i)).toHaveValue('swing');
   });


### PR DESCRIPTION
Fix Playwright timeouts on mobile browsers by ensuring the `GlobalSearch` component overlays the mobile navigation using a hardcoded `!z-[200]` class instead of a dynamically generated one. Updated related test scripts accordingly.

---
*PR created automatically by Jules for task [16304635583347890050](https://jules.google.com/task/16304635583347890050) started by @arii*