### PR TITLE
Revert SVG Inlining in NewsletterBanner

### DIFF
--- a/src/features/email-capture/NewsletterBanner.tsx
+++ b/src/features/email-capture/NewsletterBanner.tsx
@@ -1,6 +1,6 @@
 import { Box, Stack, Text } from '@/layouts/Primitives';
 import { EmailForm } from './EmailForm';
-import { X } from 'lucide-react';
+import { Mail, X } from 'lucide-react';
 import { motionTokens } from '@/styles/motion';
 import { motion } from 'motion/react';
 import { useEmailStore } from './emailStore';
@@ -53,19 +53,7 @@ export function NewsletterBanner() {
       >
         <Stack direction="row" align="center" gap={4} className="w-full md:w-auto">
           <Box padding="compact" surface="accent" opacity={5} display={{ base: 'none', sm: 'block' }} width={12} height={12}>
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              className="w-5 h-5 text-accent"
-            >
-              <rect width="20" height="16" x="2" y="4" rx="2" />
-              <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7" />
-            </svg>
+            <Mail className="w-5 h-5 text-accent" />
           </Box>
           <Stack gap={0}>
             <Text variant="display" size="base" uppercase tracking="tight">


### PR DESCRIPTION
The inline SVG in `NewsletterBanner.tsx` was replaced with the `Mail` icon from `lucide-react`. 
Visual styling was maintained using the same Tailwind classes (`w-5 h-5 text-accent`).
Verification was performed via:
- `pnpm run type-check`
- `pnpm run lint:ox`
- `pnpm run test`
- Visual regression check using Playwright.

Fixes #737

---
*PR created automatically by Jules for task [16573211917678437825](https://jules.google.com/task/16573211917678437825) started by @arii*