### PR TITLE
Implement Granular Logging for CI Process Failures

### DIFF
--- a/dev-tools/repair.py
+++ b/dev-tools/repair.py
@@ -12,6 +12,7 @@ import subprocess
 import urllib.request
 import urllib.error
 from typing import List, Dict, Any
+from utils import execute_raw
 
 OLLAMA_URL = os.environ.get("OLLAMA_URL", "http://localhost:11434/api/generate")
 MODEL = os.environ.get("OLLAMA_MODEL", "qwen2.5-coder:1.5b")
@@ -19,13 +20,6 @@ MAX_RETRIES = 3
 
 def log(msg):
     print(f"🤖 [Repair Agent] {msg}")
-
-def run_command(cmd, shell=False):
-    try:
-        result = subprocess.run(cmd, shell=shell, capture_output=True, text=True)
-        return result.stdout + result.stderr, result.returncode
-    except Exception as e:
-        return str(e), 1
 
 def get_ollama_response(prompt):
     data = {
@@ -150,9 +144,12 @@ def run_verification():
     log("Running verification checks...")
     results = {}
     # Check Oxlint (Fast)
-    results['oxlint'], _ = run_command(["pnpm", "run", "lint:ox"])
+    # Use execute_raw to gather both stdout and stderr
+    res_ox = execute_raw(["pnpm", "run", "lint:ox"])
+    results['oxlint'] = res_ox.stdout + res_ox.stderr
     # Check Typescript
-    results['tsc'], _ = run_command(["pnpm", "run", "type-check"])
+    res_tsc = execute_raw(["pnpm", "run", "type-check"])
+    results['tsc'] = res_tsc.stdout + res_tsc.stderr
     return results
 
 def agent_loop(file_path, initial_errors):

--- a/dev-tools/repo_utils.py
+++ b/dev-tools/repo_utils.py
@@ -5,8 +5,8 @@ import sys
 from typing import Optional, List, Tuple, Union
 from collections import defaultdict
 
-# Import run_command from utils
-from utils import run_command
+# Import execute from utils
+from utils import execute
 
 # Use existing github_utils if possible, but we'll add common repo walking/matching logic here
 def walk_tsx(root_dir='src'):
@@ -33,19 +33,15 @@ def find_patterns_in_file(filepath, patterns):
 
 def get_bundle_size(dist_dir='dist/assets'):
     """Returns bundle size in KB."""
-    try:
-        # Avoid 2>/dev/null to see errors if dir doesn't exist
-        cmd = f"du -sk {dist_dir}/*.js | awk '{{sum+=$1}} END{{print sum}}'"
-        result = run_command(cmd, shell=True)
-        return int(result) if result else 0
-    except Exception:
-        return 0
+    # Avoid 2>/dev/null to see errors if dir doesn't exist
+    # If this fails, let the CLIError bubble up to identify environment issues
+    cmd = f"du -sk {dist_dir}/*.js | awk '{{sum+=$1}} END{{print sum}}'"
+    result = execute(cmd, shell=True)
+    return int(result) if result else 0
 
 def get_any_count(search_dir='src'):
     """Returns count of 'any' usages in TS/TSX files."""
-    try:
-        cmd = f"grep -rn ': any\\b\\|as any\\b' {search_dir} --include='*.tsx' --include='*.ts' | wc -l"
-        result = run_command(cmd, shell=True)
-        return int(result) if result else 0
-    except Exception:
-        return 0
+    # If grep fails (e.g. directory missing), let the CLIError bubble up
+    cmd = f"grep -rn ': any\\b\\|as any\\b' {search_dir} --include='*.tsx' --include='*.ts' | wc -l"
+    result = execute(cmd, shell=True)
+    return int(result) if result else 0

--- a/dev-tools/repo_utils.py
+++ b/dev-tools/repo_utils.py
@@ -2,8 +2,11 @@ import os
 import re
 import subprocess
 import sys
-from typing import Optional, List, Tuple
+from typing import Optional, List, Tuple, Union
 from collections import defaultdict
+
+# Import run_command from utils
+from utils import run_command
 
 # Use existing github_utils if possible, but we'll add common repo walking/matching logic here
 def walk_tsx(root_dir='src'):
@@ -31,8 +34,9 @@ def find_patterns_in_file(filepath, patterns):
 def get_bundle_size(dist_dir='dist/assets'):
     """Returns bundle size in KB."""
     try:
-        cmd = f"du -sk {dist_dir}/*.js 2>/dev/null | awk '{{sum+=$1}} END{{print sum}}'"
-        result = subprocess.check_output(cmd, shell=True, text=True).strip()
+        # Avoid 2>/dev/null to see errors if dir doesn't exist
+        cmd = f"du -sk {dist_dir}/*.js | awk '{{sum+=$1}} END{{print sum}}'"
+        result = run_command(cmd, shell=True)
         return int(result) if result else 0
     except Exception:
         return 0
@@ -41,7 +45,7 @@ def get_any_count(search_dir='src'):
     """Returns count of 'any' usages in TS/TSX files."""
     try:
         cmd = f"grep -rn ': any\\b\\|as any\\b' {search_dir} --include='*.tsx' --include='*.ts' | wc -l"
-        result = subprocess.check_output(cmd, shell=True, text=True).strip()
+        result = run_command(cmd, shell=True)
         return int(result) if result else 0
     except Exception:
         return 0

--- a/dev-tools/scope_check.py
+++ b/dev-tools/scope_check.py
@@ -4,8 +4,8 @@ import sys
 import subprocess
 from typing import List, Optional
 
-# Import run_command from utils
-from utils import run_command
+# Import execute and execute_raw from utils
+from utils import execute, execute_raw
 
 def get_project_config():
     config_path = os.path.join(os.path.dirname(__file__), "project_config.json")
@@ -22,12 +22,12 @@ def get_changed_files():
     """Returns the list of files changed in the current branch."""
     config = get_project_config()
     base = config.get("base_branch", "origin/main")
-    # Using check=False to manually handle fallback
-    res = run_command(["git", "diff", "--name-only", base], check=False, log_on_error=False)
+    # Use execute_raw to manually handle fallback
+    res = execute_raw(["git", "diff", "--name-only", base], log_on_error=False)
     if res.returncode == 0:
         return res.stdout.strip().splitlines()
 
-    res = run_command(["git", "diff", "--name-only", "HEAD"], check=False, log_on_error=False)
+    res = execute_raw(["git", "diff", "--name-only", "HEAD"], log_on_error=False)
     if res.returncode == 0:
         return res.stdout.strip().splitlines()
 

--- a/dev-tools/scope_check.py
+++ b/dev-tools/scope_check.py
@@ -2,6 +2,10 @@ import json
 import os
 import sys
 import subprocess
+from typing import List, Optional
+
+# Import run_command from utils
+from utils import run_command
 
 def get_project_config():
     config_path = os.path.join(os.path.dirname(__file__), "project_config.json")
@@ -18,13 +22,16 @@ def get_changed_files():
     """Returns the list of files changed in the current branch."""
     config = get_project_config()
     base = config.get("base_branch", "origin/main")
-    try:
-        return subprocess.check_output(["git", "diff", "--name-only", base], text=True).splitlines()
-    except subprocess.CalledProcessError:
-        try:
-            return subprocess.check_output(["git", "diff", "--name-only", "HEAD"], text=True).splitlines()
-        except:
-            return []
+    # Using check=False to manually handle fallback
+    res = run_command(["git", "diff", "--name-only", base], check=False, log_on_error=False)
+    if res.returncode == 0:
+        return res.stdout.strip().splitlines()
+
+    res = run_command(["git", "diff", "--name-only", "HEAD"], check=False, log_on_error=False)
+    if res.returncode == 0:
+        return res.stdout.strip().splitlines()
+
+    return []
 
 def verify_pr_scope(file_list=None):
     """Checks if a PR touches too many core layout/component files."""

--- a/dev-tools/td_cli.py
+++ b/dev-tools/td_cli.py
@@ -13,7 +13,7 @@ import re
 import subprocess
 import json
 from datetime import datetime, timezone, timedelta
-from utils import get_github_token, get_repo_name, get_gha_variable, set_gha_variable, CLIError
+from utils import get_github_token, get_repo_name, get_gha_variable, set_gha_variable, CLIError, run_command
 from repo_utils import walk_tsx, find_patterns_in_file, get_bundle_size, get_any_count
 from collections import defaultdict
 
@@ -52,10 +52,11 @@ def get_audit_results(content: str = None, targets: list[str] = None):
     elif content is not None:
         cmd.append("-")
 
-    proc = subprocess.run(cmd, input=content, capture_output=True, text=True)
+    # Using check=False because the audit tool exits 1 on findings
+    res = run_command(cmd, input_str=content, check=False)
     try:
-        return json.loads(proc.stdout)
-    except json.JSONDecodeError:
+        return json.loads(res.stdout)
+    except (json.JSONDecodeError, AttributeError):
         return {"violations": {}, "config": {}}
 
 def extract_code_blocks(text: str) -> list[str]:
@@ -172,11 +173,10 @@ def handle_conflicts(args):
     """
     def run(cmd, exit_on_fail=False):
         print(f"🏃 Running: {cmd}")
-        res = subprocess.run(cmd, shell=True, capture_output=True, text=True)
-        if res.returncode != 0:
-            print(f"⚠️ Output/Error:\n{res.stderr.strip() or res.stdout.strip()}")
-            if exit_on_fail:
-                sys.exit(res.returncode)
+        # Use check=False to manually handle return code
+        res = run_command(cmd, shell=True, check=False)
+        if res.returncode != 0 and exit_on_fail:
+            sys.exit(res.returncode)
         return res.returncode, res.stdout.strip()
 
     base_branch = getattr(args, 'base', 'main') or 'main'
@@ -395,12 +395,12 @@ def handle_audit_pr(args):
         if files_to_audit:
             try:
                 # Use pnpm run audit as requested, passing targets after --
-                proc = subprocess.run(["pnpm", "run", "audit", "--", "--json"] + files_to_audit, capture_output=True, text=True)
-                if proc.stdout:
+                # Using run_command with check=False because audit script exits 1 on violations
+                output = run_command(["pnpm", "run", "audit", "--", "--json"] + files_to_audit, check=False)
+                if output:
                     # pnpm might add some noise to stdout before/after the actual JSON if not careful,
                     # but our script uses process.stdout.write for JSON.
                     # We try to find the JSON part if there's noise.
-                    output = proc.stdout
                     if "{" in output:
                         json_start = output.find("{")
                         json_end = output.rfind("}") + 1
@@ -435,10 +435,15 @@ def handle_pre_submit(args):
     try:
         def run_step(name, cmd, ignore_failure=False):
             if not args.json: print(f"--- {name} ---")
-            proc = subprocess.run(cmd, capture_output=args.json, text=True)
-            results["steps"].append({"name": name, "status": "success" if proc.returncode == 0 else "failure"})
-            if proc.returncode != 0 and not ignore_failure: raise subprocess.CalledProcessError(proc.returncode, cmd)
-            return proc
+            try:
+                stdout = run_command(cmd, check=not ignore_failure)
+                results["steps"].append({"name": name, "status": "success"})
+                return stdout
+            except CLIError as e:
+                results["steps"].append({"name": name, "status": "failure"})
+                if not ignore_failure:
+                    raise e
+                return ""
 
         run_step("Anti-Pattern Audit", ["pnpm", "run", "audit"])
         run_step("TypeScript", ["pnpm", "run", "type-check"])
@@ -511,9 +516,10 @@ def handle_repair(args):
             raise CLIError(f"Log file not found: {args.logs}")
     else:
         if not args.json: print("🔍 No logs provided. Running local triage...")
-        # Run lint and tsc to gather logs
-        res_lint = subprocess.run(["pnpm", "run", "lint:ox"], capture_output=True, text=True)
-        res_tsc = subprocess.run(["pnpm", "run", "type-check"], capture_output=True, text=True)
+        # Run lint and tsc to gather logs - using check=False as we WANT the error logs
+        # We gather both stdout and stderr for triage
+        res_lint = run_command(["pnpm", "run", "lint:ox"], check=False)
+        res_tsc = run_command(["pnpm", "run", "type-check"], check=False)
         logs_content = res_lint.stdout + res_lint.stderr + "\n" + res_tsc.stdout + res_tsc.stderr
         logs_source = "local triage"
 
@@ -572,8 +578,8 @@ def handle_repair(args):
 
 def handle_audit_gate(args):
     # Current violations count
-    proc_current = subprocess.run(["node", "scripts/detect-antipatterns.mjs", "--count-only"], capture_output=True, text=True)
-    current_count = int(proc_current.stdout.strip() or 0)
+    stdout_current = run_command(["node", "scripts/detect-antipatterns.mjs", "--count-only"])
+    current_count = int(stdout_current or 0)
 
     # 1. Try to get baseline from GHA variable or Environment
     baseline_count = resolve_baseline(None, 'AUDIT_BASELINE', -1)
@@ -583,7 +589,7 @@ def handle_audit_gate(args):
         baseline_count = 0
         try:
             ls_cmd = ["git", "ls-tree", "-r", "origin/main", "--name-only"]
-            main_files = subprocess.check_output(ls_cmd, text=True, stderr=subprocess.DEVNULL).splitlines()
+            main_files = run_command(ls_cmd).splitlines()
 
             relevant_main_files = []
             for mf in main_files:
@@ -597,13 +603,13 @@ def handle_audit_gate(args):
             for mf in relevant_main_files:
                 try:
                     show_cmd = ["git", "show", f"origin/main:{mf}"]
-                    content = subprocess.check_output(show_cmd, text=True, stderr=subprocess.DEVNULL)
-                    proc_baseline = subprocess.run(["node", "scripts/detect-antipatterns.mjs", "--count-only", "-"],
-                                                   input=content, capture_output=True, text=True)
-                    baseline_count += int(proc_baseline.stdout.strip() or 0)
-                except subprocess.CalledProcessError:
+                    content = run_command(show_cmd)
+                    stdout_baseline = run_command(["node", "scripts/detect-antipatterns.mjs", "--count-only", "-"],
+                                                   input_str=content)
+                    baseline_count += int(stdout_baseline or 0)
+                except (CLIError, subprocess.CalledProcessError):
                     continue
-        except subprocess.CalledProcessError:
+        except (CLIError, subprocess.CalledProcessError):
             pass
 
     if not args.json:
@@ -679,7 +685,7 @@ def handle_fix_ci(args):
     else:
         # Local dev fallback: detect current branch
         try:
-            branch = subprocess.check_output(['git', 'branch', '--show-current'], text=True).strip()
+            branch = run_command(['git', 'branch', '--show-current'])
             if not branch: raise Exception("No current branch detected")
             if not args.json: print(f"ℹ️  Detected current branch: `{branch}`")
             pulls = list(repo.get_pulls(state='open', head=f"{repo.owner.login}:{branch}"))

--- a/dev-tools/td_cli.py
+++ b/dev-tools/td_cli.py
@@ -13,7 +13,7 @@ import re
 import subprocess
 import json
 from datetime import datetime, timezone, timedelta
-from utils import get_github_token, get_repo_name, get_gha_variable, set_gha_variable, CLIError, run_command
+from utils import get_github_token, get_repo_name, get_gha_variable, set_gha_variable, CLIError, execute, execute_raw
 from repo_utils import walk_tsx, find_patterns_in_file, get_bundle_size, get_any_count
 from collections import defaultdict
 
@@ -52,8 +52,8 @@ def get_audit_results(content: str = None, targets: list[str] = None):
     elif content is not None:
         cmd.append("-")
 
-    # Using check=False because the audit tool exits 1 on findings
-    res = run_command(cmd, input_str=content, check=False)
+    # Use execute_raw because the audit tool exits 1 on findings, which is expected
+    res = execute_raw(cmd, input_str=content)
     try:
         return json.loads(res.stdout)
     except (json.JSONDecodeError, AttributeError):
@@ -173,8 +173,7 @@ def handle_conflicts(args):
     """
     def run(cmd, exit_on_fail=False):
         print(f"🏃 Running: {cmd}")
-        # Use check=False to manually handle return code
-        res = run_command(cmd, shell=True, check=False)
+        res = execute_raw(cmd, shell=True)
         if res.returncode != 0 and exit_on_fail:
             sys.exit(res.returncode)
         return res.returncode, res.stdout.strip()
@@ -395,8 +394,9 @@ def handle_audit_pr(args):
         if files_to_audit:
             try:
                 # Use pnpm run audit as requested, passing targets after --
-                # Using run_command with check=False because audit script exits 1 on violations
-                output = run_command(["pnpm", "run", "audit", "--", "--json"] + files_to_audit, check=False)
+                # Use execute_raw because audit script exits 1 on violations
+                res = execute_raw(["pnpm", "run", "audit", "--", "--json"] + files_to_audit)
+                output = res.stdout
                 if output:
                     # pnpm might add some noise to stdout before/after the actual JSON if not careful,
                     # but our script uses process.stdout.write for JSON.
@@ -435,15 +435,19 @@ def handle_pre_submit(args):
     try:
         def run_step(name, cmd, ignore_failure=False):
             if not args.json: print(f"--- {name} ---")
-            try:
-                stdout = run_command(cmd, check=not ignore_failure)
-                results["steps"].append({"name": name, "status": "success"})
-                return stdout
-            except CLIError as e:
-                results["steps"].append({"name": name, "status": "failure"})
-                if not ignore_failure:
+            if ignore_failure:
+                res = execute_raw(cmd)
+                status = "success" if res.returncode == 0 else "failure"
+                results["steps"].append({"name": name, "status": status})
+                return res.stdout.strip()
+            else:
+                try:
+                    stdout = execute(cmd)
+                    results["steps"].append({"name": name, "status": "success"})
+                    return stdout
+                except CLIError as e:
+                    results["steps"].append({"name": name, "status": "failure"})
                     raise e
-                return ""
 
         run_step("Anti-Pattern Audit", ["pnpm", "run", "audit"])
         run_step("TypeScript", ["pnpm", "run", "type-check"])
@@ -516,10 +520,10 @@ def handle_repair(args):
             raise CLIError(f"Log file not found: {args.logs}")
     else:
         if not args.json: print("🔍 No logs provided. Running local triage...")
-        # Run lint and tsc to gather logs - using check=False as we WANT the error logs
+        # Run lint and tsc to gather logs - using execute_raw as we WANT the error logs
         # We gather both stdout and stderr for triage
-        res_lint = run_command(["pnpm", "run", "lint:ox"], check=False)
-        res_tsc = run_command(["pnpm", "run", "type-check"], check=False)
+        res_lint = execute_raw(["pnpm", "run", "lint:ox"])
+        res_tsc = execute_raw(["pnpm", "run", "type-check"])
         logs_content = res_lint.stdout + res_lint.stderr + "\n" + res_tsc.stdout + res_tsc.stderr
         logs_source = "local triage"
 
@@ -578,7 +582,7 @@ def handle_repair(args):
 
 def handle_audit_gate(args):
     # Current violations count
-    stdout_current = run_command(["node", "scripts/detect-antipatterns.mjs", "--count-only"])
+    stdout_current = execute(["node", "scripts/detect-antipatterns.mjs", "--count-only"])
     current_count = int(stdout_current or 0)
 
     # 1. Try to get baseline from GHA variable or Environment
@@ -589,7 +593,7 @@ def handle_audit_gate(args):
         baseline_count = 0
         try:
             ls_cmd = ["git", "ls-tree", "-r", "origin/main", "--name-only"]
-            main_files = run_command(ls_cmd).splitlines()
+            main_files = execute(ls_cmd).splitlines()
 
             relevant_main_files = []
             for mf in main_files:
@@ -603,14 +607,20 @@ def handle_audit_gate(args):
             for mf in relevant_main_files:
                 try:
                     show_cmd = ["git", "show", f"origin/main:{mf}"]
-                    content = run_command(show_cmd)
-                    stdout_baseline = run_command(["node", "scripts/detect-antipatterns.mjs", "--count-only", "-"],
-                                                   input_str=content)
+                    # Don't log error here as it might be expected if file is new
+                    res_show = execute_raw(show_cmd, log_on_error=False)
+                    if res_show.returncode != 0:
+                        continue
+
+                    content = res_show.stdout
+                    stdout_baseline = execute(["node", "scripts/detect-antipatterns.mjs", "--count-only", "-"],
+                                               input_str=content)
                     baseline_count += int(stdout_baseline or 0)
-                except (CLIError, subprocess.CalledProcessError):
+                except (CLIError, subprocess.CalledProcessError) as e:
+                    print(f"⚠️  Warning: Failed to calculate baseline for {mf}: {e}", file=sys.stderr)
                     continue
-        except (CLIError, subprocess.CalledProcessError):
-            pass
+        except (CLIError, subprocess.CalledProcessError) as e:
+            print(f"⚠️  Warning: Failed to resolve dynamic audit baseline: {e}", file=sys.stderr)
 
     if not args.json:
         print(f"UI Anti-Pattern Audit: Current={current_count}, Baseline={baseline_count}")
@@ -685,7 +695,7 @@ def handle_fix_ci(args):
     else:
         # Local dev fallback: detect current branch
         try:
-            branch = run_command(['git', 'branch', '--show-current'])
+            branch = execute(['git', 'branch', '--show-current'])
             if not branch: raise Exception("No current branch detected")
             if not args.json: print(f"ℹ️  Detected current branch: `{branch}`")
             pulls = list(repo.get_pulls(state='open', head=f"{repo.owner.login}:{branch}"))

--- a/dev-tools/utils.py
+++ b/dev-tools/utils.py
@@ -2,7 +2,7 @@ import os
 import sys
 import subprocess
 import json
-from typing import Optional
+from typing import Optional, Union, List
 
 class CLIError(Exception):
     def __init__(self, message, code=1, data=None):
@@ -27,13 +27,45 @@ def get_github_token() -> Optional[str]:
     except (subprocess.CalledProcessError, FileNotFoundError):
         return None
 
+def run_command(cmd: Union[str, List[str]], shell: bool = False, check: bool = True, input_str: Optional[str] = None, log_on_error: bool = True) -> Union[str, subprocess.CompletedProcess]:
+    """
+    Runs a command, captures stdout/stderr, and handles errors with granular logging.
+    If check=True, returns stdout as string.
+    If check=False, returns the full CompletedProcess object.
+    """
+    try:
+        proc = subprocess.run(
+            cmd,
+            shell=shell,
+            input=input_str,
+            capture_output=True,
+            text=True,
+            check=check
+        )
+        return proc.stdout.strip() if check else proc
+    except subprocess.CalledProcessError as e:
+        if log_on_error:
+            print(f"❌ Command failed (exit {e.returncode}): {e.cmd}", file=sys.stderr)
+            if e.stdout:
+                print(f"--- stdout ---\n{e.stdout.strip()}", file=sys.stderr)
+            if e.stderr:
+                print(f"--- stderr ---\n{e.stderr.strip()}", file=sys.stderr)
+
+        if check:
+            raise CLIError(f"Command failed with exit code {e.returncode}", code=e.returncode)
+        # Should not be reachable because subprocess.run with check=False doesn't raise CalledProcessError
+        return subprocess.CompletedProcess(e.cmd, e.returncode, e.stdout, e.stderr)
+
 def get_repo_name() -> Optional[str]:
     """Auto-detect repo from git remote."""
     try:
-        url = subprocess.check_output(
-            ['git', 'config', '--get', 'remote.origin.url'],
-            stderr=subprocess.DEVNULL, text=True
-        ).strip()
+        # Using run_command here with check=False to avoid noisy logs for a common discovery step
+        res = run_command(['git', 'config', '--get', 'remote.origin.url'], check=False, log_on_error=False)
+        if res.returncode != 0:
+            return os.getenv("GH_REPO")
+        url = res.stdout.strip()
+        if not url:
+            return os.getenv("GH_REPO")
         import re
         match = re.search(r'[:/]([^/]+/[^/.]+)(\.git)?$', url)
         return match.group(1) if match else url

--- a/dev-tools/utils.py
+++ b/dev-tools/utils.py
@@ -56,9 +56,6 @@ def execute_raw(cmd: Union[str, List[str]], shell: bool = False, input_str: Opti
     """Runs a command and returns the full CompletedProcess object without raising."""
     return _run(cmd, shell, input_str, log_on_error)
 
-# Legacy alias for backward compatibility during transition
-run_command = execute_raw
-
 def get_repo_name() -> Optional[str]:
     """Auto-detect repo from git remote."""
     try:

--- a/dev-tools/utils.py
+++ b/dev-tools/utils.py
@@ -27,40 +27,43 @@ def get_github_token() -> Optional[str]:
     except (subprocess.CalledProcessError, FileNotFoundError):
         return None
 
-def run_command(cmd: Union[str, List[str]], shell: bool = False, check: bool = True, input_str: Optional[str] = None, log_on_error: bool = True) -> Union[str, subprocess.CompletedProcess]:
-    """
-    Runs a command, captures stdout/stderr, and handles errors with granular logging.
-    If check=True, returns stdout as string.
-    If check=False, returns the full CompletedProcess object.
-    """
-    try:
-        proc = subprocess.run(
-            cmd,
-            shell=shell,
-            input=input_str,
-            capture_output=True,
-            text=True,
-            check=check
-        )
-        return proc.stdout.strip() if check else proc
-    except subprocess.CalledProcessError as e:
-        if log_on_error:
-            print(f"❌ Command failed (exit {e.returncode}): {e.cmd}", file=sys.stderr)
-            if e.stdout:
-                print(f"--- stdout ---\n{e.stdout.strip()}", file=sys.stderr)
-            if e.stderr:
-                print(f"--- stderr ---\n{e.stderr.strip()}", file=sys.stderr)
+def _run(cmd: Union[str, List[str]], shell: bool = False, input_str: Optional[str] = None, log_on_error: bool = True) -> subprocess.CompletedProcess:
+    """Internal helper to run a command with granular logging on failure."""
+    proc = subprocess.run(
+        cmd,
+        shell=shell,
+        input=input_str,
+        capture_output=True,
+        text=True,
+        check=False
+    )
+    if proc.returncode != 0 and log_on_error:
+        print(f"❌ Command failed (exit {proc.returncode}): {proc.args}", file=sys.stderr)
+        if proc.stdout:
+            print(f"--- stdout ---\n{proc.stdout.strip()}", file=sys.stderr)
+        if proc.stderr:
+            print(f"--- stderr ---\n{proc.stderr.strip()}", file=sys.stderr)
+    return proc
 
-        if check:
-            raise CLIError(f"Command failed with exit code {e.returncode}", code=e.returncode)
-        # Should not be reachable because subprocess.run with check=False doesn't raise CalledProcessError
-        return subprocess.CompletedProcess(e.cmd, e.returncode, e.stdout, e.stderr)
+def execute(cmd: Union[str, List[str]], shell: bool = False, input_str: Optional[str] = None, log_on_error: bool = True) -> str:
+    """Runs a command, returns stripped stdout, and raises CLIError on failure."""
+    proc = _run(cmd, shell, input_str, log_on_error)
+    if proc.returncode != 0:
+        raise CLIError(f"Command failed with exit code {proc.returncode}", code=proc.returncode)
+    return proc.stdout.strip()
+
+def execute_raw(cmd: Union[str, List[str]], shell: bool = False, input_str: Optional[str] = None, log_on_error: bool = True) -> subprocess.CompletedProcess:
+    """Runs a command and returns the full CompletedProcess object without raising."""
+    return _run(cmd, shell, input_str, log_on_error)
+
+# Legacy alias for backward compatibility during transition
+run_command = execute_raw
 
 def get_repo_name() -> Optional[str]:
     """Auto-detect repo from git remote."""
     try:
-        # Using run_command here with check=False to avoid noisy logs for a common discovery step
-        res = run_command(['git', 'config', '--get', 'remote.origin.url'], check=False, log_on_error=False)
+        # Using execute_raw here to avoid noisy logs for a common discovery step
+        res = execute_raw(['git', 'config', '--get', 'remote.origin.url'], log_on_error=False)
         if res.returncode != 0:
             return os.getenv("GH_REPO")
         url = res.stdout.strip()

--- a/scripts/detect-antipatterns.mjs
+++ b/scripts/detect-antipatterns.mjs
@@ -273,12 +273,15 @@ function checkFile(filepath) {
 function checkPRScope() {
   try {
     const scopeCheckScript = path.join(__dirname, "../dev-tools/scope_check.py");
-    const output = execFileSync("python3", [scopeCheckScript], { encoding: "utf8" }).trim();
+    const output = execFileSync("python3", [scopeCheckScript], { encoding: "utf8", stdio: ['inherit', 'pipe', 'pipe'] }).trim();
     if (output) {
       console.log(`\x1b[33m⚠️  ${output}\x1b[0m\n`);
     }
-  } catch {
-    // Python or script might not be available
+  } catch (error) {
+    if (error.stderr && error.stderr.trim()) {
+      console.error(`\x1b[31m❌ Error running scope check:\x1b[0m\n${error.stderr}`);
+    }
+    // Don't exit here as scope check is usually a non-blocking warning
   }
 }
 

--- a/scripts/detect-antipatterns.mjs
+++ b/scripts/detect-antipatterns.mjs
@@ -278,8 +278,11 @@ function checkPRScope() {
       console.log(`\x1b[33m⚠️  ${output}\x1b[0m\n`);
     }
   } catch (error) {
+    // If the error message itself is present and is not just a standard shell error, report it
     if (error.stderr && error.stderr.trim()) {
-      console.error(`\x1b[31m❌ Error running scope check:\x1b[0m\n${error.stderr}`);
+      console.error(`\x1b[31m❌ Scope check failed:\x1b[0m\n${error.stderr}`);
+    } else if (error.message) {
+      console.error(`\x1b[31m❌ Scope check error:\x1b[0m ${error.message}`);
     }
     // Don't exit here as scope check is usually a non-blocking warning
   }


### PR DESCRIPTION
This PR implements more granular logging in the repository's CI scripts to capture stderr and identify specific root causes for process failures.

Key changes:
- Introduced a robust `run_command` helper in `dev-tools/utils.py` that captures stdout/stderr and handling errors with detailed logging to `sys.stderr`.
- Refactored `dev-tools/td_cli.py`, `dev-tools/repo_utils.py`, and `dev-tools/scope_check.py` to use `run_command`, ensuring that failures in linting, type-checking, and other CI tasks are properly logged.
- Updated `scripts/detect-antipatterns.mjs` to report errors from its internal scope check to `stderr`.
- Added a `log_on_error` parameter to `run_command` to avoid noisy logging for non-critical discovery steps (e.g., getting the repo name).
- Fixed regressions in `handle_conflicts` and `handle_repair` where exit codes or stderr content were previously being lost.

Fixes #700

---
*PR created automatically by Jules for task [17275988879795712215](https://jules.google.com/task/17275988879795712215) started by @arii*