### PR TITLE
Prioritize production domain for sitemap and metadata

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,4 +1,4 @@
-export const BASE_URL = (import.meta.env.VITE_APP_URL || 'https://arii.github.io/tech-dancer').replace(/\/$/, '');
+export const BASE_URL = (import.meta.env.VITE_APP_URL || 'https://boomtick.blog').replace(/\/$/, '');
 export const SITE_NAME = 'BoomTick.blog';
 export const GA_MEASUREMENT_ID = 'G-W9W73FV2K1';
 export const GOOGLE_SITE_VERIFICATION = import.meta.env.VITE_GOOGLE_SITE_VERIFICATION || 'FGbpuhF_c3YUFon1LzrzqmW1jvVPFygugss24n0wn5k';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -37,9 +37,10 @@ export default defineConfig(({mode}) => {
 
   const resolveHostname = () => {
     if (env.VITE_APP_URL) return env.VITE_APP_URL;
+    if (process.env.VERCEL_ENV === 'production') return 'https://boomtick.blog';
     if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`;
-    if (isVercel) return 'https://tech-dancer.vercel.app';
-    return 'https://arii.github.io';
+    if (isVercel) return 'https://boomtick.blog';
+    return 'https://boomtick.blog';
   };
 
   const hostname = resolveHostname().replace(/\/$/, '');


### PR DESCRIPTION
This change ensures that BoomTick.blog uses its production domain for all SEO-related URLs (sitemap, canonical tags, Open Graph tags) when deployed to Vercel production, while still allowing preview URLs to function correctly for non-production deployments.

Key changes:
- Modified `resolveHostname` in `vite.config.ts` to prioritize `https://boomtick.blog` when `VERCEL_ENV === 'production'`.
- Standardized fallbacks in `vite.config.ts` and `src/config/constants.ts` to `https://boomtick.blog`.
- Verified via local simulated production build that `dist/sitemap.xml` and `dist/robots.txt` use the correct domain.
- Confirmed `google-site-verification` remains intact in `index.html`.

Fixes #611

---
*PR created automatically by Jules for task [15989586500659527517](https://jules.google.com/task/15989586500659527517) started by @arii*