### PR TITLE
Simplify GearCard prop filtering

### DIFF
--- a/src/components/ui/ContentCard.tsx
+++ b/src/components/ui/ContentCard.tsx
@@ -1,8 +1,9 @@
 import { NavLink } from 'react-router-dom';
 import { motion, HTMLMotionProps } from 'motion/react';
-import { Box, Stack, Text } from '@/layouts/Primitives';
+import { Box, Stack, Text, BaseProps } from '@/layouts/Primitives';
+import { filterDataProps } from '@/lib/utils';
 
-interface ContentCardProps extends Partial<HTMLMotionProps<"a">> {
+interface ContentCardProps extends BaseProps, Partial<HTMLMotionProps<"a">> {
   slug: string;
   title: string;
   category: string;
@@ -18,15 +19,7 @@ export function ContentCard({
   basePath, 
   ...motionProps 
 }: ContentCardProps) {
-  // Destructure and ignore known data props that shouldn't bleed to the DOM
-  // even if they are passed via {...item} in parent components.
-  const {
-    // @ts-expect-error - ignoring unused data props
-    type: _type, date: _date, author: _author, authorAvatar: _authorAvatar,
-    content: _content, image: _image, tags: _tags, affiliateIds: _affiliateIds,
-    readingTime: _readingTime,
-    ...cleanMotionProps
-  } = motionProps as Record<string, unknown>;
+  const cleanMotionProps = filterDataProps(motionProps as Record<string, unknown>);
 
   const getTagColorClass = (cat: string) => {
     const c = cat.toLowerCase();

--- a/src/components/ui/GearCard.tsx
+++ b/src/components/ui/GearCard.tsx
@@ -1,10 +1,11 @@
 import { NavLink } from 'react-router-dom';
-import { Box, Stack, Text } from '@/layouts/Primitives';
+import { Box, Stack, Text, BaseProps } from '@/layouts/Primitives';
 
 import { Star, ArrowRight } from 'lucide-react';
 import { CategoryPlaceholder } from './CategoryPlaceholder';
+import { filterDataProps } from '@/lib/utils';
 
-interface GearCardProps {
+interface GearCardProps extends BaseProps {
   slug: string;
   title: string;
   category: string;
@@ -27,17 +28,7 @@ export function GearCard({
   image,
   ...rest
 }: GearCardProps) {
-  // Destructure and ignore known data props that shouldn't bleed to the DOM
-  // even if they are passed via {...item} in parent components.
-  const {
-    // @ts-expect-error - ignoring unused data props
-    type: _type, date: _date, author: _author, content: _content,
-    tags: _tags, affiliateIds: _affiliateIds,
-    priceCategory: _priceCategory, updatedDate: _updatedDate,
-    durability: _durability, value: _value, specs: _specs,
-    readingTime: _readingTime,
-    ...cleanProps
-  } = rest as Record<string, unknown>;
+  const cleanProps = filterDataProps(rest as Record<string, unknown>);
 
   return (
     <Stack

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -76,3 +76,42 @@ export function getSkeletonVariant(pathname: string, routeConfig: RouteConfig[])
 
   return matchRoute?.skeleton || 'grid';
 }
+
+/**
+ * Filters out content-specific metadata props that shouldn't bleed to the DOM.
+ */
+export function filterDataProps(props: Record<string, unknown>) {
+  const {
+    /* eslint-disable @typescript-eslint/no-unused-vars */
+    type: _type,
+    slug: _slug,
+    title: _title,
+    date: _date,
+    author: _author,
+    authorAvatar: _authorAvatar,
+    category: _category,
+    excerpt: _excerpt,
+    content: _content,
+    image: _image,
+    tags: _tags,
+    basePath: _basePath,
+    rating: _rating,
+    verdict: _verdict,
+    priceCategory: _priceCategory,
+    updatedDate: _updatedDate,
+    durability: _durability,
+    value: _value,
+    specs: _specs,
+    readingTime: _readingTime,
+    affiliateIds: _affiliateIds,
+    location: _location,
+    city: _city,
+    schedule: _schedule,
+    description: _description,
+    link: _link,
+    /* eslint-enable @typescript-eslint/no-unused-vars */
+    ...rest
+  } = props;
+
+  return rest;
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -78,38 +78,21 @@ export function getSkeletonVariant(pathname: string, routeConfig: RouteConfig[])
 }
 
 /**
+ * Content-specific metadata props that shouldn't bleed to the DOM.
+ */
+const DATA_PROPS = [
+  'type', 'slug', 'title', 'date', 'author', 'authorAvatar',
+  'category', 'excerpt', 'content', 'image', 'tags', 'basePath',
+  'rating', 'verdict', 'priceCategory', 'updatedDate', 'durability',
+  'value', 'specs', 'readingTime', 'affiliateIds', 'location',
+  'city', 'schedule', 'description', 'link'
+];
+
+/**
  * Filters out content-specific metadata props that shouldn't bleed to the DOM.
  */
 export function filterDataProps(props: Record<string, unknown>) {
-  const {
-    type: _type,
-    slug: _slug,
-    title: _title,
-    date: _date,
-    author: _author,
-    authorAvatar: _authorAvatar,
-    category: _category,
-    excerpt: _excerpt,
-    content: _content,
-    image: _image,
-    tags: _tags,
-    basePath: _basePath,
-    rating: _rating,
-    verdict: _verdict,
-    priceCategory: _priceCategory,
-    updatedDate: _updatedDate,
-    durability: _durability,
-    value: _value,
-    specs: _specs,
-    readingTime: _readingTime,
-    affiliateIds: _affiliateIds,
-    location: _location,
-    city: _city,
-    schedule: _schedule,
-    description: _description,
-    link: _link,
-    ...rest
-  } = props;
-
-  return rest;
+  return Object.fromEntries(
+    Object.entries(props).filter(([key]) => !DATA_PROPS.includes(key))
+  );
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -82,7 +82,6 @@ export function getSkeletonVariant(pathname: string, routeConfig: RouteConfig[])
  */
 export function filterDataProps(props: Record<string, unknown>) {
   const {
-    /* eslint-disable @typescript-eslint/no-unused-vars */
     type: _type,
     slug: _slug,
     title: _title,
@@ -109,7 +108,6 @@ export function filterDataProps(props: Record<string, unknown>) {
     schedule: _schedule,
     description: _description,
     link: _link,
-    /* eslint-enable @typescript-eslint/no-unused-vars */
     ...rest
   } = props;
 


### PR DESCRIPTION
This change simplifies the prop filtering logic in `GearCard` and `ContentCard` components. It replaces manual destructuring and `useMemo` overhead with a centralized `filterDataProps` utility function in `src/lib/utils.ts`. This ensures that content-specific metadata (the "slop") does not bleed into the DOM while maintaining support for layout primitives. Both components now extend `BaseProps` to properly handle system props.

Fixes #889

---
*PR created automatically by Jules for task [3675016469902778626](https://jules.google.com/task/3675016469902778626) started by @arii*