### PR TITLE
Add Playwright Browser Caching to ETL Workflow

### DIFF
--- a/.github/workflows/wcs_etl.yml
+++ b/.github/workflows/wcs_etl.yml
@@ -28,6 +28,7 @@ jobs:
           pip install -r etl/requirements.txt
 
       - name: Cache Playwright Browsers
+        id: cache-playwright
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
@@ -36,6 +37,7 @@ jobs:
             playwright-etl-${{ runner.os }}-chromium-
 
       - name: Install Playwright Chromium
+        if: steps.cache-playwright.outputs.cache-hit != 'true'
         run: playwright install chromium
 
       - name: Run Pytest (Data Validation)

--- a/.github/workflows/wcs_etl.yml
+++ b/.github/workflows/wcs_etl.yml
@@ -22,11 +22,21 @@ jobs:
           python-version: '3.11'
           cache: 'pip'
 
-      - name: Install Tools & Dependencies
+      - name: Install Python Dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r etl/requirements.txt
-          playwright install chromium
+
+      - name: Cache Playwright Browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-etl-${{ runner.os }}-chromium-v1
+          restore-keys: |
+            playwright-etl-${{ runner.os }}-chromium-
+
+      - name: Install Playwright Chromium
+        run: playwright install chromium
 
       - name: Run Pytest (Data Validation)
         run: |


### PR DESCRIPTION
Implemented Playwright browser caching in the WCS ETL workflow (`.github/workflows/wcs_etl.yml`) to improve pipeline efficiency. 

Changes:
- Refactored the monolithic installation step into separate 'Install Python Dependencies' and 'Install Playwright Chromium' steps.
- Integrated `actions/cache@v4` to persist Playwright browser binaries across runs.
- Verified that existing ETL tests pass with the modified environment setup.

Fixes #503

---
*PR created automatically by Jules for task [15277468477470866741](https://jules.google.com/task/15277468477470866741) started by @arii*