### PR TITLE
Fix UX Auditor mobile screenshots

### DIFF
--- a/src/features/ux-auditor/useUXAuditor.ts
+++ b/src/features/ux-auditor/useUXAuditor.ts
@@ -194,7 +194,7 @@ export function useUXAuditor() {
         try {
           const scaledW = Math.floor(vp.width * 0.5);
           const scaledH = Math.floor(vp.height * 0.5);
-          const snapshotUrl = `https://s0.wp.com/mshots/v1/${encodeURIComponent(targetUrl)}?w=${scaledW}&h=${scaledH}`;
+          const snapshotUrl = `https://s0.wp.com/mshots/v1/${encodeURIComponent(targetUrl)}?w=${scaledW}&h=${scaledH}&vpw=${vp.width}&vph=${vp.height}`;
           const res = await fetch(snapshotUrl);
           if (res.ok) {
             const blob = await res.blob();


### PR DESCRIPTION
Fixes an issue where the UX Auditor's mobile analysis returned a regular desktop screenshot scaled down instead of a properly formatted mobile screenshot. The fix adds `vpw` and `vph` parameters to the `mshots` API URL to explicitly request rendering at specific viewport dimensions.

---
*PR created automatically by Jules for task [17229602608787945952](https://jules.google.com/task/17229602608787945952) started by @arii*