### PR TITLE
Add Ollama health checks, structured error codes, and deterministic repair fallback

### DIFF
--- a/dev-tools/README.md
+++ b/dev-tools/README.md
@@ -60,6 +60,19 @@ Generates a high-precision prompt for fixing a specific CI error. It maps the er
   - `pnpm repair-context --log "/app/src/App.tsx:10:5: 'unused' is defined but never used. [no-unused-vars]"`
   - `python3 dev-tools/td_cli.py repair-context --file logs/ci_failure.log`
 
+#### `repair`
+Runs the autonomous local repair workflow and now performs a preflight Ollama health check before attempting AI fixes.
+- **Health checks**:
+  - Verifies Ollama service is reachable via `/api/tags`.
+  - Verifies `OLLAMA_MODEL` exists in the returned model list.
+- **Structured diagnostics**:
+  - `service_down`: Ollama is unreachable.
+  - `model_missing`: configured model not present; remediation includes an exact command, e.g. `ollama pull qwen2.5-coder:1.5b`.
+  - `generation_failed`: generation request failed (includes HTTP response body excerpt when available).
+- **Deterministic fallback mode**:
+  - If Ollama is unavailable, `repair` does **not** fail fast; it emits rule-based recommendations from lint/type-check signatures so engineers still get actionable next steps.
+- **Usage**: `python3 dev-tools/td_cli.py repair [--logs <FILE> | --stdin] [--worktree]`
+
 #### `ratchet-any` / `bundle-size`
 CI gates for tracking technical debt. These commands compare current metrics against baselines stored in GitHub Actions Variables (`ANY_COUNT_BASELINE`, `BUNDLE_BASELINE_KB`).
 - **Usage**: `python3 dev-tools/td_cli.py bundle-size`

--- a/dev-tools/repair.py
+++ b/dev-tools/repair.py
@@ -16,11 +16,48 @@ from utils import run_command
 OLLAMA_URL = os.environ.get("OLLAMA_URL", "http://localhost:11434/api/generate")
 MODEL = os.environ.get("OLLAMA_MODEL", "qwen2.5-coder:1.5b")
 MAX_RETRIES = 3
+OLLAMA_TAGS_URL = OLLAMA_URL.rsplit("/api/", 1)[0] + "/api/tags"
+
+ERROR_SERVICE_DOWN = "service_down"
+ERROR_MODEL_MISSING = "model_missing"
+ERROR_GENERATION_FAILED = "generation_failed"
 
 def log(msg):
     print(f"🤖 [Repair Agent] {msg}")
 
+def check_ollama_health() -> Dict[str, Any]:
+    """Checks Ollama service availability and model presence."""
+    req = urllib.request.Request(OLLAMA_TAGS_URL)
+    try:
+        with urllib.request.urlopen(req, timeout=3) as f:
+            raw = f.read().decode("utf-8")
+            data = json.loads(raw)
+    except Exception as e:
+        return {
+            "ok": False,
+            "code": ERROR_SERVICE_DOWN,
+            "message": f"Ollama service unavailable at {OLLAMA_TAGS_URL}: {e}",
+            "remediation": f"Start Ollama and verify it is reachable at {OLLAMA_TAGS_URL}."
+        }
+
+    models = [m.get("name") for m in data.get("models", []) if m.get("name")]
+    if MODEL not in models:
+        return {
+            "ok": False,
+            "code": ERROR_MODEL_MISSING,
+            "message": f"Configured model '{MODEL}' is not available in /api/tags.",
+            "remediation": f"Run: ollama pull {MODEL}"
+        }
+
+    return {"ok": True, "code": "ok", "message": f"Model '{MODEL}' is available."}
+
 def get_ollama_response(prompt):
+    health = check_ollama_health()
+    if not health["ok"]:
+        log(health["message"])
+        log(health["remediation"])
+        return {"ok": False, "code": health["code"], "message": health["message"]}
+
     data = {
         "model": MODEL,
         "prompt": prompt,
@@ -34,10 +71,20 @@ def get_ollama_response(prompt):
     try:
         with urllib.request.urlopen(req) as f:
             response = json.loads(f.read().decode("utf-8"))
-            return response.get("response", "")
+            return {"ok": True, "code": "ok", "response": response.get("response", "")}
+    except urllib.error.HTTPError as e:
+        body_excerpt = ""
+        try:
+            body_excerpt = e.read().decode("utf-8")[:280]
+        except Exception:
+            body_excerpt = "<unavailable>"
+        message = f"Ollama generation HTTP {e.code}: {body_excerpt}"
+        log(message)
+        return {"ok": False, "code": ERROR_GENERATION_FAILED, "message": message}
     except urllib.error.URLError as e:
-        log(f"Error connecting to Ollama: {e}")
-        return None
+        message = f"Error connecting to Ollama: {e}"
+        log(message)
+        return {"ok": False, "code": ERROR_SERVICE_DOWN, "message": message}
 
 def extract_imports(content: str) -> List[str]:
     """Basic extraction of local imports to provide context."""
@@ -206,10 +253,15 @@ def agent_loop(file_path, initial_errors):
                         break
 
         prompt = construct_prompt(file_path, content, "\n".join(current_errors), context_str, attempt=attempt)
-        repaired_content = get_ollama_response(prompt)
+        llm_result = get_ollama_response(prompt)
 
+        if not llm_result.get("ok"):
+            log(f"Failed to get response from LLM for {file_path}: {llm_result.get('code')}")
+            break
+
+        repaired_content = llm_result.get("response", "")
         if not repaired_content:
-            log(f"Failed to get response from LLM for {file_path}")
+            log(f"LLM returned empty content for {file_path}")
             break
 
         apply_fix(file_path, repaired_content)

--- a/dev-tools/td_cli.py
+++ b/dev-tools/td_cli.py
@@ -481,7 +481,8 @@ def handle_audit_pr(args):
                     else:
                         prompt = "The PR audit passed with no violations. Provide a final recommendation: 'Approved'. Respond ONLY with the recommendation string."
 
-                    recommendation = get_ollama_response(prompt)
+                    llm_result = get_ollama_response(prompt)
+                    recommendation = llm_result.get("response", "") if llm_result.get("ok") else ""
 
                     if not recommendation:
                         log_diag("Ollama unavailable. Using rule-based fallback recommendation.")
@@ -579,13 +580,25 @@ def handle_repair(args):
     """Wraps repair.py for AI-assisted CI repair."""
     import tempfile
     import shutil
+    from repair import check_ollama_health, ERROR_SERVICE_DOWN, ERROR_MODEL_MISSING, ERROR_GENERATION_FAILED
 
-    # Ensure Ollama is running or at least check it
-    try:
-        import urllib.request
-        urllib.request.urlopen("http://localhost:11434/api/tags", timeout=2)
-    except Exception:
-        if not args.json: print("⚠️ Ollama does not seem to be running on http://localhost:11434. Repair might fail.")
+    def _rule_based_recommendations(logs: str) -> list[str]:
+        findings = []
+        if re.search(r"TS\d+", logs):
+            findings.append("TypeScript errors detected: run `pnpm run type-check` and resolve reported TS codes in order.")
+        if "no-unused-vars" in logs or "unused" in logs.lower():
+            findings.append("Unused symbols detected: remove dead code or prefix intentionally unused params with `_`.")
+        if "anti-pattern" in logs.lower() or "arbitrary values" in logs.lower():
+            findings.append("Design-system violations detected: replace raw Tailwind/layout classes with primitives and tokens.")
+        if not findings:
+            findings.append("Run `pnpm run lint:ox` and `pnpm run type-check`, then address the first error per file deterministically.")
+        return findings
+
+    ollama_health = check_ollama_health()
+    if not ollama_health["ok"] and not args.json:
+        print(f"⚠️ Ollama unavailable ({ollama_health['code']}): {ollama_health['message']}")
+        if ollama_health["code"] == ERROR_MODEL_MISSING:
+            print("⚠️ Remediation:", ollama_health.get("remediation", "Run `ollama pull <model>`."))
 
     logs_source = ""
     logs_content = ""
@@ -635,6 +648,24 @@ def handle_repair(args):
             tmp_log_path = tmp_log.name
 
         if not args.json: print(f"🤖 Starting autonomous repair agent using {logs_source}...")
+
+        if not ollama_health["ok"]:
+            recs = _rule_based_recommendations(logs_content)
+            if args.json:
+                print(json.dumps({
+                    "status": "success",
+                    "mode": "fallback",
+                    "error": {
+                        "code": ollama_health["code"],
+                        "message": ollama_health["message"]
+                    },
+                    "recommendations": recs
+                }, indent=2))
+            else:
+                print("🧭 Ollama is unavailable, using deterministic fallback recommendations:")
+                for rec in recs:
+                    print(f"  - {rec}")
+            return
 
         cmd = [sys.executable, repair_script, tmp_log_path]
         # Also pass eslint json if available locally? For now let's keep it simple.


### PR DESCRIPTION
### Motivation
- Improve robustness and diagnostics for the autonomous local repair flow when Ollama is down, misconfigured, or missing the target model. 
- Ensure the `repair` workflow can still provide deterministic, actionable guidance when AI generation is unavailable.

### Description
- Added a shared preflight helper `check_ollama_health()` in `dev-tools/repair.py` that verifies service reachability at `/api/tags` and confirms the `OLLAMA_MODEL` is present. 
- Enhanced `get_ollama_response()` to return structured results (`{ok, code, ...}`), capture non-URL `HTTPError`s and include a response body excerpt for diagnostics, and surface error codes `service_down`, `model_missing`, and `generation_failed`. 
- Updated `agent_loop` and other call sites to consume the structured LLM responses and handle empty/failed results deterministically. 
- Updated `handle_repair()` in `dev-tools/td_cli.py` to run the health check, print clear remediation (including exact `ollama pull <model>` command when the model is missing), and provide a non-AI fallback that emits deterministic rule-based recommendations when Ollama is unavailable. 
- Documented the new behavior and error codes in `dev-tools/README.md` under the `repair` command. 

### Testing
- Compiled modified modules successfully with `python3 -m py_compile dev-tools/repair.py dev-tools/td_cli.py` (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb794fd79c8325b0d1582cee569407)