### PR TITLE
Define concrete Lighthouse CI assertions and budget thresholds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,8 @@ any-count.txt
 
 # Tools
 dev-tools/config.json
+.lighthouseci/*
+!.lighthouseci/assertion-results.json
 
 # IDEs
 .vscode/*

--- a/.lighthouseci/assertion-results.json
+++ b/.lighthouseci/assertion-results.json
@@ -1,1 +1,6 @@
-[]
+{
+  "assertions": {
+    "largest-contentful-paint": ["warn", {"maxNumericValue": 2500}],
+    "cumulative-layout-shift": ["error", {"maxNumericValue": 0.1}]
+  }
+}

--- a/.lighthouseci/links.json
+++ b/.lighthouseci/links.json
@@ -1,3 +1,0 @@
-{
-  "http://localhost:4173/tech-dancer/": "https://storage.googleapis.com/lighthouse-infrastructure.appspot.com/reports/1777618902871-97553.report.html"
-}

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -11,7 +11,7 @@
     "assert": {
       "assertions": {
         "categories:performance": ["error", { "minScore": 0.7 }],
-        "largest-contentful-paint": ["error", { "maxNumericValue": 4500 }],
+        "largest-contentful-paint": ["error", { "maxNumericValue": 2500 }],
         "cumulative-layout-shift": ["error", { "maxNumericValue": 0.1 }],
         "total-blocking-time": ["error", { "maxNumericValue": 200 }]
       }


### PR DESCRIPTION
This PR implements concrete Lighthouse CI assertions as requested by RepoAuditor (PR #553). It tightens the performance budget for Largest Contentful Paint to 2500ms in the main configuration file (`lighthouserc.json`) to ensure CI builds fail when performance targets are missed. Additionally, it provides the requested `.lighthouseci/assertion-results.json` template and ensures proper repository hygiene by ignoring generated Lighthouse reports in `.gitignore`.

Fixes #558

---
*PR created automatically by Jules for task [14595935280194849267](https://jules.google.com/task/14595935280194849267) started by @arii*