### PR TITLE
fix: Add PR number to td_cli.py status board JSON output

### DIFF
--- a/dev-tools/td_cli.py
+++ b/dev-tools/td_cli.py
@@ -256,7 +256,8 @@ def handle_status_board(args):
     if not args.json: print("# Active Agent Work Board\n| Branch | Issue | Status | Conflicts |\n|--------|-------|--------|-----------|")
 
     for pr in repo.get_pulls(state='open'):
-        m = re.search(r'issue-(\d+)', pr.head.ref); issue = f"#{m.group(1)}" if m else "—"
+        m = re.search(r'issue-(\d+)', pr.head.ref)
+        issue = f"#{m.group(1)}" if m and m.group(1) else "—"
         if not args.json: print(f"| {pr.head.ref} | {issue} | {'Draft' if pr.draft else 'Open'} | ... |")
         prs_data.append({"branch": pr.head.ref, "issue": issue, "status": "Draft" if pr.draft else "Open", "number": pr.number})
 
@@ -398,7 +399,8 @@ def handle_audit_pr(args):
             if patch != '_No textual diff available._':
                 for line in patch.splitlines():
                     if line.startswith('@@'):
-                        m = re.search(r'\+(\d+)', line); line_num = int(m.group(1)) if m else line_num
+                        m = re.search(r'\+(\d+)', line)
+                        line_num = int(m.group(1)) if m and m.group(1) else line_num
                         annotated.append(line)
                     elif line.startswith('+'): annotated.append(f"{line_num:4d} |{line}"); line_num += 1
                     elif line.startswith('-'): annotated.append(f"     |{line}")

--- a/dev-tools/td_cli.py
+++ b/dev-tools/td_cli.py
@@ -256,8 +256,7 @@ def handle_status_board(args):
     if not args.json: print("# Active Agent Work Board\n| Branch | Issue | Status | Conflicts |\n|--------|-------|--------|-----------|")
 
     for pr in repo.get_pulls(state='open'):
-        m = re.search(r'issue-(\d+)', pr.head.ref)
-        issue = f"#{m.group(1)}" if m and m.group(1) else "—"
+        m = re.search(r'issue-(\d+)', pr.head.ref); issue = f"#{m.group(1)}" if m else "—"
         if not args.json: print(f"| {pr.head.ref} | {issue} | {'Draft' if pr.draft else 'Open'} | ... |")
         prs_data.append({"branch": pr.head.ref, "issue": issue, "status": "Draft" if pr.draft else "Open", "number": pr.number})
 
@@ -399,8 +398,7 @@ def handle_audit_pr(args):
             if patch != '_No textual diff available._':
                 for line in patch.splitlines():
                     if line.startswith('@@'):
-                        m = re.search(r'\+(\d+)', line)
-                        line_num = int(m.group(1)) if m and m.group(1) else line_num
+                        m = re.search(r'\+(\d+)', line); line_num = int(m.group(1)) if m else line_num
                         annotated.append(line)
                     elif line.startswith('+'): annotated.append(f"{line_num:4d} |{line}"); line_num += 1
                     elif line.startswith('-'): annotated.append(f"     |{line}")

--- a/dev-tools/td_cli.py
+++ b/dev-tools/td_cli.py
@@ -258,7 +258,7 @@ def handle_status_board(args):
     for pr in repo.get_pulls(state='open'):
         m = re.search(r'issue-(\d+)', pr.head.ref); issue = f"#{m.group(1)}" if m else "—"
         if not args.json: print(f"| {pr.head.ref} | {issue} | {'Draft' if pr.draft else 'Open'} | ... |")
-        prs_data.append({"branch": pr.head.ref, "issue": issue, "status": "Draft" if pr.draft else "Open"})
+        prs_data.append({"branch": pr.head.ref, "issue": issue, "status": "Draft" if pr.draft else "Open", "number": pr.number})
 
     if args.json: print(json.dumps({"status": "success", "work": prs_data}, indent=2))
 


### PR DESCRIPTION
Fix missing PR number field in `td_cli.py status-board` output to fix crashes in `audit_headless.sh`.

---
*PR created automatically by Jules for task [9278327790728661080](https://jules.google.com/task/9278327790728661080) started by @arii*