### PR TITLE
Verify SEO Crawling 404 Status Codes with SPA Stub Generation

### DIFF
--- a/scripts/generate-spa-stubs.mjs
+++ b/scripts/generate-spa-stubs.mjs
@@ -7,6 +7,7 @@ const __dirname = path.dirname(__filename);
 
 import { CONTENT_DIR_MAP, getContentSlugs } from './content-loader.ts';
 import { routes } from '../src/config/routes.ts';
+import { RESEARCH_TOOLS } from '../src/config/research-tools.ts';
 
 const DIST_DIR = path.resolve(__dirname, '../dist');
 const INDEX_HTML = path.join(DIST_DIR, 'index.html');
@@ -21,7 +22,10 @@ const DYNAMIC_ROUTES = Object.entries(CONTENT_DIR_MAP).flatMap(([prefix, dir]) =
   getContentSlugs(dir, prefix)
 );
 
-const STUB_ROUTES = [...STATIC_ROUTES, ...DYNAMIC_ROUTES];
+// Dynamic research tool routes
+const TOOL_ROUTES = RESEARCH_TOOLS.map(tool => `/research/${tool.id}`);
+
+const STUB_ROUTES = [...STATIC_ROUTES, ...DYNAMIC_ROUTES, ...TOOL_ROUTES];
 
 async function generateStubs() {
   if (!fs.existsSync(INDEX_HTML)) {

--- a/scripts/generate-spa-stubs.mjs
+++ b/scripts/generate-spa-stubs.mjs
@@ -5,27 +5,16 @@ import { fileURLToPath } from 'url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-import { CONTENT_DIR_MAP, getContentSlugs } from './content-loader.ts';
-import { routes } from '../src/config/routes.ts';
-import { RESEARCH_TOOLS } from '../src/config/research-tools.ts';
+import { getAllRoutes } from '../src/lib/routes-discovery.ts';
 
 const DIST_DIR = path.resolve(__dirname, '../dist');
 const INDEX_HTML = path.join(DIST_DIR, 'index.html');
 
-// Automatically discover static routes from configuration, excluding parameterized and catch-all
-const STATIC_ROUTES = routes
-  .map(r => r.path)
-  .filter(path => path !== '*' && !path.includes(':') && path !== '/');
+// Automatically discover all routes
+const { all: STUB_ROUTES } = getAllRoutes();
 
-// Dynamic routes from content
-const DYNAMIC_ROUTES = Object.entries(CONTENT_DIR_MAP).flatMap(([prefix, dir]) =>
-  getContentSlugs(dir, prefix)
-);
-
-// Dynamic research tool routes
-const TOOL_ROUTES = RESEARCH_TOOLS.map(tool => `/research/${tool.id}`);
-
-const STUB_ROUTES = [...STATIC_ROUTES, ...DYNAMIC_ROUTES, ...TOOL_ROUTES];
+// Filter out root path as it already has index.html
+const filteredRoutes = STUB_ROUTES.filter(route => route !== '/');
 
 async function generateStubs() {
   if (!fs.existsSync(INDEX_HTML)) {
@@ -35,7 +24,7 @@ async function generateStubs() {
 
   const indexContent = fs.readFileSync(INDEX_HTML, 'utf-8');
 
-  for (const route of STUB_ROUTES) {
+  for (const route of filteredRoutes) {
     const dirPath = path.join(DIST_DIR, route);
     
     if (!fs.existsSync(dirPath)) {

--- a/src/config/research-tools.ts
+++ b/src/config/research-tools.ts
@@ -1,0 +1,38 @@
+export interface ResearchTool {
+  id: string;
+  name: string;
+  category: string;
+  status: string;
+  layman: string;
+}
+
+export const RESEARCH_TOOLS: ResearchTool[] = [
+  {
+    id: 'wcs-scraper',
+    name: 'WCS Prelim Scoring Scraper',
+    category: 'Dance Research',
+    status: 'Active',
+    layman: 'A sophisticated scraper for extracting and analyzing preliminary scoring data from WCS competitions.'
+  },
+  {
+    id: 'blog-drafter',
+    name: 'Blog Post Drafter',
+    category: 'Content Generation',
+    status: 'Active',
+    layman: 'Drafter tool to generate blog posts using AI with human feedback in the loop.'
+  },
+  {
+    id: 'flight-finder',
+    name: 'Event Flight Finder',
+    category: 'Logistics',
+    status: 'Active',
+    layman: 'Flight finder for WCS events - optimizing travel routes and finding the best deals.'
+  },
+  {
+    id: 'ux-auditor',
+    name: 'Visual UX Auditor',
+    category: 'Development Tool',
+    status: 'Active',
+    layman: 'Automated visual regression and UX improvement suggestions across viewports.'
+  }
+];

--- a/src/features/research/useResearch.ts
+++ b/src/features/research/useResearch.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { getStudies } from '@/lib/content';
+import { RESEARCH_TOOLS } from '@/config/research-tools';
 
 export function useResearch() {
   const { data: studies = [] } = useQuery({
@@ -7,43 +8,12 @@ export function useResearch() {
     queryFn: getStudies,
   });
 
-  const tools = [
-    {
-      id: 'wcs-scraper',
-      name: 'WCS Prelim Scoring Scraper',
-      category: 'Dance Research',
-      status: 'Active',
-      layman: 'A sophisticated scraper for extracting and analyzing preliminary scoring data from WCS competitions.'
-    },
-    {
-      id: 'blog-drafter',
-      name: 'Blog Post Drafter',
-      category: 'Content Generation',
-      status: 'Active',
-      layman: 'Drafter tool to generate blog posts using AI with human feedback in the loop.'
-    },
-    {
-      id: 'flight-finder',
-      name: 'Event Flight Finder',
-      category: 'Logistics',
-      status: 'Active',
-      layman: 'Flight finder for WCS events - optimizing travel routes and finding the best deals.'
-    },
-    {
-      id: 'ux-auditor',
-      name: 'Visual UX Auditor',
-      category: 'Development Tool',
-      status: 'Active',
-      layman: 'Automated visual regression and UX improvement suggestions across viewports.'
-    }
-  ];
-
-  const getTool = (id: string) => tools.find(t => t.id === id);
+  const getTool = (id: string) => RESEARCH_TOOLS.find(t => t.id === id);
   const getStudy = (slug: string) => studies.find(s => s.slug === slug);
 
   return {
     studies,
-    tools,
+    tools: RESEARCH_TOOLS,
     getTool,
     getStudy
   };

--- a/src/lib/routes-discovery.ts
+++ b/src/lib/routes-discovery.ts
@@ -1,0 +1,34 @@
+import { CONTENT_DIR_MAP, getContentSlugs } from '../../scripts/content-loader.ts';
+import { routes } from '../config/routes.ts';
+import { RESEARCH_TOOLS } from '../config/research-tools.ts';
+
+/**
+ * Discovers all application routes from various sources.
+ * Centralizes discovery logic to prevent duplication and drift.
+ *
+ * Used by:
+ * - vite.config.ts (for sitemap generation)
+ * - scripts/generate-spa-stubs.mjs (for SPA 200 OK stubs)
+ * - src/config/routes.ts (potential for runtime validation)
+ */
+export function getAllRoutes() {
+  // 1. Static routes from configuration (excluding parameterized and catch-all)
+  const staticRoutes = routes
+    .map(r => r.path)
+    .filter(path => path !== '*' && !path.includes(':'));
+
+  // 2. Dynamic research tool routes
+  const toolRoutes = RESEARCH_TOOLS.map(tool => `/research/${tool.id}`);
+
+  // 3. Dynamic content routes discovered from file system
+  const contentRoutes = Object.entries(CONTENT_DIR_MAP).flatMap(([prefix, dir]) =>
+    getContentSlugs(dir, prefix)
+  );
+
+  return {
+    static: staticRoutes,
+    tools: toolRoutes,
+    content: contentRoutes,
+    all: [...staticRoutes, ...toolRoutes, ...contentRoutes]
+  };
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,7 @@ import { ViteImageOptimizer } from 'vite-plugin-image-optimizer';
 import Sitemap from 'vite-plugin-sitemap';
 import { CONTENT_DIR_MAP, getContentSlugs } from './scripts/content-loader';
 import { routes } from './src/config/routes';
+import { RESEARCH_TOOLS } from './src/config/research-tools';
 
 export default defineConfig(({mode}) => {
   const env = loadEnv(mode, process.cwd(), '');
@@ -52,6 +53,8 @@ export default defineConfig(({mode}) => {
     ...routes
       .map(r => r.path)
       .filter(path => path !== '*' && !path.includes(':')),
+    // Dynamic research tool routes
+    ...RESEARCH_TOOLS.map(tool => `/research/${tool.id}`),
     // Dynamic content routes discovered from file system
     ...Object.entries(CONTENT_DIR_MAP).flatMap(([prefix, dir]) =>
       getContentSlugs(dir, prefix)

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,9 +6,7 @@ import { defineConfig, loadEnv } from 'vite';
 import Inspect from 'vite-plugin-inspect';
 import { ViteImageOptimizer } from 'vite-plugin-image-optimizer';
 import Sitemap from 'vite-plugin-sitemap';
-import { CONTENT_DIR_MAP, getContentSlugs } from './scripts/content-loader';
-import { routes } from './src/config/routes';
-import { RESEARCH_TOOLS } from './src/config/research-tools';
+import { getAllRoutes } from './src/lib/routes-discovery';
 
 export default defineConfig(({mode}) => {
   const env = loadEnv(mode, process.cwd(), '');
@@ -47,19 +45,8 @@ export default defineConfig(({mode}) => {
   const hostname = resolveHostname().replace(/\/$/, '');
   const fullAppUrl = new URL(base, hostname).href;
 
-  // Automatically discover dynamic routes from config/routes.ts and content directories
-  const dynamicRoutes = [
-    // Static routes from config (excluding parameterized and catch-all)
-    ...routes
-      .map(r => r.path)
-      .filter(path => path !== '*' && !path.includes(':')),
-    // Dynamic research tool routes
-    ...RESEARCH_TOOLS.map(tool => `/research/${tool.id}`),
-    // Dynamic content routes discovered from file system
-    ...Object.entries(CONTENT_DIR_MAP).flatMap(([prefix, dir]) =>
-      getContentSlugs(dir, prefix)
-    ),
-  ];
+  // Automatically discover dynamic routes
+  const { all: dynamicRoutes } = getAllRoutes();
 
   return {
     base,


### PR DESCRIPTION
This change resolves an SEO indexing issue where dynamic routes for research tools were returning 404 status codes on GitHub Pages. By centralizing the research tools configuration, we can now automatically include these routes in both the sitemap and the SPA stub generation process. This ensures that direct navigation to routes like `/research/wcs-scraper` returns a physical `index.html` with a 200 OK status, while still maintaining the single-page application architecture.

Fixes #555

---
*PR created automatically by Jules for task [9606220324641922541](https://jules.google.com/task/9606220324641922541) started by @arii*