### PR TITLE
ci: fix git push authentication in self-healing workflow

### DIFF
--- a/.github/workflows/self-healing.yml
+++ b/.github/workflows/self-healing.yml
@@ -145,7 +145,7 @@ jobs:
             git checkout -b "$NEW_BRANCH"
             git add .
             git commit -m "🤖 AI-generated fix for CI failures"
-            git push origin "$NEW_BRANCH" --force
+            git push "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" "$NEW_BRANCH" --force
 
             PR_MSG="Automated repair attempt for failed run $WORKFLOW_RUN_ID"
             if [ "${{ steps.verify.outputs.success }}" == "success" ]; then


### PR DESCRIPTION
Fix git push failure in self-healing CI workflow by explicitly passing the GH_TOKEN in the remote URL.

---
*PR created automatically by Jules for task [3132879796600442197](https://jules.google.com/task/3132879796600442197) started by @arii*