### PR TITLE
fix sitemap generation in deploy

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -72,10 +72,30 @@ export default defineConfig(({mode}) => {
       !process.env.VITEST && Sitemap({
         hostname: resolveHostname().replace(/\/$/, ''),
         basePath: base.replace(/\/$/, ''),
-        dynamicRoutes: dynamicRoutes.map(route => route.replace(/\/$/, '') || '/'),
+        dynamicRoutes: dynamicRoutes.filter(route => route !== '/').map(route => route.replace(/\/$/, '') || '/'),
         // Exclude infrastructure pages that are not real app routes
         exclude: ['/404', '/previews', '/previews/'],
         generateRobotsTxt: false,
+        xmlns: {
+          news: false,
+          xhtml: true,
+          image: false,
+          video: false,
+        },
+        changefreq: {
+          '/': 'daily',
+          '/blog': 'weekly',
+          '/gear': 'weekly',
+          '/research': 'weekly',
+          '*': 'monthly'
+        },
+        priority: {
+          '/': 1.0,
+          '/blog': 0.8,
+          '/gear': 0.8,
+          '/research': 0.8,
+          '*': 0.5
+        }
       }),
       ViteImageOptimizer({
         includePublic: true,


### PR DESCRIPTION
Fixes issues with sitemap generation that could cause parsing errors in Google Search Console. 

- Removed duplicate `/` URL entry.
- Simplified `xmlns` header to only include what's used (`xhtml`).
- Added customized `<priority>` and `<changefreq>` values so not all pages claim maximum importance.

---
*PR created automatically by Jules for task [9099015895447877869](https://jules.google.com/task/9099015895447877869) started by @arii*