### PR TITLE
Normalize content frontmatter and tagging

### DIFF
--- a/content/posts/2026-04-18-financial-literacy-dancers.md
+++ b/content/posts/2026-04-18-financial-literacy-dancers.md
@@ -7,8 +7,8 @@ category: "Travel/Lifestyle"
 excerpt: "A deep dive into financial literacy for dancers: maximizing travel perks while maintaining a responsible credit-as-debit philosophy."
 image: ""
 tags:
-  - financial literacy
-  - travel hacking
+  - financial-literacy
+  - travel-hacking
   - wcs
 ---
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "lint:ox": "oxlint --deny-warnings",
     "lint:eslint": "eslint . --max-warnings 0",
     "lint:types": "tsc --noEmit",
+    "lint:content": "tsx scripts/validate-content.ts",
     "knip": "knip",
     "type-check": "tsc --noEmit",
     "audit": "node scripts/detect-antipatterns.mjs"

--- a/scripts/validate-content.ts
+++ b/scripts/validate-content.ts
@@ -49,7 +49,7 @@ function parseFrontmatter(content: string) {
   if (!match) return null;
 
   const yaml = match[1];
-  const data: Record<string, any> = {};
+  const data: Record<string, string | number | string[] | undefined> = {};
 
   let currentKey = '';
   yaml.split('\n').forEach(line => {

--- a/scripts/validate-content.ts
+++ b/scripts/validate-content.ts
@@ -1,0 +1,129 @@
+import fs from 'fs';
+import { globSync } from 'glob';
+import { z } from 'zod';
+
+const tagRegex = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+
+const BaseSchema = z.object({
+  type: z.enum(['post', 'resource', 'study', 'event']),
+  title: z.string().min(1),
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Date must be YYYY-MM-DD"),
+  author: z.string().min(1),
+  category: z.string().min(1),
+  excerpt: z.string().min(1),
+  tags: z.array(z.string().regex(tagRegex, "Tags must be lowercase kebab-case")).optional(),
+});
+
+const PostSchema = BaseSchema.extend({
+  type: z.literal('post'),
+});
+
+const ResourceSchema = BaseSchema.extend({
+  type: z.literal('resource'),
+});
+
+const StudySchema = BaseSchema.extend({
+  type: z.literal('study'),
+});
+
+const EventSchema = BaseSchema.extend({
+  type: z.literal('event'),
+  location: z.string().min(1),
+  city: z.string().min(1),
+  schedule: z.string().min(1),
+  description: z.string().min(1),
+});
+
+const ContentSchema = z.discriminatedUnion('type', [
+  PostSchema,
+  ResourceSchema,
+  StudySchema,
+  EventSchema,
+]);
+
+/**
+ * Basic frontmatter parser similar to src/lib/content.ts
+ */
+function parseFrontmatter(content: string) {
+  const match = content.match(/^---\n([\s\S]+?)\n---\n/);
+  if (!match) return null;
+
+  const yaml = match[1];
+  const data: Record<string, any> = {};
+
+  let currentKey = '';
+  yaml.split('\n').forEach(line => {
+    const trimmed = line.trim();
+    if (!trimmed) return;
+
+    if (line.startsWith('  - ')) {
+      // List item
+      if (currentKey) {
+        if (!Array.isArray(data[currentKey])) data[currentKey] = [];
+        let val = trimmed.replace(/^- /, '').trim();
+        if (val.startsWith('"') && val.endsWith('"')) val = val.slice(1, -1);
+        else if (val.startsWith("'") && val.endsWith("'")) val = val.slice(1, -1);
+        data[currentKey].push(val);
+      }
+    } else {
+      const colonIdx = line.indexOf(':');
+      if (colonIdx !== -1) {
+        const key = line.slice(0, colonIdx).trim();
+        let value = line.slice(colonIdx + 1).trim();
+        currentKey = key;
+
+        if (value.startsWith('[') && value.endsWith(']')) {
+          const inner = value.slice(1, -1).trim();
+          data[key] = inner ? inner.split(',').map(v => {
+            let item = v.trim();
+            if (item.startsWith('"') && item.endsWith('"')) item = item.slice(1, -1);
+            else if (item.startsWith("'") && item.endsWith("'")) item = item.slice(1, -1);
+            return item;
+          }) : [];
+        } else if (value) {
+          if (value.startsWith('"') && value.endsWith('"')) value = value.slice(1, -1);
+          else if (value.startsWith("'") && value.endsWith("'")) value = value.slice(1, -1);
+          data[key] = value;
+        }
+      }
+    }
+  });
+
+  return data;
+}
+
+function main() {
+  const files = globSync('content/**/*.md');
+  let hasError = false;
+
+  console.log(`Validating ${files.length} content files...`);
+
+  files.forEach(file => {
+    const content = fs.readFileSync(file, 'utf-8');
+    const data = parseFrontmatter(content);
+
+    if (!data) {
+      console.error(`Error in ${file}: No frontmatter found or invalid format (missing --- delimiters)`);
+      hasError = true;
+      return;
+    }
+
+    const result = ContentSchema.safeParse(data);
+    if (!result.success) {
+      console.error(`Error in ${file}:`);
+      result.error.errors.forEach(err => {
+        console.error(`  - ${err.path.join('.')}: ${err.message}`);
+      });
+      hasError = true;
+    }
+  });
+
+  if (hasError) {
+    console.error('\nContent validation failed!');
+    process.exit(1);
+  } else {
+    console.log('\nAll content files are valid!');
+  }
+}
+
+main();

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -155,7 +155,8 @@ function transform<T extends { date?: string }>(modules: Record<string, string |
         excerpt: String(data.excerpt || ''),
         date: String(data.date || ''),
         author: String(data.author || ''),
-        tags: Array.isArray(data.tags) ? data.tags : [],
+        tags: (Array.isArray(data.tags) ? data.tags : [])
+          .map(tag => tag.toLowerCase().trim().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '')),
         content: content || '',
         slug: slugFrom(path)
       } as unknown as T;


### PR DESCRIPTION
Implemented build-time validation for markdown frontmatter using Zod and enforced lowercase kebab-case for tags. Added a new `lint:content` script and updated the content loading logic to normalize tags at runtime. Fixed existing content inconsistencies.

Fixes #570

---
*PR created automatically by Jules for task [4207264828719271707](https://jules.google.com/task/4207264828719271707) started by @arii*