### PR TITLE
Increase Size of Status Indicators in Research Section

### DIFF
--- a/src/components/ui/StatusBadge.tsx
+++ b/src/components/ui/StatusBadge.tsx
@@ -1,0 +1,7 @@
+import { Box, Text } from '@/layouts/Primitives';
+
+export const StatusBadge = ({ label }: { label: string }) => (
+  <Box surface="accent" paddingX={2} paddingY={0.5} className="bg-accent/10">
+    <Text variant="mono" size="xs" color="brand" weight="font-bold">{label.toUpperCase()}</Text>
+  </Box>
+);

--- a/src/features/research/ResearchAnalytics.tsx
+++ b/src/features/research/ResearchAnalytics.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { Database, FileText, Search, ArrowRight } from 'lucide-react';
 import { Box, Stack, Text, Grid } from '@/layouts/Primitives';
 import { SEO } from '@/components/SEO';
+import { StatusBadge } from '@/components/ui/StatusBadge';
 import { PageHeader } from '@/components/ui/PageHeader';
 import { useResearch } from './useResearch';
 
@@ -47,9 +48,7 @@ export default function ResearchAnalytics() {
                       <Box width={10} height={10} surface="muted" border display="flex" align="center" justify="center" color="dim" className="group-hover:text-accent transition-colors">
                         <Search className="w-5 h-5" />
                       </Box>
-                      <Box surface="accent" paddingX={2} paddingY={0.5} className="bg-accent/10">
-                        <Text variant="mono" size="xs" color="brand" weight="font-bold">{tool.status.toUpperCase()}</Text>
-                      </Box>
+                      <StatusBadge label={tool.status} />
                     </Box>
                     <Stack gap={2}>
                       <Text variant="display" size="xl" className="group-hover:text-accent transition-colors">{tool.name}</Text>

--- a/src/features/research/ResearchAnalytics.tsx
+++ b/src/features/research/ResearchAnalytics.tsx
@@ -47,7 +47,9 @@ export default function ResearchAnalytics() {
                       <Box width={10} height={10} surface="muted" border display="flex" align="center" justify="center" color="dim" className="group-hover:text-accent transition-colors">
                         <Search className="w-5 h-5" />
                       </Box>
-                      <Text variant="mono" size="micro" color="brand" weight="font-bold">{tool.status.toUpperCase()}</Text>
+                      <Box surface="accent" paddingX={2} paddingY={0.5} className="bg-accent/10">
+                        <Text variant="mono" size="xs" color="brand" weight="font-bold">{tool.status.toUpperCase()}</Text>
+                      </Box>
                     </Box>
                     <Stack gap={2}>
                       <Text variant="display" size="xl" className="group-hover:text-accent transition-colors">{tool.name}</Text>

--- a/src/features/research/ResearchDetail.tsx
+++ b/src/features/research/ResearchDetail.tsx
@@ -132,7 +132,9 @@ export default function ResearchDetail() {
                     <Text variant="mono" size="micro" color="dim" uppercase tracking="widest">System Status</Text>
                     <Box border padding="compact" display="flex" align="center" gap={3}>
                       <Activity className="w-4 h-4 text-accent" />
-                      <Text variant="mono" size="xs" color="brand" weight="font-bold">{tool.status.toUpperCase()}</Text>
+                      <Box surface="accent" paddingX={2} paddingY={0.5} className="bg-accent/10">
+                        <Text variant="mono" size="xs" color="brand" weight="font-bold">{tool.status.toUpperCase()}</Text>
+                      </Box>
                     </Box>
                   </Stack>
                   <Stack gap={4}>

--- a/src/features/research/ResearchDetail.tsx
+++ b/src/features/research/ResearchDetail.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { Database, Activity, ArrowLeft, Search } from 'lucide-react';
 import { Box, Stack, Text, Grid } from '@/layouts/Primitives';
+import { StatusBadge } from '@/components/ui/StatusBadge';
 import { useResearch } from './useResearch';
 import { BlogDrafter } from '@/features/lab/BlogDrafter';
 import { WCSScraperTool } from './components/WCSScraperTool';
@@ -132,9 +133,7 @@ export default function ResearchDetail() {
                     <Text variant="mono" size="micro" color="dim" uppercase tracking="widest">System Status</Text>
                     <Box border padding="compact" display="flex" align="center" gap={3}>
                       <Activity className="w-4 h-4 text-accent" />
-                      <Box surface="accent" paddingX={2} paddingY={0.5} className="bg-accent/10">
-                        <Text variant="mono" size="xs" color="brand" weight="font-bold">{tool.status.toUpperCase()}</Text>
-                      </Box>
+                      <StatusBadge label={tool.status} />
                     </Box>
                   </Stack>
                   <Stack gap={4}>

--- a/src/features/research/components/WCSScraperTool.tsx
+++ b/src/features/research/components/WCSScraperTool.tsx
@@ -145,7 +145,9 @@ function WCSScraperStats() {
           </Box>
           <Box display="flex" justify="between" align="center">
             <Text variant="body" size="xs" color="dim">Ethical Backoff</Text>
-            <Text variant="mono" size="xs" color="brand" weight="font-bold">ACTIVE</Text>
+            <Box surface="accent" paddingX={2} paddingY={0.5} className="bg-accent/10">
+              <Text variant="mono" size="xs" color="brand" weight="font-bold">ACTIVE</Text>
+            </Box>
           </Box>
         </Stack>
       </Stack>

--- a/src/features/research/components/WCSScraperTool.tsx
+++ b/src/features/research/components/WCSScraperTool.tsx
@@ -13,6 +13,7 @@ import {
   Grid,
   Button
 } from '@/layouts/Primitives';
+import { StatusBadge } from '@/components/ui/StatusBadge';
 import { useExport } from '../hooks/useExport';
 import { useWCSData, WCSRecord } from '../hooks/useWCSData';
 import { ScoreDistributionChart, AvgScoreTrendChart } from './WCSChartContainers';
@@ -145,9 +146,7 @@ function WCSScraperStats() {
           </Box>
           <Box display="flex" justify="between" align="center">
             <Text variant="body" size="xs" color="dim">Ethical Backoff</Text>
-            <Box surface="accent" paddingX={2} paddingY={0.5} className="bg-accent/10">
-              <Text variant="mono" size="xs" color="brand" weight="font-bold">ACTIVE</Text>
-            </Box>
+            <StatusBadge label="ACTIVE" />
           </Box>
         </Stack>
       </Stack>


### PR DESCRIPTION
Increased the visibility and visual hierarchy of status indicators in the Research section. Status badges for tools and system states have been scaled from 'micro' to 'xs' and wrapped in themed background boxes to ensure they are properly visible and distinguishable.

Key changes:
- ResearchAnalytics.tsx: Updated tool status badges.
- ResearchDetail.tsx: Updated system status indicator.
- WCSScraperTool.tsx: Updated 'ACTIVE' status indicator in the Scraper Intelligence section.

Fixes #526

---
*PR created automatically by Jules for task [7798265295250196094](https://jules.google.com/task/7798265295250196094) started by @arii*