### PR TITLE
Refactor Sitemap Production URL Fix

### DIFF
--- a/src/components/SEO.tsx
+++ b/src/components/SEO.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import { Helmet } from 'react-helmet-async';
 import { useLocation } from 'react-router-dom';
-import { BASE_URL, SITE_NAME, GOOGLE_SITE_VERIFICATION } from '@/config/constants';
+import { BASE_URL, SITE_NAME } from '@/config/constants';
 
 interface SEOProps {
   title: string;
@@ -10,7 +10,6 @@ interface SEOProps {
   image?: string;
   canonical?: string;
   schema?: Record<string, unknown> | Record<string, unknown>[];
-  googleVerification?: string;
 }
 
 export function SEO({
@@ -19,8 +18,7 @@ export function SEO({
   type = 'website',
   image,
   canonical,
-  schema,
-  googleVerification
+  schema
 }: SEOProps) {
   const { pathname } = useLocation();
 
@@ -48,7 +46,6 @@ export function SEO({
   return (
     <Helmet>
       {/* Standard metadata */}
-      {googleVerification && googleVerification !== GOOGLE_SITE_VERIFICATION && <meta name="google-site-verification" content={googleVerification} />}
       <title>{displayTitle}</title>
       <meta name="description" content={description} />
       <link rel="canonical" href={url} />

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,7 +1,6 @@
 export const BASE_URL = (import.meta.env.VITE_APP_URL || 'https://boomtick.blog').replace(/\/$/, '');
 export const SITE_NAME = 'BoomTick.blog';
 export const GA_MEASUREMENT_ID = 'G-W9W73FV2K1';
-export const GOOGLE_SITE_VERIFICATION = import.meta.env.VITE_GOOGLE_SITE_VERIFICATION || 'FGbpuhF_c3YUFon1LzrzqmW1jvVPFygugss24n0wn5k';
 const DEFAULT_DESCRIPTION = "The West Coast Swing Lifestyle Blog by Tech Dancer. Exploring the intersection of dance, physics, and engineering.";
 
 export const STATIC_SCHEMAS = {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -39,7 +39,6 @@ export default defineConfig(({mode}) => {
     if (env.VITE_APP_URL) return env.VITE_APP_URL;
     if (process.env.VERCEL_ENV === 'production') return 'https://boomtick.blog';
     if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`;
-    if (isVercel) return 'https://boomtick.blog';
     return 'https://boomtick.blog';
   };
 


### PR DESCRIPTION
This pull request refactors the previous implementation addressing the sitemap generation URL issue on Vercel.

**Changes made:**
- **Code Minimization:** Removed the messy `googleVerification` bypass logic added in `SEO.tsx` during the original PR. The site's base `google-site-verification` tag is safely managed in `index.html`, making the SEO prop and component logic obsolete.
- **Cleanup:** Purged `GOOGLE_SITE_VERIFICATION` entirely from `src/config/constants.ts`.
- **Simplification:** Optimized the fallback logic in `vite.config.ts`'s `resolveHostname` function by removing an unnecessary redundant boolean check for `isVercel`.

These adjustments successfully polish the original fix, ensuring it maintains functional correctness without over-engineering or leaving technical debt. Tested locally ensuring the sitemap still generates production URLs correctly.

---
*PR created automatically by Jules for task [16685608770565945757](https://jules.google.com/task/16685608770565945757) started by @arii*