### PR TITLE
Fix workflow syntax and invalid references

### DIFF
--- a/.github/workflows/auto-conflict-resolver.yml
+++ b/.github/workflows/auto-conflict-resolver.yml
@@ -202,8 +202,6 @@ jobs:
 
           # Manually trigger workflows to run on the new PR
           gh workflow run ci.yml --ref "$RESOLVE_BRANCH" || true
-          gh workflow run lint.yml --ref "$RESOLVE_BRANCH" || true
-          gh workflow run smoke-tests.yml --ref "$RESOLVE_BRANCH" || true
           gh workflow run codeql.yml --ref "$RESOLVE_BRANCH" || true
           gh workflow run conflict-check.yml --ref "$RESOLVE_BRANCH" || true
 


### PR DESCRIPTION
This PR fixes issues in the GitHub Actions workflows. Specifically, it removes references to non-existent workflows (`lint.yml` and `smoke-tests.yml`) in the `auto-conflict-resolver.yml` file. It also ensures that all YAML files in the `.github/workflows/` directory are syntactically correct, preventing potential execution failures. standard project validations (linting, type-checking, and tests) were successfully run to ensure no regressions.

Fixes #741

---
*PR created automatically by Jules for task [16897113188008654010](https://jules.google.com/task/16897113188008654010) started by @arii*