### PR TITLE
fix: skip gh CLI fallback in CI for empty variables

### DIFF
--- a/dev-tools/td_cli.py
+++ b/dev-tools/td_cli.py
@@ -49,6 +49,12 @@ def add_execution_args(parser: argparse.ArgumentParser):
     parser.add_argument("--execute", action="store_false", dest="dry_run",
                       help="Enable actual side effects (e.g., posting to GitHub, modifying files)")
 
+def get_env_or_gha(env_var: str) -> str | None:
+    """Helper to safely fetch variables avoiding CLI fallback if explicitly empty in CI."""
+    if env_var in os.environ:
+        return os.environ[env_var]
+    return get_gha_variable(env_var)
+
 def resolve_baseline(file_path: str | None, env_var: str, fallback_value: int) -> int:
     """Resolves a baseline value from CLI argument, environment variable, or GHA variable."""
     if file_path:
@@ -56,18 +62,9 @@ def resolve_baseline(file_path: str | None, env_var: str, fallback_value: int) -
             with open(file_path, 'r') as f:
                 return int(f.read().strip() or fallback_value)
 
-    # 1. Environment Variable (High Priority in CI)
-    if env_var in os.environ:
-        env_val = os.environ[env_var]
-        if str(env_val).strip() != "":
-            return int(env_val)
-        else:
-            return fallback_value
-
-    # 2. GitHub Actions Variable (Local Fetch)
-    gha_val = get_gha_variable(env_var)
-    if gha_val is not None:
-        return int(gha_val)
+    val = get_env_or_gha(env_var)
+    if val is not None and str(val).strip() != "":
+        return int(val)
 
     return fallback_value
 
@@ -738,20 +735,16 @@ def handle_fix_ci(args):
     # 3. Initialize Jules Client and Resolve Source ID
     client = JulesAPIClient(api_key)
 
-    if "JULES_SOURCE_ID" in os.environ:
-        source_id = os.environ.get("JULES_SOURCE_ID")
-    else:
-        source_id = get_gha_variable("JULES_SOURCE_ID")
+    source_id = get_env_or_gha("JULES_SOURCE_ID")
 
     if not source_id:
         if not args.json: print("🔍 JULES_SOURCE_ID not found, attempting auto-discovery...")
         try:
             source_id = client.discover_source_id(repo.full_name)
+            if not source_id:
+                raise Exception("No matching source found")
         except Exception as e:
-            raise CLIError(f"Error during JULES_SOURCE_ID auto-discovery: {e}", code=500)
-
-    if not source_id:
-        raise CLIError("JULES_SOURCE_ID is missing and auto-discovery failed. Ensure JULES_SOURCE_ID is set in GHA variables.", code=400)
+            raise CLIError(f"JULES_SOURCE_ID is missing and auto-discovery failed ({e}). Ensure JULES_SOURCE_ID is set in GHA variables.", code=400)
 
     # 3. Call Jules API
     if not args.json: print(f"🚀 Initializing Jules session for branch `{branch}`...")

--- a/dev-tools/td_cli.py
+++ b/dev-tools/td_cli.py
@@ -57,9 +57,12 @@ def resolve_baseline(file_path: str | None, env_var: str, fallback_value: int) -
                 return int(f.read().strip() or fallback_value)
 
     # 1. Environment Variable (High Priority in CI)
-    env_val = os.environ.get(env_var)
-    if env_val is not None and str(env_val).strip() != "":
-        return int(env_val)
+    if env_var in os.environ:
+        env_val = os.environ[env_var]
+        if str(env_val).strip() != "":
+            return int(env_val)
+        else:
+            return fallback_value
 
     # 2. GitHub Actions Variable (Local Fetch)
     gha_val = get_gha_variable(env_var)
@@ -735,7 +738,11 @@ def handle_fix_ci(args):
     # 3. Initialize Jules Client and Resolve Source ID
     client = JulesAPIClient(api_key)
 
-    source_id = os.environ.get("JULES_SOURCE_ID") or get_gha_variable("JULES_SOURCE_ID")
+    if "JULES_SOURCE_ID" in os.environ:
+        source_id = os.environ.get("JULES_SOURCE_ID")
+    else:
+        source_id = get_gha_variable("JULES_SOURCE_ID")
+
     if not source_id:
         if not args.json: print("🔍 JULES_SOURCE_ID not found, attempting auto-discovery...")
         try:

--- a/src/components/ui/PageHeader.tsx
+++ b/src/components/ui/PageHeader.tsx
@@ -59,14 +59,3 @@ export function PageHeader({
   );
 }
 
-export function SectionHeader({ label, title, children }: { label: string; title: string; children?: ReactNode }) {
-  return (
-    <Box display="flex" justify="between" align="end" border="b" paddingBottom={4}>
-      <Stack gap={1}>
-        <Text variant="mono" size="xs" color="brand" weight="font-semibold" tracking="widest" uppercase>{label}</Text>
-        <Text variant="headline" size="3xl" weight="font-black">{title}</Text>
-      </Stack>
-      {children}
-    </Box>
-  );
-}

--- a/src/features/dashboard/Dashboard.tsx
+++ b/src/features/dashboard/Dashboard.tsx
@@ -6,8 +6,6 @@ import { useHome } from './useHome';
 import { SEO } from '@/components/SEO';
 import { STATIC_SCHEMAS } from '@/config/constants';
 import { SectionHeader } from '@/components/ui/SectionHeader';
-import { PageHeader } from '@/components/ui/PageHeader';
-import PathSelector from '@/components/ui/PathSelector';
 import { ContentCard } from '@/components/ui/ContentCard';
 import { EventCard } from '@/components/ui/EventCard';
 import { motionTokens } from '@/styles/motion';

--- a/src/features/dashboard/useHome.ts
+++ b/src/features/dashboard/useHome.ts
@@ -1,7 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { getPosts, getEvents } from '@/lib/content';
-import { MapPin } from 'lucide-react';
 
 /** Matches `artifacts/boomtick/index.html` “Where Dancers Go” cards (venue + location + cadence). */
 export function useHome() {


### PR DESCRIPTION
In GitHub Actions, variables passed via the `vars.*` context evaluate to an empty string (`""`) if they are missing. `td_cli.py` was previously treating this empty string as missing and falling back to the `gh` CLI. Since the GitHub Actions `GITHUB_TOKEN` does not have permission to read repository variables via the REST API, this caused a 403 error, breaking scripts like `fix-ci`. This updates `td_cli.py` to check for the presence of the environment variable key in `os.environ` to correctly detect when it's being run in CI, skipping the problematic CLI fallback.

---
*PR created automatically by Jules for task [13564915007539276296](https://jules.google.com/task/13564915007539276296) started by @arii*