### PR TITLE
Improve search relevance by tuning Fuse.js parameters

### DIFF
--- a/src/hooks/useGlobalSearch.ts
+++ b/src/hooks/useGlobalSearch.ts
@@ -56,8 +56,13 @@ export function useGlobalSearch() {
 
   const fuse = useMemo(() => {
     return new Fuse(allContent, {
-      keys: ['title', 'excerpt', 'content', 'tags'],
-      threshold: 0.3,
+      keys: [
+        { name: 'title', weight: 0.7 },
+        { name: 'tags', weight: 0.5 },
+        { name: 'excerpt', weight: 0.3 },
+        { name: 'content', weight: 0.1 }
+      ],
+      threshold: 0.2,
       ignoreLocation: true
     });
   }, [allContent]);


### PR DESCRIPTION
This change improves the relevance of global search results by making the Fuse.js search stricter and prioritizing certain fields.

Key changes:
- Reduced `threshold` from 0.3 to 0.2 in `useGlobalSearch.ts`.
- Added weights to search keys: `title` (0.7), `tags` (0.5), `excerpt` (0.3), and `content` (0.1).
- Verified that common searches like "loop" now return only highly relevant results.

Fixes #484

---
*PR created automatically by Jules for task [506107467047410442](https://jules.google.com/task/506107467047410442) started by @arii*