### PR TITLE
chore: rebrand site to BoomTick.blog and update persona

### DIFF
--- a/USAGE_NOTES.md
+++ b/USAGE_NOTES.md
@@ -1,7 +1,7 @@
 # PR Review Tooling: USAGE_NOTES
 
 ## Overview
-The PR review system is centralized in the unified Tech-Dancer CLI.
+The PR review system is centralized in the unified BoomTick.blog CLI.
 - **CLI Entry Point**: `dev-tools/td_cli.py`
 - **Read Context**: `dev-tools/logs/reviews/pr-context-{PR}.md` (Diffs, stats, and valid line ranges).
 - **Write Review**: `dev-tools/logs/reviews/pr-review-{PR}.md` (Checklist and JSON output block).

--- a/content/events/weekly.md
+++ b/content/events/weekly.md
@@ -2,7 +2,7 @@
 type: event
 title: "Weekly Class"
 date: "2024-01-01"
-author: "Ariel Anders, PhD"
+author: "Tech Dancer"
 category: "Dance"
 excerpt: "Weekly social dance and classes at Mission City Swing in San Francisco."
 location: "Mission City Swing"

--- a/content/posts/2026-04-18-ai-content-creation.md
+++ b/content/posts/2026-04-18-ai-content-creation.md
@@ -2,7 +2,7 @@
 type: post
 title: "AI powered content creation and development"
 date: "2026-04-18"
-author: "Ariel Anders, PhD"
+author: "Tech Dancer"
 category: "Tech Portfolio"
 excerpt: "How I use Jules and other AI tools to generate data analytics and blog posts with a human in the loop."
 image: ""

--- a/content/posts/2026-04-18-ai-role-dance.md
+++ b/content/posts/2026-04-18-ai-role-dance.md
@@ -2,7 +2,7 @@
 type: post
 title: "The role of AI in Dance"
 date: "2026-04-18"
-author: "Ariel Anders, PhD"
+author: "Tech Dancer"
 category: "Tech"
 excerpt: "Exploring how video analysis helps lead-follow connection. AI can check your frame during a whip or your response time. It's about getting objective video feedback to fix your mechanics."
 image: ""

--- a/content/posts/2026-04-18-competition-metrics.md
+++ b/content/posts/2026-04-18-competition-metrics.md
@@ -2,7 +2,7 @@
 type: post
 title: "Ignore scores and focus on your results"
 date: "2026-04-18"
-author: "Ariel Anders, PhD"
+author: "Tech Dancer"
 category: "All about WCS"
 excerpt: "Setting granular measurable metrics for competitions, recording comp videos, and objective analysis."
 image: ""

--- a/content/posts/2026-04-18-financial-literacy-dancers.md
+++ b/content/posts/2026-04-18-financial-literacy-dancers.md
@@ -2,7 +2,7 @@
 type: post
 title: "Why I have the Amex Platinum and Hyatt card"
 date: "2026-04-18"
-author: "Ariel Anders, PhD"
+author: "Tech Dancer"
 category: "Travel/Lifestyle"
 excerpt: "A deep dive into financial literacy for dancers: maximizing travel perks while maintaining a responsible credit-as-debit philosophy."
 image: ""

--- a/content/posts/2026-04-18-github-actions.md
+++ b/content/posts/2026-04-18-github-actions.md
@@ -2,7 +2,7 @@
 type: post
 title: "How I used GitHub Actions to power this site"
 date: "2026-04-18"
-author: "Ariel Anders, PhD"
+author: "Tech Dancer"
 category: "Tech"
 excerpt: "Automated deployments and CI/CD pipelines for a roboticist's living portfolio."
 image: ""

--- a/content/posts/2026-04-18-halloween-costumes.md
+++ b/content/posts/2026-04-18-halloween-costumes.md
@@ -2,7 +2,7 @@
 type: post
 title: "Halloween costumes you can dance in"
 date: "2026-04-18"
-author: "Ariel Anders, PhD"
+author: "Tech Dancer"
 category: "Gear Reviews"
 excerpt: "How to stay thematic without sacrificing your spin or frame. Featuring the pumpkin outfit stress-test."
 image: ""

--- a/content/posts/2026-04-18-make-shoe-dance.md
+++ b/content/posts/2026-04-18-make-shoe-dance.md
@@ -2,7 +2,7 @@
 type: post
 title: "Make any shoe a dance shoe"
 date: "2026-04-18"
-author: "Ariel Anders, PhD"
+author: "Tech Dancer"
 category: "Gear Reviews"
 excerpt: "Suede your dance shoes with a $15 DIY hack. A comparison of sticker coverage and traction response."
 image: ""

--- a/content/posts/2026-04-18-pivoting-consultant.md
+++ b/content/posts/2026-04-18-pivoting-consultant.md
@@ -2,7 +2,7 @@
 type: post
 title: "Pivoting to consulting and project based work"
 date: "2026-04-18"
-author: "Ariel Anders, PhD"
+author: "Tech Dancer"
 category: "Tech Portfolio"
 excerpt: "A pun-intended look at moving from fixed industry roles to highly specialized project-based consultancy."
 image: ""

--- a/content/posts/2026-04-18-why-finals-are-hard.md
+++ b/content/posts/2026-04-18-why-finals-are-hard.md
@@ -2,7 +2,7 @@
 type: post
 title: "The majority of above average dancers don’t make it to finals"
 date: "2026-04-18"
-author: "Ariel Anders, PhD"
+author: "Tech Dancer"
 category: "Data & Dev Lab"
 excerpt: "A statistical look at competition heat density and judge variance, explaining why placement is a poor metric for progress."
 image: ""

--- a/content/posts/2026-04-19-gear-essentials.md
+++ b/content/posts/2026-04-19-gear-essentials.md
@@ -2,7 +2,7 @@
 type: post
 title: "The WCS Travel Pack: 3 Essentials You’re Forgetting"
 date: "2026-04-19"
-author: "Ariel Anders, PhD"
+author: "Tech Dancer"
 category: "Travel"
 excerpt: "Loop earplugs, industrial travel steamers, and portable sound. Why these three Pieces of gear are the secret to a better dance weekend."
 image: ""

--- a/content/posts/2026-04-20-stop-wasting-vercel-credits-deploy-every-branch-to-github-pages.md
+++ b/content/posts/2026-04-20-stop-wasting-vercel-credits-deploy-every-branch-to-github-pages.md
@@ -2,7 +2,7 @@
 type: post
 title: Stop Wasting Vercel Credits: Deploy Every Branch to GitHub Pages
 date: "2026-04-20"
-author: "Ariel Anders, PhD"
+author: "Tech Dancer"
 category: Tech
 excerpt: Time is your most precious commodity. Narrow the gap between coding and seeing your changes by deploying every branch to GitHub Pages.
 ---

--- a/content/resources/2023-10-01-loop-earplugs.md
+++ b/content/resources/2023-10-01-loop-earplugs.md
@@ -2,7 +2,7 @@
 type: resource
 title: "Loop Experience Earplugs"
 date: "2023-10-01"
-author: "Ariel Anders, PhD"
+author: "Tech Dancer"
 category: "Dance Gear"
 excerpt: "A must-have for protecting your hearing in loud ballroom and social dance settings without sacrificing sound quality."
 affiliateIds: ["loop-experience"]

--- a/content/resources/2023-11-01-travel-steamer.md
+++ b/content/resources/2023-11-01-travel-steamer.md
@@ -2,7 +2,7 @@
 type: resource
 title: "Travel Steamer Pro"
 date: "2023-11-01"
-author: "Ariel Anders, PhD"
+author: "Tech Dancer"
 category: "Travel"
 excerpt: "Compact, efficient, and dual-voltage. Keep your competition shirts and skirts wrinkle-free on the road."
 affiliateIds: ["amazon"]

--- a/content/resources/2024-01-01-portable-speaker.md
+++ b/content/resources/2024-01-01-portable-speaker.md
@@ -2,7 +2,7 @@
 type: resource
 title: "Portable Bluetooth Speaker (UE Wonderboom 4)"
 date: "2024-01-01"
-author: "Ariel Anders, PhD"
+author: "Tech Dancer"
 category: "Dance Gear"
 excerpt: "Rugged, waterproof, and surprisingly loud. Perfect for hotel practice sessions or outdoor social gatherings."
 affiliateIds: ["amazon"]

--- a/content/resources/2026-04-12-suede-shoe-diy.md
+++ b/content/resources/2026-04-12-suede-shoe-diy.md
@@ -2,7 +2,7 @@
 type: resource
 title: "How to Suede Your Own Dance Shoes for $15"
 date: "2026-04-12"
-author: "Ariel Anders, PhD"
+author: "Tech Dancer"
 category: "Gear"
 excerpt: "The $15 DIY hack for perfect traction on any ballroom floor."
 affiliateIds:

--- a/dev-tools/td_cli.py
+++ b/dev-tools/td_cli.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-td_cli.py - Unified Tech-Dancer Developer CLI
+td_cli.py - Unified BoomTick.blog Developer CLI
 
 Consolidates multiple fragmented scripts into a single entry point for repo automation.
 Supports structured JSON output for tool integration.
@@ -526,7 +526,7 @@ def handle_manage_reviews(args):
     if args.json: print(json.dumps({"status": "success", "prs": prs_data}, indent=2))
 
 def main():
-    parser = argparse.ArgumentParser(description="Tech-Dancer Repository CLI")
+    parser = argparse.ArgumentParser(description="BoomTick.blog Repository CLI")
     parser.add_argument("--json", action="store_true", help="Output results in JSON format")
     subparsers = parser.add_subparsers(dest="command", help="Command to run")
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-example",
+  "name": "boomtick-blog",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/public/404.html
+++ b/public/404.html
@@ -2,11 +2,11 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <title>Tech-Dancer // Redirecting...</title>
+    <title>BoomTick.blog // Redirecting...</title>
     <script type="text/javascript">
       // SPA redirect for GitHub Pages.
-      // This script handles redirects for both the main deployment (/tech-dancer/)
-      // and branch preview deployments (/tech-dancer/<branch>/).
+      // This script handles redirects for both the main deployment (/boomtick-blog/)
+      // and branch preview deployments (/boomtick-blog/<branch>/).
       // It probes the path hierarchy to find the deepest index.html.
       (function () {
         var l = window.location;

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,7 +1,7 @@
 {
-  "name": "Tech-Dancer",
-  "short_name": "TechDancer",
-  "description": "The Roboticist's Guide to WCS",
+  "name": "BoomTick.blog",
+  "short_name": "BoomTick",
+  "description": "The West Coast Swing Lifestyle Blog",
   "theme_color": "#1A2B3C",
   "background_color": "#ffffff",
   "display": "standalone",

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -13,7 +13,7 @@ export const STATIC_SCHEMAS = {
     "description": DEFAULT_DESCRIPTION,
     "publisher": {
       "@type": "Person",
-      "name": "Ariel Anders"
+      "name": "Tech Dancer"
     }
   },
   ABOUT: (bioName: string, bioRole: string) => ({

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,8 +1,9 @@
-export const BASE_URL = (import.meta.env.VITE_APP_URL || 'https://arii.github.io/tech-dancer').replace(/\/$/, '');
+import { SITE_METADATA } from "@/config/content";
+export const BASE_URL = (import.meta.env.VITE_APP_URL || 'https://arii.github.io/boomtick-blog').replace(/\/$/, '');
 export const SITE_NAME = 'BoomTick.blog';
 export const GA_MEASUREMENT_ID = 'G-W9W73FV2K1';
 export const GOOGLE_SITE_VERIFICATION = import.meta.env.VITE_GOOGLE_SITE_VERIFICATION || 'FGbpuhF_c3YUFon1LzrzqmW1jvVPFygugss24n0wn5k';
-const DEFAULT_DESCRIPTION = "The West Coast Swing Lifestyle Blog by Tech Dancer. Exploring the intersection of dance, physics, and engineering.";
+const DEFAULT_DESCRIPTION = `The West Coast Swing Lifestyle Blog by ${SITE_METADATA.author}. Exploring the intersection of dance, physics, and engineering.`;
 
 export const STATIC_SCHEMAS = {
   HOME: {
@@ -13,7 +14,7 @@ export const STATIC_SCHEMAS = {
     "description": DEFAULT_DESCRIPTION,
     "publisher": {
       "@type": "Person",
-      "name": "Tech Dancer"
+      "name": SITE_METADATA.author
     }
   },
   ABOUT: (bioName: string, bioRole: string) => ({

--- a/src/config/content.ts
+++ b/src/config/content.ts
@@ -6,11 +6,11 @@ export const CONTENT_CATEGORIES = [
 ] as const;
 
 export const SITE_METADATA = {
-  title: 'Tech-Dancer',
-  author: 'Ariel Anders, PhD',
-  description: 'The Roboticist\'s Guide to the West Coast Swing',
+  title: 'BoomTick.blog',
+  author: 'Tech Dancer',
+  description: 'The West Coast Swing Lifestyle Blog',
   repo: {
     owner: 'arii',
-    name: 'tech-dancer'
+    name: 'boomtick-blog'
   }
 };

--- a/src/features/journal/BlogPost.tsx
+++ b/src/features/journal/BlogPost.tsx
@@ -25,7 +25,7 @@ export default function BlogPost() {
       "description": post.excerpt,
       "author": {
         "@type": "Person",
-        "name": post.author || "Tech Dancer",
+        "name": post.author || SITE_METADATA.author,
         "url": `${BASE_URL}/about`
       },
       "datePublished": post.date,

--- a/src/features/journal/BlogPost.tsx
+++ b/src/features/journal/BlogPost.tsx
@@ -25,7 +25,7 @@ export default function BlogPost() {
       "description": post.excerpt,
       "author": {
         "@type": "Person",
-        "name": post.author || "Ariel Anders",
+        "name": post.author || "Tech Dancer",
         "url": `${BASE_URL}/about`
       },
       "datePublished": post.date,

--- a/src/features/lab/BlogDrafter.tsx
+++ b/src/features/lab/BlogDrafter.tsx
@@ -41,7 +41,7 @@ export function BlogDrafter() {
   };
 
   const handleCopyPrompt = () => {
-    const prompt = `Objective: Expand the following blog post draft JSON for Tech-Dancer.
+    const prompt = `Objective: Expand the following blog post draft JSON for BoomTick.blog.
 Requirements:
 1. Respond ONLY with a valid JSON object.
 2. DO NOT include any explanatory text, commentary, or markdown markers outside or inside the JSON values.
@@ -95,7 +95,7 @@ Draft Data: ${JSON.stringify(data, null, 2)}`;
                 <Info className="w-4 h-4 text-accent" />
               </Box>
               <Text variant="body" size="xs">
-                This tool prepares your blog post for the Tech-Dancer automated pipeline.
+                This tool prepares your blog post for the BoomTick.blog automated pipeline.
                 Complete the form below to generate a pre-formatted GitHub Issue link.
               </Text>
            </Stack>

--- a/src/features/lab/GearPost.tsx
+++ b/src/features/lab/GearPost.tsx
@@ -37,7 +37,7 @@ export default function GearPost() {
         },
         "author": {
           "@type": "Person",
-          "name": "Tech Dancer",
+          "name": SITE_METADATA.author,
           "url": `${BASE_URL}/about`
         },
         "datePublished": resource.date

--- a/src/features/lab/GearPost.tsx
+++ b/src/features/lab/GearPost.tsx
@@ -37,7 +37,7 @@ export default function GearPost() {
         },
         "author": {
           "@type": "Person",
-          "name": "Ariel Anders",
+          "name": "Tech Dancer",
           "url": `${BASE_URL}/about`
         },
         "datePublished": resource.date

--- a/src/features/lab/useBlogDrafter.ts
+++ b/src/features/lab/useBlogDrafter.ts
@@ -18,8 +18,8 @@ export interface HistoryEntry {
   data: DraftData;
 }
 
-const STORAGE_KEY = 'tech-dancer-blog-draft';
-const HISTORY_KEY = 'tech-dancer-blog-history';
+const STORAGE_KEY = 'boomtick-blog-draft';
+const HISTORY_KEY = 'boomtick-blog-history';
 const DEBOUNCE_WAIT = 1000; // 1 second
 
 // Safe ID generator with fallback for legacy browsers

--- a/src/features/profile/ArielProfile.tsx
+++ b/src/features/profile/ArielProfile.tsx
@@ -11,7 +11,7 @@ export default function ArielProfile() {
     <Box as="section" height="full">
       <SEO
         title="About"
-        description="Ariel Anders, PhD: Roboticist, Dancer, and Engineer. Exploring the intersection of technical systems and creative movement."
+        description="Tech Dancer: West Coast Swing Blogger // Data Science Consultant. Exploring the intersection of dance, physics, and engineering."
       />
       
       <PageHeader

--- a/src/features/profile/PersonaProfile.tsx
+++ b/src/features/profile/PersonaProfile.tsx
@@ -1,17 +1,18 @@
+import { SITE_METADATA } from "@/config/content";
 import { Box, Stack, Text, Grid } from '@/layouts/Primitives';
 import { SEO } from '@/components/SEO';
 import { PageHeader } from '@/components/ui/PageHeader';
 import { Reveal } from '@/components/ui/Reveal';
 import { useProfile } from './useProfile';
 
-export default function ArielProfile() {
+export default function PersonaProfile() {
   const { bio } = useProfile();
 
   return (
     <Box as="section" height="full">
       <SEO
         title="About"
-        description="Tech Dancer: West Coast Swing Blogger // Data Science Consultant. Exploring the intersection of dance, physics, and engineering."
+        description={`${SITE_METADATA.author}: West Coast Swing Blogger // Data Science Consultant. Exploring the intersection of dance, physics, and engineering.`}
       />
       
       <PageHeader

--- a/src/features/profile/useProfile.ts
+++ b/src/features/profile/useProfile.ts
@@ -1,8 +1,8 @@
 import { ProfileData } from './types';
 
 const PROFILE_DATA: ProfileData = {
-    name: "Ariel Anders, PhD",
-    role: "MIT Roboticist // WCS Tech-Dancer",
+    name: "Tech Dancer",
+    role: "West Coast Swing Blogger // Data Science Consultant",
     sections: [
       {
         id: "dance-background",

--- a/src/features/profile/useProfile.ts
+++ b/src/features/profile/useProfile.ts
@@ -1,7 +1,8 @@
+import { SITE_METADATA } from "@/config/content";
 import { ProfileData } from './types';
 
 const PROFILE_DATA: ProfileData = {
-    name: "Tech Dancer",
+    name: SITE_METADATA.author,
     role: "West Coast Swing Blogger // Data Science Consultant",
     sections: [
       {

--- a/src/features/research/ResearchDetail.tsx
+++ b/src/features/research/ResearchDetail.tsx
@@ -37,7 +37,7 @@ export default function ResearchDetail() {
         "description": study.excerpt,
         "author": {
           "@type": "Person",
-          "name": study.author || "Ariel Anders",
+          "name": study.author || "Tech Dancer",
           "url": `${BASE_URL}/about`
         },
         "datePublished": study.date,
@@ -152,7 +152,7 @@ export default function ResearchDetail() {
                       <Stack gap={2}>
                         <Text variant="display" size="xl">Work in Progress</Text>
                         <Text variant="body" size="sm" color="dim" maxWidth="md">
-                          This specialized module is currently being integrated into the Tech-Dancer platform. We are finalizing the analysis models and UI components.
+                          This specialized module is currently being integrated into the BoomTick.blog platform. We are finalizing the analysis models and UI components.
                         </Text>
                       </Stack>
                     </Stack>

--- a/src/features/research/ResearchDetail.tsx
+++ b/src/features/research/ResearchDetail.tsx
@@ -37,7 +37,7 @@ export default function ResearchDetail() {
         "description": study.excerpt,
         "author": {
           "@type": "Person",
-          "name": study.author || "Tech Dancer",
+          "name": study.author || SITE_METADATA.author,
           "url": `${BASE_URL}/about`
         },
         "datePublished": study.date,

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,2 +1,2 @@
-import About from '@/features/profile/ArielProfile';
+import About from '@/features/profile/PersonaProfile';
 export default About;

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -74,7 +74,7 @@ export default function Contact() {
     <>
       <SEO
         title="Contact"
-        description="Get in touch with tech-dancer. Send your feedback, inquiries, or collaboration proposals regarding West Coast Swing and robotics."
+        description="Get in touch with boomtick-blog. Send your feedback, inquiries, or collaboration proposals regarding West Coast Swing and robotics."
       />
       <ContactFormView
         register={register}


### PR DESCRIPTION
This PR implements the site-wide rebranding to `BoomTick.blog`.

Changes include:
- Renaming the package in `package.json` to `boomtick-blog`.
- Updating the author persona from "Ariel Anders, PhD" to "Tech Dancer" across content files and configuration.
- Adjusting the professional role to "West Coast Swing Blogger // Data Science Consultant".
- Changing the site's tagline to "The West Coast Swing Lifestyle Blog".
- Updating configuration files (`manifest.webmanifest`, `404.html`, etc.) to use the new "BoomTick.blog" brand and updated routing paths.

---
*PR created automatically by Jules for task [1770114126300875003](https://jules.google.com/task/1770114126300875003) started by @arii*