### PR TITLE
ci: fix prune-stale-previews failing on missing directories

### DIFF
--- a/.github/workflows/prune-stale-previews.yml
+++ b/.github/workflows/prune-stale-previews.yml
@@ -40,6 +40,9 @@ jobs:
             # Skip root and infra folders
             [[ "$dir" =~ ^(\.|\.\.|assets|tmp|previews)$ ]] && continue
 
+            # If the directory was already removed in a previous iteration, skip it
+            [ -d "$dir" ] || continue
+
             # Check if it doesn't match an active branch
             if ! echo "$ACTIVE_BRANCHES" | grep -Fxq "$dir"; then
               # Get the timestamp of the last update
@@ -48,7 +51,7 @@ jobs:
 
               if [ "$AGE" -gt "$GRACE_PERIOD" ]; then
                 echo "Branch '$dir' no longer exists and deployment is older than 24h (${AGE}s). Removing preview..."
-                git rm -r "$dir"
+                git rm -r --ignore-unmatch "$dir"
                 CHANGES_MADE=true
               else
                 echo "Branch '$dir' no longer exists but deployment is within 24h grace period (${AGE}s). Skipping..."


### PR DESCRIPTION
The `prune-stale-previews.yml` action was failing with `fatal: pathspec ... did not match any files`. The issue occurred because it processes directories based on `index.html` locations. If there is an `index.html` at the branch root, and another `index.html` in a nested folder (like `previews/index.html`), the script processes the branch root first and runs `git rm -r <branch_root>`. In the next loop iteration, it tries to process the nested `previews` directory, which no longer exists, causing `git rm -r` to throw an error and fail the action.

This PR adds:
1. A check `[ -d "$dir" ] || continue` to skip directories that were already removed.
2. The `--ignore-unmatch` flag to `git rm` to guarantee the command does not fail if a path doesn't exist.

---
*PR created automatically by Jules for task [4162409462211398192](https://jules.google.com/task/4162409462211398192) started by @arii*