### PR TITLE
Fix E2E Test Failures in Subpath Deployments

### DIFF
--- a/tests/previews.spec.ts
+++ b/tests/previews.spec.ts
@@ -2,8 +2,8 @@ import { test, expect } from '@playwright/test';
 
 test.describe('Preview Dashboard', () => {
   test('should load the dashboard and show initial elements', async ({ page }) => {
-    // Navigate to the preview dashboard
-    await page.goto(`${process.env.VITE_BASE_PATH || '/'}previews/index.html`);
+    // Navigate to the preview dashboard using a relative path to ensure correct resolution against baseURL
+    await page.goto('./previews/index.html');
     await page.waitForLoadState('networkidle');
 
     // Check title
@@ -23,7 +23,7 @@ test.describe('Preview Dashboard', () => {
   });
 
   test('responsive layout check', async ({ page }) => {
-    await page.goto(`${process.env.VITE_BASE_PATH || '/'}previews/index.html`);
+    await page.goto('./previews/index.html');
     await page.waitForLoadState('networkidle');
 
     // Desktop view

--- a/tests/search.spec.ts
+++ b/tests/search.spec.ts
@@ -28,7 +28,7 @@ test.describe('Global Search Modal', () => {
     await page.getByRole('navigation', { name: 'Main Navigation' }).getByRole('button', { name: 'Search' }).click();
     await expect(page.getByPlaceholder('SEARCH REPOSITORY // FILTER BLOG & GEAR')).toBeVisible();
 
-    await page.goto('./gear');
+    await page.goto('gear');
     await page.waitForLoadState('networkidle');
 
     await expect(page.getByPlaceholder('SEARCH REPOSITORY // FILTER BLOG & GEAR')).not.toBeVisible();
@@ -77,7 +77,7 @@ test.describe('Search and Filter URL Persistence', () => {
   });
 
   test('Blog category filter should persist after reload', async ({ page }) => {
-    await page.goto('./blog');
+    await page.goto('blog');
     await page.waitForLoadState('networkidle');
 
     const categoryButton = page.getByRole('button', { name: 'Tech Portfolio', exact: true }).or(page.getByRole('button', { name: 'Tech Portfolio' }).first());
@@ -94,7 +94,7 @@ test.describe('Search and Filter URL Persistence', () => {
   });
 
   test('Blog search term should persist after reload', async ({ page }) => {
-    await page.goto('./blog');
+    await page.goto('blog');
     await page.waitForLoadState('networkidle');
 
     const searchInput = page.getByPlaceholder(/Search posts/i);
@@ -111,7 +111,7 @@ test.describe('Search and Filter URL Persistence', () => {
   });
 
   test('Gear search term should persist after reload', async ({ page }) => {
-    await page.goto('./gear');
+    await page.goto('gear');
     await page.waitForLoadState('networkidle');
 
     const searchInput = page.getByPlaceholder(/Search gear/i);

--- a/tests/search.spec.ts
+++ b/tests/search.spec.ts
@@ -28,7 +28,7 @@ test.describe('Global Search Modal', () => {
     await page.getByRole('navigation', { name: 'Main Navigation' }).getByRole('button', { name: 'Search' }).click();
     await expect(page.getByPlaceholder('SEARCH REPOSITORY // FILTER BLOG & GEAR')).toBeVisible();
 
-    await page.goto('gear');
+    await page.goto('./gear');
     await page.waitForLoadState('networkidle');
 
     await expect(page.getByPlaceholder('SEARCH REPOSITORY // FILTER BLOG & GEAR')).not.toBeVisible();
@@ -77,7 +77,7 @@ test.describe('Search and Filter URL Persistence', () => {
   });
 
   test('Blog category filter should persist after reload', async ({ page }) => {
-    await page.goto('blog');
+    await page.goto('./blog');
     await page.waitForLoadState('networkidle');
 
     const categoryButton = page.getByRole('button', { name: 'Tech Portfolio', exact: true }).or(page.getByRole('button', { name: 'Tech Portfolio' }).first());
@@ -94,7 +94,7 @@ test.describe('Search and Filter URL Persistence', () => {
   });
 
   test('Blog search term should persist after reload', async ({ page }) => {
-    await page.goto('blog');
+    await page.goto('./blog');
     await page.waitForLoadState('networkidle');
 
     const searchInput = page.getByPlaceholder(/Search posts/i);
@@ -111,7 +111,7 @@ test.describe('Search and Filter URL Persistence', () => {
   });
 
   test('Gear search term should persist after reload', async ({ page }) => {
-    await page.goto('gear');
+    await page.goto('./gear');
     await page.waitForLoadState('networkidle');
 
     const searchInput = page.getByPlaceholder(/Search gear/i);

--- a/tests/search_mobile.spec.ts
+++ b/tests/search_mobile.spec.ts
@@ -4,7 +4,7 @@ test.use({ ...devices['Pixel 7'] });
 
 test.describe('Global Search Modal - Mobile', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/');
+    await page.goto('./');
   });
 
   test('should open search modal via mobile menu', async ({ page }) => {

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -66,7 +66,7 @@ test('all nav links are reachable and error-free', async ({ page }) => {
 });
 
 test('all post/content pages load without errors', async ({ page }) => {
-  const contentIndexes = ['blog', 'gear', 'research'];
+  const contentIndexes = ['./blog', './gear', './research'];
 
   for (const index of contentIndexes) {
     await page.goto(index);

--- a/tests/visual.spec.ts
+++ b/tests/visual.spec.ts
@@ -2,11 +2,11 @@ import { test, expect } from '@playwright/test';
 
 const routes = [
   { name: 'home', path: './' },
-  { name: 'blog', path: 'blog' },
-  { name: 'gear', path: 'gear' },
-  { name: 'research', path: 'research' },
-  { name: 'about', path: 'about' },
-  { name: 'contact', path: 'contact' }
+  { name: 'blog', path: './blog' },
+  { name: 'gear', path: './gear' },
+  { name: 'research', path: './research' },
+  { name: 'about', path: './about' },
+  { name: 'contact', path: './contact' }
 ];
 
 test.describe('Visual Regression Tests', () => {
@@ -23,9 +23,7 @@ test.describe('Visual Regression Tests', () => {
       await page.waitForLoadState('networkidle');
 
       // Ensure the main content is loaded and visible
-      // We wait for both #root to be visible and for the main element to be present
-      // to ensure hydration has finished and initial animations (opacity) have progressed.
-      await expect(page.locator('#root')).toBeVisible({ timeout: 10000 });
+      // Relying solely on the main element ensures hydration and layout are ready.
       await expect(page.locator('main')).toBeVisible({ timeout: 10000 });
 
       // Robust scroll to bottom to trigger all lazy-loaded content

--- a/tests/visual.spec.ts
+++ b/tests/visual.spec.ts
@@ -2,11 +2,11 @@ import { test, expect } from '@playwright/test';
 
 const routes = [
   { name: 'home', path: './' },
-  { name: 'blog', path: './blog' },
-  { name: 'gear', path: './gear' },
-  { name: 'research', path: './research' },
-  { name: 'about', path: './about' },
-  { name: 'contact', path: './contact' }
+  { name: 'blog', path: 'blog' },
+  { name: 'gear', path: 'gear' },
+  { name: 'research', path: 'research' },
+  { name: 'about', path: 'about' },
+  { name: 'contact', path: 'contact' }
 ];
 
 test.describe('Visual Regression Tests', () => {
@@ -22,8 +22,11 @@ test.describe('Visual Regression Tests', () => {
       await page.goto(route.path);
       await page.waitForLoadState('networkidle');
 
-      // Ensure the main content is loaded instead of using a manual timeout
-      await expect(page.locator('#root')).toBeVisible();
+      // Ensure the main content is loaded and visible
+      // We wait for both #root to be visible and for the main element to be present
+      // to ensure hydration has finished and initial animations (opacity) have progressed.
+      await expect(page.locator('#root')).toBeVisible({ timeout: 10000 });
+      await expect(page.locator('main')).toBeVisible({ timeout: 10000 });
 
       // Robust scroll to bottom to trigger all lazy-loaded content
       await page.evaluate(async () => {


### PR DESCRIPTION
This PR fixes E2E test failures occurring in subpath deployment environments by:
1. Converting absolute navigation paths (e.g., `/`) to relative ones (`./`), ensuring Playwright respects the configured `baseURL`.
2. Improving the reliability of visual regression tests by waiting for actual application content (`main`) to become visible, which prevents premature snapshots during hydration or entry animations.

Fixes #721

---
*PR created automatically by Jules for task [2101375226973389495](https://jules.google.com/task/2101375226973389495) started by @arii*