### PR TITLE
Fix deployment feedback comment logic

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -134,6 +134,7 @@ jobs:
       - name: Update Deployment Feedback
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
@@ -162,14 +163,18 @@ jobs:
 
             if (branchName === 'main') return;
 
-            const { data: pullRequests } = await github.rest.pulls.list({
+            console.log(`Searching for open PRs for branch: ${branchName}`);
+            const pullRequests = await github.paginate(github.rest.pulls.list, {
               owner,
               repo,
-              head: `${owner}:${branchName}`,
               state: 'open'
             });
 
-            for (const pr of pullRequests) {
+            const matchingPRs = pullRequests.filter(pr => pr.head.ref === branchName);
+            console.log(`Found ${matchingPRs.length} matching PRs`);
+
+            for (const pr of matchingPRs) {
+              console.log(`Updating feedback for PR #${pr.number}`);
               const commentTag = `<!-- preview-url-comment-${branchName} -->`;
               const body = [
                 `🚀 **Deployment Details** (Last updated: ${pstTime} PST)`,
@@ -181,7 +186,7 @@ jobs:
                 commentTag
               ].join('\n');
 
-              const { data: comments } = await github.rest.issues.listComments({
+              const comments = await github.paginate(github.rest.issues.listComments, {
                 owner,
                 repo,
                 issue_number: pr.number,
@@ -190,6 +195,7 @@ jobs:
               const existingComment = comments.find(c => c.body.includes(commentTag));
 
               if (existingComment) {
+                console.log(`Updating existing comment ${existingComment.id}`);
                 await github.rest.issues.updateComment({
                   owner,
                   repo,
@@ -197,6 +203,7 @@ jobs:
                   body,
                 });
               } else {
+                console.log(`Creating new comment for PR #${pr.number}`);
                 await github.rest.issues.createComment({
                   issue_number: pr.number,
                   owner,


### PR DESCRIPTION
This PR improves the reliability of the deployment feedback script that posts preview URLs to Pull Requests. It addresses issues where comments were no longer being posted by switching to a more robust pagination and filtering strategy.

Key changes:
- Switched to `github.paginate` for `pulls.list` and `issues.listComments` to handle repositories with many PRs or comments.
- Replaced the API-side `head` filter with a client-side filter on `pr.head.ref`, which is more reliable for different branch naming conventions.
- Added explicit `github-token` input.
- Added detailed logging via `console.log` for troubleshooting.

Fixes #493

---
*PR created automatically by Jules for task [4384236701894468978](https://jules.google.com/task/4384236701894468978) started by @arii*