### PR TITLE
Fix Self-Healing CI Workflow and Repair Script Robustness

### DIFF
--- a/.github/workflows/self-healing.yml
+++ b/.github/workflows/self-healing.yml
@@ -123,6 +123,15 @@ jobs:
         id: verify
         run: |
           echo "Verifying repairs..."
+          # Remove diagnostic files so they don't count as "changes"
+          rm -f ci_logs.txt eslint-errors.json
+
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "No changes made by AI. Skipping commit."
+            echo "success=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
           if pnpm run lint:ox && pnpm run type-check; then
             echo "Repair verified successfully!"
             echo "success=true" >> $GITHUB_OUTPUT
@@ -138,6 +147,9 @@ jobs:
       - name: Commit & Push Changes
         if: steps.verify.outputs.success != 'false'
         run: |
+          # Redundant check to ensure diagnostic logs are never committed
+          rm -f ci_logs.txt eslint-errors.json
+
           if [ -n "$(git status --porcelain)" ]; then
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/dev-tools/repair.py
+++ b/dev-tools/repair.py
@@ -83,11 +83,20 @@ def parse_eslint_json(json_path: str) -> List[Dict[str, Any]]:
                         "type": "eslint"
                     })
         return findings
-    except:
+    except json.JSONDecodeError as e:
+        log(f"Error: Failed to parse {json_path} as JSON: {e}")
+        return []
+    except Exception as e:
+        log(f"Error: Unexpected error parsing {json_path}: {e}")
         return []
 
 def extract_failing_info(logs):
     findings = []
+    # ESLint / Oxlint Text Format
+    lint_errors = re.findall(r"([a-zA-Z0-9_\-\./]+\.[tj]sx?):(\d+):(\d+): (.*)", logs)
+    for file_path, line, col, msg in lint_errors:
+        findings.append({"file": file_path, "line": line, "message": msg, "type": "lint"})
+
     # TS Errors
     ts_errors = re.findall(r"([a-zA-Z0-9_\-\./]+\.[tj]sx?):(\d+):(\d+) - error (TS\d+): (.*)", logs)
     for file_path, line, col, code, msg in ts_errors:


### PR DESCRIPTION
The "Self-Healing CI" workflow was mistakenly committing diagnostic log files and proceeding even when no code changes were made by the AI. This PR fixes these issues by:

1.  **Refining Workflow Logic:** Updating `.github/workflows/self-healing.yml` to explicitly remove diagnostic files before checking for git changes and setting `success=false` if no actual code modifications are detected.
2.  **Improving Error Extraction:** Enhancing `dev-tools/repair.py` with regex patterns to capture standard ESLint and Oxlint text output from logs, ensuring the agent has context even when JSON artifacts are missing or empty.
3.  **Hardening the Repair Script:** Adding robust error handling to the JSON parser in `repair.py` to prevent crashes and provide better diagnostic feedback in CI logs.

These changes ensure the self-healing cycle remains clean and only applies verified code fixes.

Fixes #771

---
*PR created automatically by Jules for task [858113810596725478](https://jules.google.com/task/858113810596725478) started by @arii*