### PR TITLE
Normalize content frontmatter and tagging

### DIFF
--- a/content/events/weekly.md
+++ b/content/events/weekly.md
@@ -1,11 +1,15 @@
 ---
-type: event
+type: "event"
 title: "Weekly Class"
 location: "Mission City Swing"
 city: "San Francisco // CA"
 schedule: "Wednesdays"
 description: "Weekly social dance and classes at Mission City Swing."
 link: "https://missioncityswing.com"
+author: "Ariel Anders, PhD"
+date: "2026-01-01"
+category: "General"
+excerpt: "Weekly social dance and classes at Mission City Swing."
 ---
 
 Mission City Swing is the hub for WCS in San Francisco. Join us every Wednesday for classes and social dancing.

--- a/content/posts/2026-04-18-ai-content-creation.md
+++ b/content/posts/2026-04-18-ai-content-creation.md
@@ -1,5 +1,5 @@
 ---
-type: post
+type: "post"
 title: "AI powered content creation and development"
 date: "2026-04-18"
 author: "Ariel Anders, PhD"

--- a/content/posts/2026-04-18-ai-role-dance.md
+++ b/content/posts/2026-04-18-ai-role-dance.md
@@ -1,5 +1,5 @@
 ---
-type: post
+type: "post"
 title: "The role of AI in Dance"
 date: "2026-04-18"
 author: "Ariel Anders, PhD"

--- a/content/posts/2026-04-18-competition-metrics.md
+++ b/content/posts/2026-04-18-competition-metrics.md
@@ -1,5 +1,5 @@
 ---
-type: post
+type: "post"
 title: "Ignore scores and focus on your results"
 date: "2026-04-18"
 author: "Ariel Anders, PhD"

--- a/content/posts/2026-04-18-financial-literacy-dancers.md
+++ b/content/posts/2026-04-18-financial-literacy-dancers.md
@@ -1,5 +1,5 @@
 ---
-type: post
+type: "post"
 title: "Why I have the Amex Platinum and Hyatt card"
 date: "2026-04-18"
 author: "Ariel Anders, PhD"
@@ -7,8 +7,8 @@ category: "Travel/Lifestyle"
 excerpt: "A deep dive into financial literacy for dancers: maximizing travel perks while maintaining a responsible credit-as-debit philosophy."
 image: ""
 tags:
-  - financial literacy
-  - travel hacking
+  - financial-literacy
+  - travel-hacking
   - wcs
 ---
 

--- a/content/posts/2026-04-18-github-actions.md
+++ b/content/posts/2026-04-18-github-actions.md
@@ -1,5 +1,5 @@
 ---
-type: post
+type: "post"
 title: "How I used GitHub Actions to power this site"
 date: "2026-04-18"
 author: "Ariel Anders, PhD"

--- a/content/posts/2026-04-18-halloween-costumes.md
+++ b/content/posts/2026-04-18-halloween-costumes.md
@@ -1,5 +1,5 @@
 ---
-type: post
+type: "post"
 title: "Halloween costumes you can dance in"
 date: "2026-04-18"
 author: "Ariel Anders, PhD"

--- a/content/posts/2026-04-18-make-shoe-dance.md
+++ b/content/posts/2026-04-18-make-shoe-dance.md
@@ -1,5 +1,5 @@
 ---
-type: post
+type: "post"
 title: "Make any shoe a dance shoe"
 date: "2026-04-18"
 author: "Ariel Anders, PhD"

--- a/content/posts/2026-04-18-pivoting-consultant.md
+++ b/content/posts/2026-04-18-pivoting-consultant.md
@@ -1,5 +1,5 @@
 ---
-type: post
+type: "post"
 title: "Pivoting to consulting and project based work"
 date: "2026-04-18"
 author: "Ariel Anders, PhD"

--- a/content/posts/2026-04-18-why-finals-are-hard.md
+++ b/content/posts/2026-04-18-why-finals-are-hard.md
@@ -1,5 +1,5 @@
 ---
-type: post
+type: "post"
 title: "The majority of above average dancers don’t make it to finals"
 date: "2026-04-18"
 author: "Ariel Anders, PhD"

--- a/content/posts/2026-04-19-gear-essentials.md
+++ b/content/posts/2026-04-19-gear-essentials.md
@@ -1,12 +1,15 @@
 ---
-type: post
+type: "post"
 title: "The WCS Travel Pack: 3 Essentials You’re Forgetting"
 date: "2026-04-19"
 author: "Ariel Anders, PhD"
 category: "Travel"
 excerpt: "Loop earplugs, industrial travel steamers, and portable sound. Why these three Pieces of gear are the secret to a better dance weekend."
 image: ""
-tags: ["travel", "gear", "systems"]
+tags:
+  - travel
+  - gear
+  - systems
 ---
 
 ## Elevating Your Dance Weekend

--- a/content/posts/2026-04-20-stop-wasting-vercel-credits-deploy-every-branch-to-github-pages.md
+++ b/content/posts/2026-04-20-stop-wasting-vercel-credits-deploy-every-branch-to-github-pages.md
@@ -1,9 +1,10 @@
 ---
-title: Stop Wasting Vercel Credits: Deploy Every Branch to GitHub Pages
-date: 2026-04-20
-author: Ariel Anders, PhD
-category: Tech
-excerpt: Time is your most precious commodity. Narrow the gap between coding and seeing your changes by deploying every branch to GitHub Pages.
+title: "Stop Wasting Vercel Credits: Deploy Every Branch to GitHub Pages"
+date: "2026-04-20"
+author: "Ariel Anders, PhD"
+category: "Tech"
+excerpt: "Time is your most precious commodity. Narrow the gap between coding and seeing your changes by deploying every branch to GitHub Pages."
+type: "post"
 ---
 
 ### Kill the Vercel Build Grind

--- a/content/resources/2026-04-12-suede-shoe-diy.md
+++ b/content/resources/2026-04-12-suede-shoe-diy.md
@@ -1,5 +1,5 @@
 ---
-type: resource
+type: "resource"
 title: "How to Suede Your Own Dance Shoes for $15"
 date: "2026-04-12"
 author: "Ariel Anders, PhD"
@@ -12,7 +12,7 @@ tags:
   - diy
   - footwear
   - budget
-rating: 4.7
+rating: "4.7"
 verdict: "Best Budget Hack"
 priceCategory: "$"
 updatedDate: "Mar 2024"

--- a/content/resources/loop-earplugs.md
+++ b/content/resources/loop-earplugs.md
@@ -1,14 +1,20 @@
 ---
-type: resource
+type: "resource"
 title: "Loop Experience Earplugs"
 category: "Dance Gear"
 excerpt: "A must-have for protecting your hearing in loud ballroom and social dance settings without sacrificing sound quality."
-affiliateIds: ["loop-experience"]
-tags: ["safety", "ballroom", "music"]
-rating: 5
+affiliateIds:
+  - loop-experience
+tags:
+  - safety
+  - ballroom
+  - music
+rating: "5"
 verdict: "Highly Recommended"
 priceCategory: "$$"
 updatedDate: "Oct 2023"
+author: "Ariel Anders, PhD"
+date: "2026-01-01"
 ---
 
 ## Why Dancers Need Hearing Protection

--- a/content/resources/portable-speaker.md
+++ b/content/resources/portable-speaker.md
@@ -1,14 +1,20 @@
 ---
-type: resource
+type: "resource"
 title: "Portable Bluetooth Speaker (UE Wonderboom 4)"
 category: "Dance Gear"
 excerpt: "Rugged, waterproof, and surprisingly loud. Perfect for hotel practice sessions or outdoor social gatherings."
-affiliateIds: ["amazon"]
-tags: ["practice", "music", "travel"]
-rating: 4.8
+affiliateIds:
+  - amazon
+tags:
+  - practice
+  - music
+  - travel
+rating: "4.8"
 verdict: "Best for Travel"
 priceCategory: "$$"
 updatedDate: "Jan 2024"
+author: "Ariel Anders, PhD"
+date: "2026-01-01"
 ---
 
 ## Practice Anywhere

--- a/content/resources/travel-steamer.md
+++ b/content/resources/travel-steamer.md
@@ -1,14 +1,20 @@
 ---
-type: resource
+type: "resource"
 title: "Travel Steamer Pro"
 category: "Travel"
 excerpt: "Compact, efficient, and dual-voltage. Keep your competition shirts and skirts wrinkle-free on the road."
-affiliateIds: ["amazon"]
-tags: ["travel", "clothing", "competition"]
-rating: 4.5
+affiliateIds:
+  - amazon
+tags:
+  - travel
+  - clothing
+  - competition
+rating: "4.5"
 verdict: "Essential for Competitors"
 priceCategory: "$$$"
 updatedDate: "Nov 2023"
+author: "Ariel Anders, PhD"
+date: "2026-01-01"
 ---
 
 ## Competition Ready, Anywhere

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "clean": "rm -rf dist",
     "lint": "run-p lint:*",
     "lint:ox": "oxlint --deny-warnings",
+    "lint:content": "tsx scripts/validate-content.ts",
     "lint:eslint": "eslint . --max-warnings 0",
     "lint:types": "tsc --noEmit",
     "knip": "knip",

--- a/scripts/normalize-content.ts
+++ b/scripts/normalize-content.ts
@@ -1,0 +1,124 @@
+import fs from 'fs';
+import { glob } from 'glob';
+
+/**
+ * Normalizes a string to lowercase kebab-case.
+ */
+function toKebabCase(str: string) {
+  return str
+    .toLowerCase()
+    .trim()
+    .replace(/\s+/g, '-')
+    .replace(/[^a-z0-9-]/g, '');
+}
+
+/**
+ * Lightweight browser-safe frontmatter parser (mirrored from src/lib/content.ts)
+ */
+function parseFrontmatter(content: string) {
+  const match = content.match(/^---\n([\s\S]+?)\n---\n([\s\S]*)$/);
+  if (!match) return null;
+
+  const yaml = match[1];
+  const body = match[2];
+  const data: Record<string, string | number | string[] | undefined> = {};
+
+  let currentKey = '';
+  yaml.split('\n').forEach(line => {
+    const trimmed = line.trim();
+    if (!trimmed) return;
+
+    if (line.startsWith('  - ')) {
+      // List item
+      if (currentKey) {
+        if (!Array.isArray(data[currentKey])) data[currentKey] = [];
+        let val = trimmed.replace(/^-\s+/, '').trim();
+        if (val.startsWith('"') && val.endsWith('"')) val = val.slice(1, -1);
+        else if (val.startsWith("'") && val.endsWith("'")) val = val.slice(1, -1);
+        data[currentKey].push(val);
+      }
+    } else {
+      const colonIdx = line.indexOf(':');
+      if (colonIdx !== -1) {
+        const key = line.slice(0, colonIdx).trim();
+        let value = line.slice(colonIdx + 1).trim();
+        currentKey = key;
+
+        if (value.startsWith('[') && value.endsWith(']')) {
+          const inner = value.slice(1, -1).trim();
+          data[key] = inner ? inner.split(',').map(v => {
+            let item = v.trim();
+            if (item.startsWith('"') && item.endsWith('"')) item = item.slice(1, -1);
+            else if (item.startsWith("'") && item.endsWith("'")) item = item.slice(1, -1);
+            return item;
+          }) : [];
+        } else if (value) {
+          if (value.startsWith('"') && value.endsWith('"')) value = value.slice(1, -1);
+          else if (value.startsWith("'") && value.endsWith("'")) value = value.slice(1, -1);
+          data[key] = value;
+        }
+      }
+    }
+  });
+
+  return { data, body };
+}
+
+function stringifyFrontmatter(data: Record<string, string | number | string[] | undefined>) {
+  let yaml = '---\n';
+  Object.entries(data).forEach(([key, value]) => {
+    if (Array.isArray(value)) {
+      yaml += `${key}:\n`;
+      value.forEach(item => {
+        yaml += `  - ${item}\n`;
+      });
+    } else {
+      yaml += `${key}: ${JSON.stringify(value)}\n`;
+    }
+  });
+  yaml += '---';
+  return yaml;
+}
+
+async function normalize() {
+  const files = await glob('content/**/*.md');
+
+  console.log(`🔨 Normalizing ${files.length} content files...`);
+
+  for (const file of files) {
+    const content = fs.readFileSync(file, 'utf8');
+    const parsed = parseFrontmatter(content);
+
+    if (!parsed) {
+      console.warn(`⚠️ Skipping ${file}: No frontmatter`);
+      continue;
+    }
+
+    const { data, body } = parsed;
+
+    // 1. Normalize tags
+    if (data.tags && Array.isArray(data.tags)) {
+      data.tags = data.tags.map(toKebabCase);
+    }
+
+    // 2. Ensure mandatory fields
+    if (!data.author) data.author = "Ariel Anders, PhD";
+    if (!data.date) {
+        // Try to extract date from filename
+        const dateMatch = file.match(/(\d{4}-\d{2}-\d{2})/);
+        data.date = dateMatch ? dateMatch[1] : "2026-01-01";
+    }
+    if (!data.category) data.category = "General";
+    if (!data.excerpt) data.excerpt = data.description || "No excerpt provided.";
+
+    // Special fix for the one file with invalid type
+    if (data.type === "Post") data.type = "post";
+    if (!data.type) data.type = "post";
+
+    const newContent = `${stringifyFrontmatter(data)}\n${body}`;
+    fs.writeFileSync(file, newContent);
+    console.log(`✅ Normalized ${file}`);
+  }
+}
+
+normalize().catch(console.error);

--- a/scripts/validate-content.ts
+++ b/scripts/validate-content.ts
@@ -1,0 +1,146 @@
+import fs from 'fs';
+import { glob } from 'glob';
+import { z } from 'zod';
+
+const tagRegex = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+
+const BaseSchema = z.object({
+  type: z.enum(['post', 'resource', 'study', 'event']),
+  title: z.string().min(1),
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Date must be YYYY-MM-DD"),
+  author: z.string().min(1),
+  category: z.string().min(1),
+  excerpt: z.string().min(1),
+  tags: z.array(z.string().regex(tagRegex, "Tags must be lowercase kebab-case")).optional(),
+});
+
+const PostSchema = BaseSchema.extend({
+  type: z.literal('post'),
+  image: z.string().optional(),
+  affiliateIds: z.array(z.string()).optional(),
+});
+
+const ResourceSchema = BaseSchema.extend({
+  type: z.literal('resource'),
+  image: z.string().optional(),
+  affiliateIds: z.array(z.string()).optional(),
+  rating: z.number().optional(),
+  verdict: z.string().optional(),
+  priceCategory: z.string().optional(),
+  updatedDate: z.string().optional(),
+  durability: z.number().optional(),
+  value: z.number().optional(),
+  specs: z.record(z.string()).optional(),
+});
+
+const StudySchema = BaseSchema.extend({
+  type: z.literal('study'),
+});
+
+const EventSchema = BaseSchema.extend({
+  type: z.literal('event'),
+  location: z.string(),
+  city: z.string(),
+  schedule: z.string(),
+  description: z.string(),
+  link: z.string().optional(),
+});
+
+const ContentSchema = z.discriminatedUnion('type', [
+  PostSchema,
+  ResourceSchema,
+  StudySchema,
+  EventSchema,
+]);
+
+/**
+ * Lightweight browser-safe frontmatter parser (mirrored from src/lib/content.ts)
+ */
+function parseFrontmatter(content: string) {
+  const match = content.match(/^---\n([\s\S]+?)\n---\n/);
+  if (!match) return null;
+
+  const yaml = match[1];
+  const data: Record<string, string | number | string[] | undefined> = {};
+
+  let currentKey = '';
+  yaml.split('\n').forEach(line => {
+    const trimmed = line.trim();
+    if (!trimmed) return;
+
+    if (line.startsWith('  - ')) {
+      // List item
+      if (currentKey) {
+        if (!Array.isArray(data[currentKey])) data[currentKey] = [];
+        let val = trimmed.replace(/^-\s+/, '').trim();
+        if (val.startsWith('"') && val.endsWith('"')) val = val.slice(1, -1);
+        else if (val.startsWith("'") && val.endsWith("'")) val = val.slice(1, -1);
+        data[currentKey].push(val);
+      }
+    } else {
+      const colonIdx = line.indexOf(':');
+      if (colonIdx !== -1) {
+        const key = line.slice(0, colonIdx).trim();
+        let value = line.slice(colonIdx + 1).trim();
+        currentKey = key;
+
+        if (value.startsWith('[') && value.endsWith(']')) {
+          const inner = value.slice(1, -1).trim();
+          data[key] = inner ? inner.split(',').map(v => {
+            let item = v.trim();
+            if (item.startsWith('"') && item.endsWith('"')) item = item.slice(1, -1);
+            else if (item.startsWith("'") && item.endsWith("'")) item = item.slice(1, -1);
+            return item;
+          }) : [];
+        } else if (value) {
+          if (value.startsWith('"') && value.endsWith('"')) value = value.slice(1, -1);
+          else if (value.startsWith("'") && value.endsWith("'")) value = value.slice(1, -1);
+
+          // Basic numeric conversion for rating
+          if (['rating', 'durability', 'value'].includes(key)) data[key] = parseFloat(value);
+          else data[key] = value;
+        }
+      }
+    }
+  });
+
+  return data;
+}
+
+async function validate() {
+  const files = await glob('content/**/*.md');
+  let hasError = false;
+
+  console.log(`🔍 Validating ${files.length} content files...`);
+
+  for (const file of files) {
+    const content = fs.readFileSync(file, 'utf8');
+    const data = parseFrontmatter(content);
+
+    if (!data) {
+      console.error(`❌ ${file}: Missing frontmatter block`);
+      hasError = true;
+      continue;
+    }
+
+    const result = ContentSchema.safeParse(data);
+    if (!result.success) {
+      console.error(`❌ ${file}:`);
+      result.error.issues.forEach(issue => {
+        console.error(`  - [${issue.path.join('.')}] ${issue.message}`);
+      });
+      hasError = true;
+    }
+  }
+
+  if (hasError) {
+    process.exit(1);
+  } else {
+    console.log('✅ All content files validated successfully');
+  }
+}
+
+validate().catch(err => {
+  console.error('Fatal error during validation:', err);
+  process.exit(1);
+});

--- a/src/features/lab/BlogDrafter.tsx
+++ b/src/features/lab/BlogDrafter.tsx
@@ -121,6 +121,33 @@ Draft Data: ${JSON.stringify(data, null, 2)}`;
           </Box>
 
           <Stack gap={6}>
+            <Grid cols={2} gap={4}>
+              <Stack gap={2}>
+                <Text variant="mono" size="micro" color="dim" className={inputs.label} marginBottom={0}>CONTENT_TYPE</Text>
+                <Box
+                  as="select"
+                  value={data.type}
+                  onChange={(e: ChangeEvent<HTMLSelectElement>) => updateField('type', e.target.value)}
+                  className={cn(inputs.base, "appearance-none")}
+                >
+                  <option value="post">Blog Post</option>
+                  <option value="resource">Gear Resource</option>
+                  <option value="study">Data Study</option>
+                  <option value="event">Event</option>
+                </Box>
+              </Stack>
+              <Stack gap={2}>
+                <Text variant="mono" size="micro" color="dim" className={inputs.label} marginBottom={0}>DATE</Text>
+                <Box
+                  as="input"
+                  type="date"
+                  value={data.date}
+                  onChange={(e: ChangeEvent<HTMLInputElement>) => updateField('date', e.target.value)}
+                  className={inputs.base}
+                />
+              </Stack>
+            </Grid>
+
             <Stack gap={2}>
               <Text variant="mono" size="micro" color="dim" className={inputs.label} marginBottom={0}>POST_TITLE</Text>
               <Box
@@ -148,12 +175,12 @@ Draft Data: ${JSON.stringify(data, null, 2)}`;
                 </Box>
               </Stack>
               <Stack gap={2}>
-                <Text variant="mono" size="micro" color="dim" className={inputs.label} marginBottom={0}>DATE</Text>
+                <Text variant="mono" size="micro" color="dim" className={inputs.label} marginBottom={0}>AUTHOR</Text>
                 <Box
                   as="input"
-                  type="date"
-                  value={data.date}
-                  onChange={(e: ChangeEvent<HTMLInputElement>) => updateField('date', e.target.value)}
+                  type="text"
+                  value={data.author}
+                  onChange={(e: ChangeEvent<HTMLInputElement>) => updateField('author', e.target.value)}
                   className={inputs.base}
                 />
               </Stack>
@@ -170,6 +197,31 @@ Draft Data: ${JSON.stringify(data, null, 2)}`;
                 className={cn(inputs.base, "resize-none")}
               />
             </Stack>
+
+            <Grid cols={2} gap={4}>
+              <Stack gap={2}>
+                <Text variant="mono" size="micro" color="dim" className={inputs.label} marginBottom={0}>TAGS (COMMA SEPARATED)</Text>
+                <Box
+                  as="input"
+                  type="text"
+                  value={data.tags}
+                  onChange={(e: ChangeEvent<HTMLInputElement>) => updateField('tags', e.target.value)}
+                  placeholder="tag-one, tag-two"
+                  className={inputs.base}
+                />
+              </Stack>
+              <Stack gap={2}>
+                <Text variant="mono" size="micro" color="dim" className={inputs.label} marginBottom={0}>IMAGE_URL</Text>
+                <Box
+                  as="input"
+                  type="text"
+                  value={data.image}
+                  onChange={(e: ChangeEvent<HTMLInputElement>) => updateField('image', e.target.value)}
+                  placeholder="https://picsum.photos/..."
+                  className={inputs.base}
+                />
+              </Stack>
+            </Grid>
 
             <Stack gap={2}>
               <Text variant="mono" size="micro" color="dim" className={inputs.label} marginBottom={0}>AMAZON_AFFILIATE_LINK (OPTIONAL)</Text>

--- a/src/features/lab/useBlogDrafter.ts
+++ b/src/features/lab/useBlogDrafter.ts
@@ -3,6 +3,7 @@ import { debounce } from 'throttle-debounce';
 import { SITE_METADATA } from '@/config/content';
 
 export interface DraftData {
+  type: string;
   title: string;
   category: string;
   excerpt: string;
@@ -10,6 +11,8 @@ export interface DraftData {
   date: string;
   affiliateLink: string;
   commentary: string;
+  tags: string;
+  image: string;
 }
 
 export interface HistoryEntry {
@@ -41,13 +44,16 @@ export function useBlogDrafter() {
       }
     }
     return {
+      type: 'post',
       title: '',
       category: 'Lifestyle',
       excerpt: '',
       author: SITE_METADATA.author,
       date: new Date().toISOString().split('T')[0],
       affiliateLink: '',
-      commentary: ''
+      commentary: '',
+      tags: '',
+      image: ''
     };
   });
 
@@ -99,18 +105,32 @@ export function useBlogDrafter() {
   };
 
   const markdownPreview = useMemo(() => {
-    return `# ${data.title || '[Title]'}
+    const normalizeTag = (tag: string) => tag.toLowerCase().trim().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
+    const tagsArr = data.tags.split(',').map(normalizeTag).filter(Boolean);
 
-> **Category**: ${data.category} | **Date**: ${data.date} | **Author**: ${data.author}
+    const frontmatter = {
+      type: data.type,
+      title: data.title || 'Untitled',
+      date: data.date,
+      author: data.author,
+      category: data.category,
+      excerpt: data.excerpt || 'No excerpt provided.',
+      image: data.image || '',
+      tags: tagsArr,
+      ...(data.affiliateLink ? { affiliateIds: ['amazon'] } : {})
+    };
 
-${data.excerpt ? `*${data.excerpt}*` : ''}
+    const yaml = `---\n${Object.entries(frontmatter)
+      .map(([key, value]) => {
+        if (Array.isArray(value)) {
+          if (value.length === 0) return `${key}: []`;
+          return `${key}:\n${value.map(v => `  - ${v}`).join('\n')}`;
+        }
+        return `${key}: ${JSON.stringify(value)}`;
+      })
+      .join('\n')}\n---`;
 
----
-
-${data.commentary || '[Your commentary/content goes here]'}
-
-${data.affiliateLink ? `\n[Buy on Amazon](${data.affiliateLink})` : ''}
-`;
+    return `${yaml}\n\n${data.commentary || '[Your content goes here]'}${data.affiliateLink ? `\n\n[Buy on Amazon](${data.affiliateLink})` : ''}`;
   }, [data]);
 
   const githubIssueUrl = useMemo(() => {
@@ -156,13 +176,16 @@ ${data.affiliateLink ? `\n[Buy on Amazon](${data.affiliateLink})` : ''}
 
   const clearForm = () => {
     setData({
+      type: 'post',
       title: '',
       category: 'Lifestyle',
       excerpt: '',
       author: SITE_METADATA.author,
       date: new Date().toISOString().split('T')[0],
       affiliateLink: '',
-      commentary: ''
+      commentary: '',
+      tags: '',
+      image: ''
     });
   };
 

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -106,12 +106,17 @@ export interface Study {
 export interface Event {
   slug: string;
   title: string;
+  date: string;
+  author: string;
+  category: string;
+  excerpt: string;
   location: string;
   city: string;
   schedule: string;
   description: string;
   link?: string;
   content: string;
+  tags?: string[];
 }
 
 export type ContentItem = Post | Resource | Study | Event;
@@ -129,6 +134,17 @@ const contentModules = {
 
 const slugFrom = (path: string) => path.split('/').pop()?.replace('.md', '') || '';
 
+/**
+ * Normalizes a tag to lowercase kebab-case.
+ */
+function normalizeTag(tag: string) {
+  return tag
+    .toLowerCase()
+    .trim()
+    .replace(/\s+/g, '-')
+    .replace(/[^a-z0-9-]/g, '');
+}
+
 function transform<T extends { date?: string }>(modules: Record<string, string | ContentModule>): T[] {
   return Object.entries(modules)
     .map(([path, raw]) => {
@@ -139,6 +155,10 @@ function transform<T extends { date?: string }>(modules: Record<string, string |
         data.image = undefined;
       }
 
+      const tags = Array.isArray(data.tags)
+        ? data.tags.map(t => normalizeTag(String(t)))
+        : [];
+
       return {
         ...data,
         title: String(data.title || 'Untitled'),
@@ -146,7 +166,7 @@ function transform<T extends { date?: string }>(modules: Record<string, string |
         excerpt: String(data.excerpt || ''),
         date: String(data.date || ''),
         author: String(data.author || ''),
-        tags: Array.isArray(data.tags) ? data.tags : [],
+        tags,
         content: content || '',
         slug: slugFrom(path)
       } as unknown as T;


### PR DESCRIPTION
This PR implements a robust validation and normalization pipeline for content frontmatter and tagging.

Key changes:
1.  **Validation**: Added `scripts/validate-content.ts` which uses Zod to enforce mandatory frontmatter fields (`type`, `title`, `date`, `author`, `category`, `excerpt`) and validates that tags follow the lowercase kebab-case convention.
2.  **Normalization**: Added `scripts/normalize-content.ts` to automatically migrate existing content. It adds missing mandatory fields (with sensible defaults) and converts all tags to kebab-case.
3.  **CI Integration**: A new `lint:content` script is added to `package.json` and included in the main `pnpm lint` command, ensuring no invalid content is merged.
4.  **Runtime Consistency**: Updated `src/lib/content.ts` to ensure the `Event` type matches the mandatory requirements and added a runtime helper to normalize tags, providing a second layer of defense.

All existing content files have been normalized and passed validation.

Fixes #570

---
*PR created automatically by Jules for task [12531175689791989355](https://jules.google.com/task/12531175689791989355) started by @arii*