### PR TITLE
Fix git push authentication in self-healing CI workflow

### DIFF
--- a/.github/workflows/self-healing.yml
+++ b/.github/workflows/self-healing.yml
@@ -148,7 +148,7 @@ jobs:
             git checkout -b "$NEW_BRANCH"
             git add .
             git commit -m "🤖 AI-generated fix for CI failures"
-            git push origin "$NEW_BRANCH" --force
+            git push "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" "$NEW_BRANCH" --force
 
             PR_MSG="Automated repair attempt for failed run $WORKFLOW_RUN_ID"
             if [ "${{ steps.verify.outputs.success }}" == "success" ]; then

--- a/.github/workflows/self-healing.yml
+++ b/.github/workflows/self-healing.yml
@@ -148,6 +148,7 @@ jobs:
             git checkout -b "$NEW_BRANCH"
             git add .
             git commit -m "🤖 AI-generated fix for CI failures"
+            echo "::add-mask::${GH_TOKEN}"
             git push "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" "$NEW_BRANCH" --force
 
             PR_MSG="Automated repair attempt for failed run $WORKFLOW_RUN_ID"


### PR DESCRIPTION
Resolves the fatal authentication error `could not read Username for 'https://github.com': No such device or address` observed in the self-healing CI pipeline.

---
*PR created automatically by Jules for task [11839046423358088281](https://jules.google.com/task/11839046423358088281) started by @arii*