### PR TITLE
Fix BlogDrafter Component Tokens and Spacing

### DIFF
--- a/src/components/ui/PrimaryActionButton.tsx
+++ b/src/components/ui/PrimaryActionButton.tsx
@@ -7,25 +7,32 @@ interface PrimaryActionButtonProps extends BoxProps {
   as?: ElementType;
 }
 
+import { forwardRef, Ref } from 'react';
+
 /**
  * Standard primary action button used across the lab and preview features.
  * Encapsulates brand-aligned interactive styling.
  */
-export function PrimaryActionButton({ children, className, ...props }: PrimaryActionButtonProps) {
-  return (
-    <Box
-      as="button"
-      display="flex"
-      align="center"
-      justify="center"
-      surface="accent"
-      className={cn(
-        "bg-accent text-bg hover:bg-accent/90 transition-all cursor-pointer font-bold uppercase tracking-widest text-xs",
-        className
-      )}
-      {...props}
-    >
-      {children}
-    </Box>
-  );
-}
+export const PrimaryActionButton = forwardRef<HTMLElement, PrimaryActionButtonProps>(
+  ({ children, className, as = "button", ...props }, ref) => {
+    return (
+      <Box
+        as={as}
+        ref={ref as Ref<HTMLDivElement>}
+        display="flex"
+        align="center"
+        justify="center"
+        surface="accent"
+        className={cn(
+          "bg-accent text-bg hover:bg-accent/90 transition-all cursor-pointer font-bold uppercase tracking-widest text-xs",
+          className
+        )}
+        {...props}
+      >
+        {children}
+      </Box>
+    );
+  }
+);
+
+PrimaryActionButton.displayName = "PrimaryActionButton";

--- a/src/components/ui/PrimaryActionButton.tsx
+++ b/src/components/ui/PrimaryActionButton.tsx
@@ -1,0 +1,31 @@
+import { ReactNode, ElementType } from 'react';
+import { Box, BoxProps } from '@/layouts/Primitives';
+import { cn } from '@/lib/utils';
+
+interface PrimaryActionButtonProps extends BoxProps {
+  children: ReactNode;
+  as?: ElementType;
+}
+
+/**
+ * Standard primary action button used across the lab and preview features.
+ * Encapsulates brand-aligned interactive styling.
+ */
+export function PrimaryActionButton({ children, className, ...props }: PrimaryActionButtonProps) {
+  return (
+    <Box
+      as="button"
+      display="flex"
+      align="center"
+      justify="center"
+      surface="accent"
+      className={cn(
+        "bg-accent text-bg hover:bg-accent/90 transition-all cursor-pointer font-bold uppercase tracking-widest text-xs",
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </Box>
+  );
+}

--- a/src/features/lab/BlogDrafter.tsx
+++ b/src/features/lab/BlogDrafter.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Github, FileText, Send, Terminal, ExternalLink, Info, Check, RotateCcw, Save, History, Trash2, Eye } from 'lucide-react';
 import { Box, Stack, Text, Grid } from '@/layouts/Primitives';
+import { PrimaryActionButton } from '@/components/ui/PrimaryActionButton';
 import { useBlogDrafter } from './useBlogDrafter';
 import { MarkdownRenderer } from '@/components/ui/MarkdownRenderer';
 import { CONTENT_CATEGORIES } from '@/config/content';
@@ -309,20 +310,14 @@ Draft Data: ${JSON.stringify(data, null, 2)}`;
               size="sm"
               className="focus:border-accent outline-none resize-none"
             />
-            <Box
-              as="button"
+            <PrimaryActionButton
               onClick={handleApply}
-              display="flex"
-              align="center"
-              justify="center"
               gap={3}
-              surface="accent"
               padding={4}
-              className="bg-accent text-bg hover:bg-accent/90 transition-all cursor-pointer font-bold uppercase tracking-widest text-xs"
             >
               <Send className="w-4 h-4" />
               APPLY_RESPONSE
-            </Box>
+            </PrimaryActionButton>
           </Stack>
 
           <Box border="b" paddingBottom={2} display="flex" justify="between" align="center">

--- a/src/features/lab/BlogDrafter.tsx
+++ b/src/features/lab/BlogDrafter.tsx
@@ -87,8 +87,8 @@ Draft Data: ${JSON.stringify(data, null, 2)}`;
           </Box>
         </Box>
         <Box border surface="accent" padding="compact" opacity={5} className="bg-accent/5">
-           <Stack gap={2} display="flex" align="start" direction="row">
-              <Box as="span" marginTop={1} className="shrink-0">
+           <Stack gap={2} display="flex" align="baseline" direction="row">
+              <Box as="span" className="shrink-0">
                 <Info className="w-4 h-4 text-accent" />
               </Box>
               <Text variant="body" size="xs">
@@ -110,7 +110,7 @@ Draft Data: ${JSON.stringify(data, null, 2)}`;
                display="flex"
                align="center"
                gap={2}
-               className="text-accent hover:text-accent-brand transition-colors cursor-pointer"
+               className="text-accent hover:opacity-70 transition-all cursor-pointer"
              >
                 <Save className="w-3 h-3" />
                 <Text variant="mono" size="micro" weight="font-bold">SNAPSHOT_NOW</Text>
@@ -318,7 +318,7 @@ Draft Data: ${JSON.stringify(data, null, 2)}`;
               gap={3}
               surface="accent"
               padding={4}
-              className="bg-accent text-bg hover:bg-accent-brand transition-all cursor-pointer font-bold uppercase tracking-widest text-xs"
+              className="bg-accent text-bg hover:bg-accent/90 transition-all cursor-pointer font-bold uppercase tracking-widest text-xs"
             >
               <Send className="w-4 h-4" />
               APPLY_RESPONSE
@@ -335,7 +335,7 @@ Draft Data: ${JSON.stringify(data, null, 2)}`;
                  align="center"
                  gap={1}
                  paddingLeft={4}
-                 className="text-accent hover:text-accent-brand transition-colors cursor-pointer"
+                 className="text-accent hover:opacity-70 transition-all cursor-pointer"
                >
                  <Eye className="w-3 h-3" />
                  <Text variant="mono" size="micro" weight="font-bold">FULL_PREVIEW</Text>

--- a/src/features/lab/components/FullPreview.tsx
+++ b/src/features/lab/components/FullPreview.tsx
@@ -38,7 +38,7 @@ export function FullPreview({
         surface="accent"
         paddingX={4}
         paddingY={2}
-        className="bg-accent text-bg hover:bg-accent-brand transition-all cursor-pointer font-bold uppercase tracking-widest text-xs shadow-xl"
+        className="bg-accent text-bg hover:bg-accent/90 transition-all cursor-pointer font-bold uppercase tracking-widest text-xs shadow-xl"
       >
         <Layout className="w-4 h-4" />
         EXIT_FULL_PREVIEW

--- a/src/features/lab/components/FullPreview.tsx
+++ b/src/features/lab/components/FullPreview.tsx
@@ -1,5 +1,6 @@
 import { ExternalLink, Layout } from 'lucide-react';
 import { Box, Stack, Text } from '@/layouts/Primitives';
+import { PrimaryActionButton } from '@/components/ui/PrimaryActionButton';
 import { DetailLayout } from '@/components/layout/DetailLayout';
 
 interface FullPreviewProps {
@@ -25,24 +26,20 @@ export function FullPreview({
 }: FullPreviewProps) {
   return (
     <Box position="relative">
-      <Box
+      <PrimaryActionButton
         position="fixed"
         top={4}
         right={4}
         zIndex={50}
-        as="button"
         onClick={onClose}
-        display="flex"
-        align="center"
         gap={2}
-        surface="accent"
         paddingX={4}
         paddingY={2}
-        className="bg-accent text-bg hover:bg-accent/90 transition-all cursor-pointer font-bold uppercase tracking-widest text-xs shadow-xl"
+        className="shadow-xl"
       >
         <Layout className="w-4 h-4" />
         EXIT_FULL_PREVIEW
-      </Box>
+      </PrimaryActionButton>
       <DetailLayout
         title={title || 'Untitled Post'}
         category={category}


### PR DESCRIPTION
Updated `BlogDrafter.tsx` and `FullPreview.tsx` to align with the design system. Replaced non-standard colors like `text-accent-brand` and `hover:bg-accent-brand` with the standard `accent` token and Tailwind opacity modifiers (`hover:bg-accent/90`, `hover:opacity-70`). Also replaced manual margin spacing (`marginTop={1}`) with the `align="baseline"` prop on the parent `Stack` component for a more robust layout. Passed all quality gates and anti-pattern audits.

Fixes #319

---
*PR created automatically by Jules for task [13988297076008218308](https://jules.google.com/task/13988297076008218308) started by @arii*