### PR TITLE
Evaluate and Fix SVG CSS Variable Injection

### DIFF
--- a/boomtick_logo.svg
+++ b/boomtick_logo.svg
@@ -1,11 +1,4 @@
 <svg viewBox="0 0 450 110" fill="none" xmlns="http://www.w3.org/2000/svg" class="h-full w-auto max-w-none overflow-visible" aria-hidden="true" preserveAspectRatio="xMidYMid meet">
-  <style>
-    :root {
-      --brand-accent: #0891b2;
-      --brand-accent-hero: #00CFFF;
-      --brand-accent-purple: #8b5cf6;
-    }
-  </style>
   <defs>
     <linearGradient id="logo-grad" x1="0%" y1="0%" x2="0%" y2="100%">
       <stop offset="0%" stop-color="#00CFFF" />

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,11 +1,4 @@
 <svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <style>
-    :root {
-      --brand-bg: #020617;
-      --brand-accent: #00CFFF;
-      --brand-accent-purple: #8b5cf6;
-    }
-  </style>
   <rect width="64" height="64" rx="14" fill="#020617"/>
   <defs>
     <linearGradient id="favicon-grad" x1="0%" y1="0%" x2="0%" y2="100%">

--- a/src/components/ui/Logo.tsx
+++ b/src/components/ui/Logo.tsx
@@ -28,8 +28,8 @@ export function Logo({ className, showText = true }: LogoProps) {
       <title id={titleId}>BoomTick Logo</title>
       <defs>
         <linearGradient id={gradientId} x1="0%" y1="0%" x2="0%" y2="100%">
-          <stop offset="0%" stopColor="#00CFFF" />
-          <stop offset="100%" stopColor="#8b5cf6" />
+          <stop offset="0%" stopColor="var(--color-accent-hero, #00CFFF)" />
+          <stop offset="100%" stopColor="var(--color-accent-purple, #8b5cf6)" />
         </linearGradient>
         <filter id={filterId} x="-50%" y="-50%" width="200%" height="200%">
           <feGaussianBlur stdDeviation="3" result="blur" />
@@ -76,7 +76,7 @@ export function Logo({ className, showText = true }: LogoProps) {
             letterSpacing: '-1.5px'
           }}
         >
-          boom<tspan fill="#00CFFF">tick</tspan><tspan fill="rgba(255,255,255,0.6)" fontWeight="300">.blog</tspan>
+          boom<tspan fill="var(--color-accent, #22d3ee)">tick</tspan><tspan fill="rgba(255,255,255,0.6)" fontWeight="300">.blog</tspan>
         </text>
       )}
     </svg>


### PR DESCRIPTION
This PR addresses the issue of CSS variable injection in standalone SVG files and ensures consistent theming for React-rendered SVG components.

### Changes:
- **Standalone SVGs:** Removed internal `<style>` blocks containing `:root` CSS variables from `public/favicon.svg` and `boomtick_logo.svg`. These assets now rely on direct HEX values for attributes, ensuring they render correctly in isolated contexts (like `<img>` tags or as favicons) where global CSS variables are inaccessible.
- **React Logo Component:** Updated `src/components/ui/Logo.tsx` to utilize global CSS variables (`--color-accent-hero`, `--color-accent-purple`, and `--color-accent`). Each `var()` call includes a brand-compliant HEX fallback to ensure the logo remains robust if the theme variables are not yet loaded or are missing.

### Verification:
- Ran `pnpm test` to ensure no regressions in existing logic.
- Ran `pnpm run audit` to confirm compliance with project UI standards.
- Executed a Playwright verification script to visually confirm that the logo renders correctly with its signature gradients and colors in the live application.

Fixes #900

---
*PR created automatically by Jules for task [16056241139273471629](https://jules.google.com/task/16056241139273471629) started by @arii*