### PR TITLE
fix(seo): update robots.txt paths for github pages subpath deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,8 +60,10 @@ jobs:
           if [ "${{ github.ref_name }}" = "main" ]; then
             # Generate robots.txt pointing at canonical sitemap location
             echo "User-agent: *" > dist/robots.txt
-            echo "Allow: /" >> dist/robots.txt
-            echo "Sitemap: https://$OWNER.github.io/tech-dancer/sitemap.xml" >> dist/robots.txt
+            echo "Allow: /$REPO_NAME/" >> dist/robots.txt
+            echo "Disallow: /$REPO_NAME/previews/" >> dist/robots.txt
+            echo "Disallow: /$REPO_NAME/404.html" >> dist/robots.txt
+            echo "Sitemap: https://$OWNER.github.io/$REPO_NAME/sitemap.xml" >> dist/robots.txt
 
             echo "SEO assets generated successfully."
           fi

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,6 +1,6 @@
 User-agent: *
-Allow: /
-Disallow: /previews/
-Disallow: /404.html
+Allow: /tech-dancer/
+Disallow: /tech-dancer/previews/
+Disallow: /tech-dancer/404.html
 
 Sitemap: https://arii.github.io/tech-dancer/sitemap.xml


### PR DESCRIPTION
Updated `robots.txt` generation in `deploy.yml` and the static `public/robots.txt` to correctly prefix `Allow` and `Disallow` paths with the repo base URL (`/tech-dancer/`). This resolves SEO crawling issues where `robots.txt` generated for the root domain (`arii.github.io/robots.txt`) did not accurately map internal paths to the tech-dancer project.

---
*PR created automatically by Jules for task [2815797412871317531](https://jules.google.com/task/2815797412871317531) started by @arii*