### PR TITLE
fix: remove redundant box from contact form and apply 3xl max-width globally

### DIFF
--- a/src/components/ui/SearchBox.tsx
+++ b/src/components/ui/SearchBox.tsx
@@ -13,7 +13,7 @@ export function SearchBox({
   value,
   onChange,
   placeholder = "Search articles, guides, or gear...",
-  maxWidth = "2xl"
+  maxWidth = "3xl"
 }: SearchBoxProps) {
   return (
     <Box

--- a/src/features/contact/components/ContactFormView.tsx
+++ b/src/features/contact/components/ContactFormView.tsx
@@ -34,14 +34,13 @@ export function ContactFormView({ register, errors, isSubmitting, onSubmit }: Co
           description="Questions about West Coast Swing training, travel, gear, or data? Send a note and I’ll reply soon."
         />
 
-        <Box maxWidth="3xl">
-          <Stack gap={8}>
-            <Stack gap={2}>
-              <Text variant="display" size="2xl" weight="font-black" className="text-accent-navy">Inquiries</Text>
-              <Text variant="body" size="base" color="dim">
-                Send blog ideas, event notes, gear suggestions, or anything you want featured on boomtick.blog.
-              </Text>
-            </Stack>
+        <Stack gap={8} maxWidth="3xl">
+          <Stack gap={2}>
+            <Text variant="display" size="2xl" weight="font-black" className="text-accent-navy">Inquiries</Text>
+            <Text variant="body" size="base" color="dim">
+              Send blog ideas, event notes, gear suggestions, or anything you want featured on boomtick.blog.
+            </Text>
+          </Stack>
 
             <Box as="form" onSubmit={onSubmit} className="space-y-6" noValidate>
               <FormField label="Your Name" error={errors.name?.message}>
@@ -102,30 +101,29 @@ export function ContactFormView({ register, errors, isSubmitting, onSubmit }: Co
                 </Text>
               )}
 
-              <Box display="flex" justify="end">
-                <Button
-                  type="submit"
-                  variant="professional"
-                  disabled={isSubmitting}
-                  paddingX={8}
-                  className="font-semibold text-base min-h-12"
-                >
-                  {isSubmitting ? (
-                    <Stack direction="row" align="center" gap={3}>
-                      <Box width={4} height={4} border={2} className="border-current border-t-transparent animate-spin" />
-                      <Text variant="sans" color="inherit" size="sm" weight="font-semibold">Sending...</Text>
-                    </Stack>
-                  ) : (
-                    <>
-                      <Send className="w-4 h-4" />
-                      <span>Send Message</span>
-                    </>
-                  )}
-                </Button>
-              </Box>
+            <Box display="flex" justify="end">
+              <Button
+                type="submit"
+                variant="professional"
+                disabled={isSubmitting}
+                paddingX={8}
+                className="font-semibold text-base min-h-12"
+              >
+                {isSubmitting ? (
+                  <Stack direction="row" align="center" gap={3}>
+                    <Box width={4} height={4} border={2} className="border-current border-t-transparent animate-spin" />
+                    <Text variant="sans" color="inherit" size="sm" weight="font-semibold">Sending...</Text>
+                  </Stack>
+                ) : (
+                  <>
+                    <Send className="w-4 h-4" />
+                    <span>Send Message</span>
+                  </>
+                )}
+              </Button>
             </Box>
-          </Stack>
-        </Box>
+          </Box>
+        </Stack>
       </Stack>
     </Box>
   );

--- a/src/features/contact/components/ContactFormView.tsx
+++ b/src/features/contact/components/ContactFormView.tsx
@@ -42,7 +42,7 @@ export function ContactFormView({ register, errors, isSubmitting, onSubmit }: Co
             </Text>
           </Stack>
 
-            <Box as="form" onSubmit={onSubmit} className="space-y-6" noValidate>
+          <Box as="form" onSubmit={onSubmit} className="space-y-6" noValidate>
               <FormField label="Your Name" error={errors.name?.message}>
                 <Box as="input"
                   {...register('name')}

--- a/src/features/email-capture/EmailForm.tsx
+++ b/src/features/email-capture/EmailForm.tsx
@@ -13,7 +13,7 @@ export function EmailForm() {
   };
 
   return (
-    <Box as="form" onSubmit={handleSubmit} noValidate width={{ base: "full", md: "auto" }} maxWidth="md">
+    <Box as="form" onSubmit={handleSubmit} noValidate width={{ base: "full", md: "auto" }} maxWidth="3xl">
       <Stack direction="row" gap={0} position="relative" width="full">
         <Box
           as="input"


### PR DESCRIPTION
Refactored `ContactFormView.tsx` to remove the redundant wrapping `<Box maxWidth="3xl">` element, applying `maxWidth="3xl"` directly to the `<Stack>` container.
Updated `SearchBox.tsx` and `EmailForm.tsx` to use the `3xl` max-width token for consistent design parity across forms in the codebase.
Updated visual regression snapshots due to structural DOM changes in the contact view.

---
*PR created automatically by Jules for task [5924767043849769716](https://jules.google.com/task/5924767043849769716) started by @arii*