### PR TITLE
Improve Contrast Ratio for Section Labels

### DIFF
--- a/src/components/ui/PageHeader.tsx
+++ b/src/components/ui/PageHeader.tsx
@@ -31,7 +31,7 @@ export function PageHeader({
       border={border}
     >
       <Stack gap={4}>
-        <Text variant="mono" size="xs" color="dim" weight="font-bold" tracking="wide-editorial" uppercase>
+        <Text variant="mono" size="xs" color="brand" weight="font-bold" tracking="wide-editorial" uppercase>
           {label}
         </Text>
         <Text as={as} variant="headline" size={titleSize} weight="font-black" className="text-accent-navy leading-tight tracking-tight">
@@ -63,7 +63,7 @@ export function SectionHeader({ label, title, children }: { label: string; title
   return (
     <Box display="flex" justify="between" align="end" border="b" paddingBottom={4} className="border-line">
       <Stack gap={1}>
-        <Text variant="mono" size="xs" color="dim" weight="font-semibold" tracking="widest" uppercase>{label}</Text>
+        <Text variant="mono" size="xs" color="brand" weight="font-semibold" tracking="widest" uppercase>{label}</Text>
         <Text variant="display" size="3xl" weight="font-black" className="text-accent-navy">{title}</Text>
       </Stack>
       {children}

--- a/src/features/profile/ArielProfile.tsx
+++ b/src/features/profile/ArielProfile.tsx
@@ -42,7 +42,7 @@ export default function ArielProfile() {
               <Grid cols={{ base: 1, md: 3 }} gap={8}>
                 {bio.details.map((detail) => (
                   <Stack key={detail.label} gap={1}>
-                    <Text variant="mono" size="xs" color="dim" weight="font-bold">{detail.label}</Text>
+                    <Text variant="mono" size="xs" color="brand" weight="font-bold">{detail.label}</Text>
                     <Text variant="body" size="sm" color="main" weight="font-semibold" className="break-words">{detail.value}</Text>
                   </Stack>
                 ))}


### PR DESCRIPTION
Improved the contrast ratio for mono-spaced section labels (e.g., 'BIOGRAPHY', 'THE TOOLBOX', 'INSIGHTS') by updating the `color` prop from `dim` to `brand` in `PageHeader.tsx` and `SectionHeader.tsx`. This ensures that these labels use `text-accent-navy` (#1A2B3C), which provides sufficient contrast against a white background. I also applied the same update to the biographical detail labels in `ArielProfile.tsx` for visual consistency across the application. Verified the changes via Playwright screenshots and confirmed all local quality gate checks pass.

Fixes #521

---
*PR created automatically by Jules for task [14364347213637875269](https://jules.google.com/task/14364347213637875269) started by @arii*