### PR TITLE
Resolve Search Icon Collision on Mobile

### DIFF
--- a/src/components/ui/SearchBox.tsx
+++ b/src/components/ui/SearchBox.tsx
@@ -29,17 +29,19 @@ export function SearchBox({
       radius="lg"
       className="focus-within:ring-2 focus-within:ring-accent transition-all"
     >
-      <Search size={18} className="text-text-dim" />
-      <Box
-        as="input"
-        type="text"
-        placeholder={placeholder}
-        variant="mono"
-        size="sm"
-        className="bg-transparent border-none outline-none pl-3 w-full focus:ring-0"
-        value={value}
-        onChange={onChange}
-      />
+      <Box position="relative" display="flex" align="center" width="full">
+        <Search size={18} className="text-text-dim absolute left-0 pointer-events-none" />
+        <Box
+          as="input"
+          type="text"
+          placeholder={placeholder}
+          variant="mono"
+          size="sm"
+          className="bg-transparent border-none outline-none pl-10 w-full focus:ring-0"
+          value={value}
+          onChange={onChange}
+        />
+      </Box>
     </Box>
   );
 }

--- a/src/components/ui/SearchBox.tsx
+++ b/src/components/ui/SearchBox.tsx
@@ -19,6 +19,7 @@ export function SearchBox({
     <Box
       display="flex"
       align="center"
+      position="relative"
       surface="default"
       border
       paddingX={4}
@@ -29,19 +30,20 @@ export function SearchBox({
       radius="lg"
       className="focus-within:ring-2 focus-within:ring-accent transition-all"
     >
-      <Box position="relative" display="flex" align="center" width="full">
-        <Search size={18} className="text-text-dim absolute left-0 pointer-events-none" />
-        <Box
-          as="input"
-          type="text"
-          placeholder={placeholder}
-          variant="mono"
-          size="sm"
-          className="bg-transparent border-none outline-none pl-10 w-full focus:ring-0"
-          value={value}
-          onChange={onChange}
-        />
-      </Box>
+      <Search
+        size={18}
+        className="text-text-dim absolute left-4 pointer-events-none"
+      />
+      <Box
+        as="input"
+        type="text"
+        placeholder={placeholder}
+        variant="mono"
+        size="sm"
+        className="bg-transparent border-none outline-none pl-10 w-full focus:ring-0"
+        value={value}
+        onChange={onChange}
+      />
     </Box>
   );
 }


### PR DESCRIPTION
This PR resolves a UI issue where the search icon (magnifying glass) was overlapping the placeholder text in the Blog and Gear search boxes, especially noticeable on mobile devices.

Changes:
- Modified `src/components/ui/SearchBox.tsx` to wrap the icon and input in a relative container.
- Absolutely positioned the `Search` icon to the left.
- Increased the input's `padding-left` from `pl-3` (12px) to `pl-10` (40px) to provide ample clearance for the icon and consistent spacing.
- Added `pointer-events-none` to the icon to ensure clicks pass through to the input.

Verification:
- Created a reproduction Playwright test on a mobile viewport (iPhone 13).
- Verified via screenshot and video that the collision is resolved and the text starts after the icon.
- Ran all existing search-related tests (`tests/search_mobile.spec.ts` and `tests/search.spec.ts`), all passed.
- Ran the unified quality gate (`td_cli.py pre-submit`), all checks passed.

Fixes #520

---
*PR created automatically by Jules for task [6946222253420010073](https://jules.google.com/task/6946222253420010073) started by @arii*