### PR TITLE
Remove redundant class names from Box components

### DIFF
--- a/src/components/GlobalSearch.tsx
+++ b/src/components/GlobalSearch.tsx
@@ -101,7 +101,7 @@ export function GlobalSearch() {
         className="border-accent/20"
         onClick={(e: MouseEvent) => e.stopPropagation()}
       >
-        <Box border="b" padding={6} display="flex" align="center" gap={4} className="relative">
+        <Box border="b" padding={6} display="flex" align="center" gap={4} position="relative">
           <Search className="w-6 h-6 text-accent shrink-0" />
           <Text
             as="input"
@@ -124,7 +124,8 @@ export function GlobalSearch() {
             onClick={close}
             padding={2}
             cursor="pointer"
-            className="group hover:bg-accent/5 transition-colors border border-line/50"
+            border
+            className="group hover:bg-accent/5 transition-colors border-line/50"
           >
             <X className="w-6 h-6 text-text-dim group-hover:text-accent" />
           </Box>
@@ -150,13 +151,13 @@ export function GlobalSearch() {
                   cursor="pointer"
                   className="hover:bg-accent/5 group transition-colors"
                 >
-                   <Box border padding={2} surface="muted" radius="sm" className="shrink-0">
+                   <Box border padding={2} surface="muted" radius="sm" shrink={0}>
                       <Hash className="w-4 h-4 text-accent opacity-50" />
                    </Box>
                    <Stack gap={1} flex className="min-w-0">
                       <Box display="flex" align="center" justify="between" gap={3}>
                          <Text variant="display" size="lg" className="group-hover:text-accent truncate">{highlight(res.title)}</Text>
-                         <Box border paddingX={2} paddingY={0.5} radius="none" className="bg-accent/5 shrink-0">
+                         <Box border paddingX={2} paddingY={0.5} radius="none" shrink={0} className="bg-accent/5">
                             <Text variant="mono" size="micro" color="brand">{res.type.toUpperCase()}</Text>
                           </Box>
                       </Box>

--- a/src/components/MobileBottomNav.tsx
+++ b/src/components/MobileBottomNav.tsx
@@ -12,9 +12,10 @@ export function MobileBottomNav() {
       position="fixed"
       inset="bottom"
       zIndex="sticky"
-      className="lg:hidden bg-surface/90 backdrop-blur-xl border-t border-line pb-[safe-area-inset-bottom]"
+      border="t"
+      className="lg:hidden bg-surface/90 backdrop-blur-xl border-line pb-[safe-area-inset-bottom]"
     >
-      <Box as="ul" display="flex" justify="around" align="center" width="full" className="h-16">
+      <Box as="ul" display="flex" justify="around" align="center" width="full" height={16}>
         {MOBILE_NAV_ROUTES.map((item) => {
           const Icon = item.icon;
           return (
@@ -27,7 +28,7 @@ export function MobileBottomNav() {
                 )}
               >
                 <Icon className={cn("w-6 h-6", stroke.thick)} />
-                <Text variant="mono" size="micro" weight="font-bold" className="mt-1">
+                <Text variant="mono" size="micro" weight="font-bold" marginTop={1}>
                   {item.label.split(' ')[0]}
                 </Text>
               </NavLink>

--- a/src/components/navigation/MobileHeader.tsx
+++ b/src/components/navigation/MobileHeader.tsx
@@ -16,7 +16,8 @@ export function MobileHeader({ isOpen, onToggle, onClose }: MobileHeaderProps) {
       as="nav"
       aria-label="Mobile Navigation"
       layout="mobileHeader"
-      className="transition-[backdrop-filter] duration-300 bg-surface border-b border-line"
+      border="b"
+      className="transition-[backdrop-filter] duration-300 bg-surface border-line"
     >
       <Box as={NavLink} to="/" onClick={onClose} display="flex" align="center">
         <Logo className="h-6" />
@@ -28,7 +29,8 @@ export function MobileHeader({ isOpen, onToggle, onClose }: MobileHeaderProps) {
         display="flex"
         align="center"
         justify="center"
-        className="min-h-12 min-w-12 rounded-full hover:bg-bg/50 active:bg-accent/10 transition-colors"
+        radius="full"
+        className="min-h-12 min-w-12 hover:bg-bg/50 active:bg-accent/10 transition-colors"
         aria-label={isOpen ? "Close menu" : "Open menu"}
         aria-expanded={isOpen}
         whileTap={{ scale: 0.95 }}

--- a/src/components/navigation/MobileMenuOverlay.tsx
+++ b/src/components/navigation/MobileMenuOverlay.tsx
@@ -63,7 +63,8 @@ export function MobileMenuOverlay({ isOpen, onClose, onSearchClick }: MobileMenu
       animate={{ x: 0 }}
       exit={{ x: '-100%' }}
       position="fixed"
-      className="top-16 left-0 right-0 bottom-0 z-[100] bg-bg lg:hidden w-full"
+      width="full"
+      className="top-16 left-0 right-0 bottom-0 z-[100] bg-bg lg:hidden"
       padding={8}
       overflow="y-auto"
       role="dialog"
@@ -83,7 +84,9 @@ export function MobileMenuOverlay({ isOpen, onClose, onSearchClick }: MobileMenu
             paddingY={6}
             border="b"
             width="full"
-            className="transition-all relative z-10 rounded-md text-text-dim hover:text-accent hover:bg-bg/50 border-line/50 min-h-[44px]"
+            position="relative"
+            radius="md"
+            className="transition-all z-10 text-text-dim hover:text-accent hover:bg-bg/50 border-line/50 min-h-[44px]"
           >
             <Search className={`w-6 h-6 ${stroke.thick} flex-shrink-0`} />
             <Text variant="sans" size="xl" weight="font-bold" className="leading-none">

--- a/src/components/ui/CardImagePlaceholder.tsx
+++ b/src/components/ui/CardImagePlaceholder.tsx
@@ -19,7 +19,7 @@ export function CardImagePlaceholder({ image, category, title }: CardImagePlaceh
   else if (norm.includes('lifestyle')) surfaceVariant = 'danger';
 
   return (
-    <Box shrink={false} aspect="video" maxHeight="cardImage" width="full" className="relative overflow-hidden border-b border-line bg-bg">
+    <Box shrink={false} aspect="video" maxHeight="cardImage" width="full" border="b" position="relative" overflow="hidden" className="bg-bg">
       {image ? (
         <img
           src={image}
@@ -36,8 +36,8 @@ export function CardImagePlaceholder({ image, category, title }: CardImagePlaceh
           </Box>
         </Stack>
       )}
-      <Box className="absolute top-4 left-4">
-        <Box className="flex items-center gap-2 px-3 py-1 bg-surface/95 backdrop-blur-md border border-line rounded-sm shadow-sm">
+      <Box position="absolute" className="top-4 left-4">
+        <Box border display="flex" align="center" gap={2} paddingX={3} paddingY={1} radius="sm" shadow="sm" className="bg-surface/95 backdrop-blur-md">
           {(() => {
             const icon = getCategoryIcon(category);
             return React.createElement(icon, { className: "w-3.5 h-3.5 text-accent", strokeWidth: 2.5 });

--- a/src/components/ui/ContentCard.tsx
+++ b/src/components/ui/ContentCard.tsx
@@ -94,7 +94,7 @@ export function ContentCard({
         </Stack>
 
         {!compact && (
-          <Box display="flex" align="center" gap={2} paddingTop={4} border="t" className="border-line/50 mt-auto">
+          <Box display="flex" align="center" gap={2} paddingTop={4} border="t" marginTop="auto" className="border-line/50">
             <Text variant="mono" size="xs" weight="font-bold" tracking="wider" color="accent">
               Read Article
             </Text>

--- a/src/components/ui/FilterBar.tsx
+++ b/src/components/ui/FilterBar.tsx
@@ -10,7 +10,7 @@ export function FilterBar({ categories }: FilterBarProps) {
   const [activeCategory, setActiveCategory] = useSearchParam('category', 'All');
 
   return (
-    <Box border="b" className="w-full bg-surface/80 backdrop-blur-md sticky top-16 lg:top-0 z-40 overflow-x-auto no-scrollbar" paddingY={5}>
+    <Box border="b" width="full" position="sticky" zIndex={40} overflowX="auto" className="bg-surface/80 backdrop-blur-md top-16 lg:top-0 no-scrollbar" paddingY={5}>
       <Stack direction="row" gap={4} className="min-w-max">
         {categories.map((cat) => (
           <Box

--- a/src/components/ui/ListRow.tsx
+++ b/src/components/ui/ListRow.tsx
@@ -22,7 +22,7 @@ export function ListRow({ slug, title, category, excerpt, date, basePath, conten
       display="flex" align="center" border="b"
       className="group hover:bg-surface/50 transition-colors"
     >
-      <Box className="w-1 self-stretch bg-accent shrink-0 opacity-0 group-hover:opacity-100 transition-opacity" />
+      <Box shrink={0} className="w-1 self-stretch bg-accent opacity-0 group-hover:opacity-100 transition-opacity" />
       <Box width={12} height={12} margin={3} shrink={0} radius="none" overflow="hidden" display="flex" align="center" justify="center">
         <CategoryPlaceholder category={category} size="md" />
       </Box>
@@ -34,7 +34,7 @@ export function ListRow({ slug, title, category, excerpt, date, basePath, conten
         <Text variant="display" size="sm" weight="font-bold" className="line-clamp-1">{title}</Text>
         <Text variant="body" size="xs" color="dim" className="truncate">{excerpt}</Text>
       </Stack>
-      <Box display="flex" align="center" gap={3} padding={4} className="shrink-0 text-text-dim">
+      <Box display="flex" align="center" gap={3} padding={4} shrink={0} className="text-text-dim">
         <Text variant="mono" size="micro">{rt} min</Text>
         <ChevronRight className="w-3.5 h-3.5 opacity-30 group-hover:opacity-100 transition-opacity" />
       </Box>

--- a/src/components/ui/PageHeader.tsx
+++ b/src/components/ui/PageHeader.tsx
@@ -61,7 +61,7 @@ export function PageHeader({
 
 export function SectionHeader({ label, title, children }: { label: string; title: string; children?: ReactNode }) {
   return (
-    <Box display="flex" justify="between" align="end" border="b" paddingBottom={4} className="border-line">
+    <Box display="flex" justify="between" align="end" border="b" paddingBottom={4}>
       <Stack gap={1}>
         <Text variant="mono" size="xs" color="brand" weight="font-semibold" tracking="widest" uppercase>{label}</Text>
         <Text variant="headline" size="3xl" weight="font-black">{title}</Text>

--- a/src/components/ui/PageSkeleton.tsx
+++ b/src/components/ui/PageSkeleton.tsx
@@ -51,8 +51,8 @@ function PostSkeleton() {
 function SimpleSkeleton() {
   const { opacity } = motionTokens.skeleton;
   return (
-    <Stack gap={12} className={`w-full ${opacity}`}>
-      <Box paddingBottom={10} className="border-b border-line/30">
+    <Stack gap={12} width="full" className={opacity}>
+      <Box paddingBottom={10} border="b" className="border-line/30">
         <Stack gap={4}>
           <Skeleton height={4} width={24} />
           <Skeleton height={10} width="1/2" />
@@ -76,7 +76,7 @@ const SKELETON_MAP: Record<SkeletonVariant, ReactNode> = {
 
 export function PageSkeleton({ className, variant = 'grid' }: PageSkeletonProps) {
   return (
-    <Box className={`w-full ${className || ''}`}>
+    <Box width="full" className={className || ''}>
       {SKELETON_MAP[variant]}
     </Box>
   );

--- a/src/features/dashboard/Dashboard.tsx
+++ b/src/features/dashboard/Dashboard.tsx
@@ -105,7 +105,7 @@ export default function Home() {
             cursor="pointer"
             onClick={() => handleNavigate('/research')}
           >
-            <Box width={16} height={16} radius="xl" surface="muted" display="flex" align="center" justify="center" color="accent" className="shrink-0">
+            <Box width={16} height={16} radius="xl" surface="muted" display="flex" align="center" justify="center" color="accent" shrink={0}>
                <ArrowRight className="w-8 h-8" />
             </Box>
             <Stack gap={1} flex={1}>
@@ -160,7 +160,8 @@ export default function Home() {
                   as={motion.div}
                   variants={motionTokens.staggerItem}
                   border
-                  className="border-line h-full"
+                  height="full"
+                  className="border-line"
                 >
                   <EventCard {...event} />
                 </Box>

--- a/src/features/lab/Toolbox.tsx
+++ b/src/features/lab/Toolbox.tsx
@@ -48,7 +48,7 @@ export default function Toolbox() {
           <ViewToggle view={view} onChange={setView} />
         </Box>
 
-        <Box marginBottom={8} display="flex" wrap gap={2} padding={3} marginTop={8} className="rounded-2xl border border-line/80 bg-surface/60 shadow-sm">
+        <Box marginBottom={8} display="flex" wrap gap={2} padding={3} marginTop={8} border radius="2xl" shadow="sm" className="border-line/80 bg-surface/60">
           <span
             onClick={() => setSelectedPill('all')}
             className={cn(

--- a/src/features/research/ResearchAnalytics.tsx
+++ b/src/features/research/ResearchAnalytics.tsx
@@ -25,7 +25,7 @@ export default function ResearchAnalytics() {
         />
 
         <Stack gap={8}>
-          <Box paddingBottom={4} display="flex" justify="between" align="end" className="border-b border-line">
+          <Box paddingBottom={4} display="flex" justify="between" align="end" border="b">
             <Text variant="headline" size="2xl" weight="font-black">Tools Ecosystem</Text>
             <Text variant="mono" size="xs" color="dim" weight="font-semibold" className="tracking-widest">{tools.length} TOOLS</Text>
           </Box>
@@ -71,7 +71,7 @@ export default function ResearchAnalytics() {
         </Stack>
 
         <Stack gap={8}>
-          <Box paddingBottom={4} display="flex" justify="between" align="end" className="border-b border-line">
+          <Box paddingBottom={4} display="flex" justify="between" align="end" border="b">
             <Text variant="headline" size="2xl" weight="font-black">Studies</Text>
             <Text variant="mono" size="xs" color="dim" weight="font-semibold" className="tracking-widest">{studies.length} ARTICLES</Text>
           </Box>
@@ -108,7 +108,7 @@ export default function ResearchAnalytics() {
               ))}
             </Grid>
           ) : (
-            <Box padding={12} className="rounded-2xl border border-dashed border-line/80 bg-surface/40 text-center shadow-xl relative overflow-hidden">
+            <Box padding={12} border radius="2xl" shadow="xl" position="relative" overflow="hidden" className="border-dashed border-line/80 bg-surface/40 text-center">
                <Box position="absolute" top={-12} right={-12} width={40} height={40} surface="accent" opacity={0.03} radius="full" className="blur-3xl" />
                <Stack align="center" justify="center" gap={4}>
                   <Box color="dim" opacity={0.5}>

--- a/src/layouts/Footer.tsx
+++ b/src/layouts/Footer.tsx
@@ -9,7 +9,7 @@ export function Footer() {
   ];
 
   return (
-    <Box as="footer" paddingY={12} paddingX={4} surface="bg" className="opacity-80 border-t border-line mt-auto">
+    <Box as="footer" paddingY={12} paddingX={4} surface="bg" border="t" opacity={80} marginTop="auto">
       <Stack direction={{ base: 'col', sm: 'row' }} justify="between" align="center" gap={4}>
         <Stack direction="row" align="center" gap={2}>
           <BrandIcon className="w-4 h-4 opacity-50" />


### PR DESCRIPTION
Removed redundant Tailwind class names and migrated them to <Box> system props across several components to reduce DOM attribute bloat. Verified changes via manual inspection and test suite execution.

Fixes #557

---
*PR created automatically by Jules for task [12184392782289752446](https://jules.google.com/task/12184392782289752446) started by @arii*