### PR TITLE
Fix E2E Test Execution Failure in Subpath Environments

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module" src="src/main.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
This PR fixes the E2E test execution failure in CI by modifying `index.html` to use a relative path for the main entry script. 

When the application is deployed to a subpath (configured via `VITE_BASE_PATH`), an absolute path like `/src/main.tsx` resolves to the domain root, bypassing the subpath and causing 404 errors. Switching to a relative path `src/main.tsx` allows the browser (and Vite's build process) to correctly resolve the entry point relative to the base path.

Verified locally by building and running Playwright tests with `VITE_BASE_PATH=/tech-dancer/`.

Fixes #703

---
*PR created automatically by Jules for task [10055093476102634223](https://jules.google.com/task/10055093476102634223) started by @arii*