### PR TITLE
fix: add missing cn import to DetailLayout

### DIFF
--- a/src/components/layout/DetailLayout.tsx
+++ b/src/components/layout/DetailLayout.tsx
@@ -1,6 +1,7 @@
 import { motion } from 'motion/react';
 import { ArrowLeft } from 'lucide-react';
 import { Box, Stack, Text, Grid } from '@/layouts/Primitives';
+import { cn } from '@/lib/utils';
 import { MarkdownRenderer } from '@/components/ui/MarkdownRenderer';
 import { readingTime } from '@/lib/content';
 


### PR DESCRIPTION
Fixes a runtime crash (`ReferenceError: cn is not defined`) when navigating to "gear" and "blog" post pages by importing the missing `cn` utility function into `src/components/layout/DetailLayout.tsx`.

---
*PR created automatically by Jules for task [16556868700378094501](https://jules.google.com/task/16556868700378094501) started by @arii*