### PR TITLE
Migrate search hooks to central implementation

### DIFF
--- a/src/features/research/hooks/useWCSData.ts
+++ b/src/features/research/hooks/useWCSData.ts
@@ -1,5 +1,6 @@
 import { useState, useMemo, useEffect } from 'react';
 import { parquetReadObjects } from 'hyparquet';
+import { useSearchParam } from '@/hooks/useSearchParam';
 
 export interface WCSRecord {
   Dancer_ID: string;
@@ -14,8 +15,8 @@ export interface WCSRecord {
 export function useWCSData() {
   const [data, setData] = useState<WCSRecord[]>([]);
   const [isLoading, setIsLoading] = useState(true);
-  const [searchTerm, setSearchTerm] = useState('');
-  const [filterPromoted, setFilterPromoted] = useState<'all' | 'promoted' | 'not-promoted'>('all');
+  const [searchTerm, setSearchTerm] = useSearchParam('search');
+  const [filterPromoted, setFilterPromoted] = useSearchParam<'all' | 'promoted' | 'not-promoted'>('filter', 'all');
 
   useEffect(() => {
     const loadData = async () => {

--- a/src/hooks/useGlobalSearch.ts
+++ b/src/hooks/useGlobalSearch.ts
@@ -1,42 +1,22 @@
 import { useMemo, useCallback } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParam } from './useSearchParam';
 import { useQueries } from '@tanstack/react-query';
 import { getPosts, getResources, getStudies } from '@/lib/content';
 import Fuse from 'fuse.js';
 
 export function useGlobalSearch() {
-  const [searchParams, setSearchParams] = useSearchParams();
-  const query = searchParams.get('q') || '';
-
-  const setQuery = useCallback((newQuery: string) => {
-    setSearchParams(prev => {
-      const next = new URLSearchParams(prev);
-      if (newQuery) {
-        next.set('q', newQuery);
-      } else {
-        next.delete('q');
-      }
-      return next;
-    }, { replace: true });
-  }, [setSearchParams]);
+  const [query, setQuery] = useSearchParam('q');
+  const [searchState, setSearchState] = useSearchParam('modal');
   
-  const isOpen = searchParams.get('search') === 'true';
+  const isOpen = searchState === 'true';
 
   const open = useCallback(() => {
-    setSearchParams(prev => {
-      const next = new URLSearchParams(prev);
-      next.set('search', 'true');
-      return next;
-    }, { replace: true });
-  }, [setSearchParams]);
+    setSearchState('true');
+  }, [setSearchState]);
 
   const close = useCallback(() => {
-    setSearchParams(prev => {
-      const next = new URLSearchParams(prev);
-      next.delete('search');
-      return next;
-    }, { replace: true });
-  }, [setSearchParams]);
+    setSearchState('');
+  }, [setSearchState]);
 
   const [postsQuery, resourcesQuery, studiesQuery] = useQueries({
     queries: [

--- a/src/hooks/useSearchParam.ts
+++ b/src/hooks/useSearchParam.ts
@@ -5,19 +5,21 @@ import { useSearchParams } from "react-router-dom";
  * A hook to manage a single URL search parameter.
  * Centralizes the logic for updating URL state with { replace: true }.
  */
-export function useSearchParam(key: string, defaultValue: string = '') {
+export function useSearchParam<T extends string = string>(key: string, defaultValue: T = '' as T) {
   const [searchParams, setSearchParams] = useSearchParams();
-  const value = searchParams.get(key) || defaultValue;
+  const value = (searchParams.get(key) as T) || defaultValue;
 
-  const setValue = useCallback((newValue: string) => {
-    const params = new URLSearchParams(searchParams);
-    if (newValue && newValue !== defaultValue) {
-      params.set(key, newValue);
-    } else {
-      params.delete(key);
-    }
-    setSearchParams(params, { replace: true });
-  }, [key, defaultValue, searchParams, setSearchParams]);
+  const setValue = useCallback((newValue: T) => {
+    setSearchParams(prev => {
+      const next = new URLSearchParams(prev);
+      if (newValue && newValue !== defaultValue) {
+        next.set(key, newValue);
+      } else {
+        next.delete(key);
+      }
+      return next;
+    }, { replace: true });
+  }, [key, defaultValue, setSearchParams]);
 
   return [value, setValue] as const;
 }

--- a/tests/search.spec.ts
+++ b/tests/search.spec.ts
@@ -65,7 +65,7 @@ test.describe('Search and Filter URL Persistence', () => {
     await page.reload();
     await page.waitForLoadState('networkidle');
 
-    // The modal should open automatically because 'search=true' is in the URL
+    // The modal should open automatically because 'modal=true' is in the URL
     // No need to click the search button again.
     const searchInputReload = page.getByPlaceholder(/SEARCH REPOSITORY/i);
     await expect(searchInputReload).toBeVisible({ timeout: 10000 });


### PR DESCRIPTION
This PR centralizes search and filter state management by migrating local hooks and custom `useSearchParams` logic to the unified `useSearchParam` hook. 

Key changes:
- **`useSearchParam` enhancement**: Now uses the functional update pattern with `setSearchParams` for better reliability when multiple parameters are updated simultaneously. Added generic support for type-safe union string parameters.
- **`useGlobalSearch` migration**: Refactored to use `useSearchParam`. The URL parameter for the modal visibility was changed from `search=true` to `modal=true` to avoid naming conflicts with the `search` term used by other features (e.g., Blog, Gear, WCS Data).
- **`useWCSData` migration**: Replaced local `useState` for `searchTerm` and `filterPromoted` with `useSearchParam`.
- **Test updates**: Updated `tests/search.spec.ts` to expect `modal=true` for search persistence tests.

These changes ensure a single source of truth for URL-based state and prevent regressions where global search interactions could overwrite feature-specific search terms.

Fixes #573

---
*PR created automatically by Jules for task [9621673456076857484](https://jules.google.com/task/9621673456076857484) started by @arii*