### PR TITLE
Fix gh CLI token error handling in GHAConfigManager

### DIFF
--- a/dev-tools/utils.py
+++ b/dev-tools/utils.py
@@ -108,7 +108,7 @@ class GHAConfigManager:
                 return val
 
             stderr = result.stderr.lower()
-            if "not authenticated" in stderr or "not logged in" in stderr:
+            if "not authenticated" in stderr or "not logged in" in stderr or "gh_token" in stderr:
                 if not self.warned_auth:
                     print(f"⚠️  Warning: 'gh' CLI not authenticated. Run 'gh auth login' to fetch baselines.", file=sys.stderr)
                     self.warned_auth = True


### PR DESCRIPTION
When the `gh` CLI lacks the `GH_TOKEN` environment variable in GitHub actions, it outputs an error containing "gh_token" in `stderr`. Previously, this caused the variable-fetching script in `dev-tools/utils.py` to hard fail with a misleading error. Now, it checks for this string specifically and prints the same standard warning it uses for "not authenticated", gracefully falling back to baselines.

---
*PR created automatically by Jules for task [6358168387876960525](https://jules.google.com/task/6358168387876960525) started by @arii*