### PR TITLE
Refactor WSDCReminders into sub-components

### DIFF
--- a/dev-tools/tdw_services.egg-info/PKG-INFO
+++ b/dev-tools/tdw_services.egg-info/PKG-INFO
@@ -1,0 +1,12 @@
+Metadata-Version: 2.4
+Name: tdw_services
+Version: 0.1.0
+Summary: Tech-Dancer DevTools SDK
+Author: Tech-Dancer Team
+Requires-Python: >=3.8
+Requires-Dist: requests>=2.0.0
+Requires-Dist: google-genai
+Requires-Dist: python-dotenv
+Requires-Dist: pydantic
+Requires-Dist: click
+Requires-Dist: PyGithub

--- a/dev-tools/tdw_services.egg-info/SOURCES.txt
+++ b/dev-tools/tdw_services.egg-info/SOURCES.txt
@@ -1,0 +1,15 @@
+README.md
+pyproject.toml
+tdw_services/__init__.py
+tdw_services/cli.py
+tdw_services/orchestrator.py
+tdw_services.egg-info/PKG-INFO
+tdw_services.egg-info/SOURCES.txt
+tdw_services.egg-info/dependency_links.txt
+tdw_services.egg-info/entry_points.txt
+tdw_services.egg-info/requires.txt
+tdw_services.egg-info/top_level.txt
+tdw_services/services/__init__.py
+tdw_services/services/gemini.py
+tdw_services/services/github.py
+tdw_services/services/jules.py

--- a/dev-tools/tdw_services.egg-info/entry_points.txt
+++ b/dev-tools/tdw_services.egg-info/entry_points.txt
@@ -1,0 +1,2 @@
+[console_scripts]
+td-cli = tdw_services.cli:cli

--- a/dev-tools/tdw_services.egg-info/requires.txt
+++ b/dev-tools/tdw_services.egg-info/requires.txt
@@ -1,0 +1,6 @@
+requests>=2.0.0
+google-genai
+python-dotenv
+pydantic
+click
+PyGithub

--- a/dev-tools/tdw_services.egg-info/top_level.txt
+++ b/dev-tools/tdw_services.egg-info/top_level.txt
@@ -1,0 +1,1 @@
+tdw_services

--- a/src/features/lab/wsdc-reminders/TimelineRow.tsx
+++ b/src/features/lab/wsdc-reminders/TimelineRow.tsx
@@ -1,0 +1,68 @@
+import { Calendar, Plane, Hotel, Trophy, ShieldCheck, CheckCircle2 } from 'lucide-react';
+import { Box, Stack, Text, Grid, Button } from '@/layouts/Primitives';
+import { TimelineItem } from './types';
+
+const ICON_MAP: Record<string, React.ReactNode> = {
+  'flight-track': <Plane className="w-5 h-5" />,
+  'early-bird': <Trophy className="w-5 h-5" />,
+  'hotel-block': <Hotel className="w-5 h-5" />,
+  'comp-window': <CheckCircle2 className="w-5 h-5" />,
+  'cancel-safety': <ShieldCheck className="w-5 h-5" />,
+};
+
+interface TimelineRowProps {
+  item: TimelineItem;
+  onSync: (item: TimelineItem) => void;
+}
+
+export function TimelineRow({ item, onSync }: TimelineRowProps) {
+  return (
+    <Box position="relative" display="flex" gap={{ base: 4, sm: 10 }} className="group">
+      {/* Dot / Icon */}
+      <Box
+        display="flex"
+        align="center"
+        justify="center"
+        width={10}
+        height={10}
+        radius="full"
+        border
+        surface="surface"
+        color="accent"
+        zIndex={10}
+        className="shrink-0 group-hover:border-accent transition-colors shadow-sm"
+      >
+        {ICON_MAP[item.id] || <Calendar className="w-5 h-5" />}
+      </Box>
+
+      <Box flex={1} border radius="lg" padding={6} surface="surface" className="hover:border-accent/40 transition-all">
+        <Grid cols={{ base: 1, md: 4 }} gap={4} align="center">
+          <Box className="md:col-span-1">
+            <Text variant="mono" size="xs" color="accent" weight="font-bold">
+              {item.date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
+            </Text>
+          </Box>
+          <Box className="md:col-span-2">
+            <Stack gap={1}>
+              <Text variant="headline" size="md" weight="font-black" className="uppercase tracking-tight">{item.label}</Text>
+              <Text size="sm" color="dim" className="leading-relaxed">{item.description}</Text>
+            </Stack>
+          </Box>
+          <Box display="flex" justify={{ base: 'start', md: 'end' }}>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => onSync(item)}
+              className="h-10"
+            >
+              <Box display="flex" align="center" gap={2} paddingX={4}>
+                <Calendar className="w-3 h-3" />
+                <Text as="span" size="xs" weight="font-bold" uppercase className="tracking-widest">Sync</Text>
+              </Box>
+            </Button>
+          </Box>
+        </Grid>
+      </Box>
+    </Box>
+  );
+}

--- a/src/features/lab/wsdc-reminders/TimelineRow.tsx
+++ b/src/features/lab/wsdc-reminders/TimelineRow.tsx
@@ -1,21 +1,24 @@
-import { Calendar, Plane, Hotel, Trophy, ShieldCheck, CheckCircle2 } from 'lucide-react';
+import { Calendar, Plane, Hotel, Trophy, ShieldCheck, CheckCircle2, type LucideIcon } from 'lucide-react';
 import { Box, Stack, Text, Grid, Button } from '@/layouts/Primitives';
 import { TimelineItem } from './types';
 
-const ICON_MAP: Record<string, React.ReactNode> = {
-  'flight-track': <Plane className="w-5 h-5" />,
-  'early-bird': <Trophy className="w-5 h-5" />,
-  'hotel-block': <Hotel className="w-5 h-5" />,
-  'comp-window': <CheckCircle2 className="w-5 h-5" />,
-  'cancel-safety': <ShieldCheck className="w-5 h-5" />,
+const ICON_MAP: Record<string, LucideIcon> = {
+  'flight-track': Plane,
+  'early-bird': Trophy,
+  'hotel-block': Hotel,
+  'comp-window': CheckCircle2,
+  'cancel-safety': ShieldCheck,
 };
 
 interface TimelineRowProps {
   item: TimelineItem;
+  formattedDate: string;
   onSync: (item: TimelineItem) => void;
 }
 
-export function TimelineRow({ item, onSync }: TimelineRowProps) {
+export function TimelineRow({ item, formattedDate, onSync }: TimelineRowProps) {
+  const Icon = ICON_MAP[item.id] || Calendar;
+
   return (
     <Box position="relative" display="flex" gap={{ base: 4, sm: 10 }} className="group">
       {/* Dot / Icon */}
@@ -32,14 +35,14 @@ export function TimelineRow({ item, onSync }: TimelineRowProps) {
         zIndex={10}
         className="shrink-0 group-hover:border-accent transition-colors shadow-sm"
       >
-        {ICON_MAP[item.id] || <Calendar className="w-5 h-5" />}
+        <Icon className="w-5 h-5" />
       </Box>
 
       <Box flex={1} border radius="lg" padding={6} surface="surface" className="hover:border-accent/40 transition-all">
         <Grid cols={{ base: 1, md: 4 }} gap={4} align="center">
           <Box className="md:col-span-1">
             <Text variant="mono" size="xs" color="accent" weight="font-bold">
-              {item.date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
+              {formattedDate}
             </Text>
           </Box>
           <Box className="md:col-span-2">

--- a/src/features/lab/wsdc-reminders/WSDCReminders.tsx
+++ b/src/features/lab/wsdc-reminders/WSDCReminders.tsx
@@ -33,7 +33,10 @@ export default function WSDCReminders() {
 
   const timeline = useMemo(() => {
     if (!activeEvent.startDate || !activeEvent.earlyBirdDate || !activeEvent.hotelCutoffDate) return [];
-    return calculateTimeline(activeEvent);
+    return calculateTimeline(activeEvent).map(item => ({
+      ...item,
+      formattedDate: item.date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+    }));
   }, [activeEvent]);
 
   const handleCustomChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -180,7 +183,12 @@ export default function WSDCReminders() {
 
             <Stack gap={6}>
               {timeline.map((item) => (
-                <TimelineRow key={item.id} item={item} onSync={handleSingleSync} />
+                <TimelineRow
+                  key={item.id}
+                  item={item}
+                  formattedDate={item.formattedDate!}
+                  onSync={handleSingleSync}
+                />
               ))}
             </Stack>
           </Box>

--- a/src/features/lab/wsdc-reminders/WSDCReminders.tsx
+++ b/src/features/lab/wsdc-reminders/WSDCReminders.tsx
@@ -1,75 +1,11 @@
 import React, { useState, useMemo } from 'react';
-import { Calendar, Download, Plus, Search, Globe, AlertCircle, CheckCircle2, Plane, Hotel, Trophy, ShieldCheck } from 'lucide-react';
+import { Calendar, Download, Plus, Search, Globe, AlertCircle } from 'lucide-react';
 import { Box, Stack, Text, Grid, Button } from '@/layouts/Primitives';
 import { getEvents } from '@/lib/content';
 import { calculateTimeline } from './lib/timeline-engine';
 import { generateICS, downloadICS } from './lib/ics-generator';
 import { EventAnchors, TimelineItem } from './types';
-
-const ICON_MAP: Record<string, React.ReactNode> = {
-  'flight-track': <Plane className="w-5 h-5" />,
-  'early-bird': <Trophy className="w-5 h-5" />,
-  'hotel-block': <Hotel className="w-5 h-5" />,
-  'comp-window': <CheckCircle2 className="w-5 h-5" />,
-  'cancel-safety': <ShieldCheck className="w-5 h-5" />,
-};
-
-interface TimelineRowProps {
-  item: TimelineItem;
-  onSync: (item: TimelineItem) => void;
-}
-
-function TimelineRow({ item, onSync }: TimelineRowProps) {
-  return (
-    <Box position="relative" display="flex" gap={{ base: 4, sm: 10 }} className="group">
-      {/* Dot / Icon */}
-      <Box
-        display="flex"
-        align="center"
-        justify="center"
-        width={10}
-        height={10}
-        radius="full"
-        border
-        surface="surface"
-        color="accent"
-        zIndex={10}
-        className="shrink-0 group-hover:border-accent transition-colors shadow-sm"
-      >
-        {ICON_MAP[item.id] || <Calendar className="w-5 h-5" />}
-      </Box>
-
-      <Box flex={1} border radius="lg" padding={6} surface="surface" className="hover:border-accent/40 transition-all">
-        <Grid cols={{ base: 1, md: 4 }} gap={4} align="center">
-          <Box className="md:col-span-1">
-            <Text variant="mono" size="xs" color="accent" weight="font-bold">
-              {item.date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
-            </Text>
-          </Box>
-          <Box className="md:col-span-2">
-            <Stack gap={1}>
-              <Text variant="headline" size="md" weight="font-black" className="uppercase tracking-tight">{item.label}</Text>
-              <Text size="sm" color="dim" className="leading-relaxed">{item.description}</Text>
-            </Stack>
-          </Box>
-          <Box display="flex" justify={{ base: 'start', md: 'end' }}>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => onSync(item)}
-              className="h-10"
-            >
-              <Box display="flex" align="center" gap={2} paddingX={4}>
-                <Calendar className="w-3 h-3" />
-                <Text as="span" size="xs" weight="font-bold" uppercase className="tracking-widest">Sync</Text>
-              </Box>
-            </Button>
-          </Box>
-        </Grid>
-      </Box>
-    </Box>
-  );
-}
+import { TimelineRow } from './TimelineRow';
 
 export default function WSDCReminders() {
   const events = useMemo(() => getEvents().filter(e => e.startDate && e.earlyBirdDate && e.hotelCutoffDate), []);

--- a/src/features/lab/wsdc-reminders/WSDCReminders.tsx
+++ b/src/features/lab/wsdc-reminders/WSDCReminders.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo } from 'react';
-import { Calendar, Download, Plus, Search, Globe, AlertCircle } from 'lucide-react';
+import { Download, Plus, Search, Globe, AlertCircle } from 'lucide-react';
 import { Box, Stack, Text, Grid, Button } from '@/layouts/Primitives';
 import { getEvents } from '@/lib/content';
 import { calculateTimeline } from './lib/timeline-engine';

--- a/src/features/lab/wsdc-reminders/WSDCReminders.tsx
+++ b/src/features/lab/wsdc-reminders/WSDCReminders.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import { useState, useMemo } from 'react';
 import { Download, Plus, Search, Globe, AlertCircle } from 'lucide-react';
 import { Box, Stack, Text, Grid, Button } from '@/layouts/Primitives';
 import { getEvents } from '@/lib/content';

--- a/src/features/lab/wsdc-reminders/types.ts
+++ b/src/features/lab/wsdc-reminders/types.ts
@@ -11,4 +11,5 @@ export interface TimelineItem {
   date: Date;
   label: string;
   description: string;
+  formattedDate?: string;
 }


### PR DESCRIPTION
This PR refactors the WSDCReminders component by extracting the TimelineRow logic and its associated icon mapping into a separate TimelineRow.tsx file. This reduces the complexity of the main WSDCReminders.tsx file and improves maintainability.

Key changes:
- Created src/features/lab/wsdc-reminders/TimelineRow.tsx.
- Moved TimelineRow component and ICON_MAP to the new file.
- Updated WSDCReminders.tsx to import and use the new TimelineRow component.
- Removed unnecessary React imports to comply with project anti-pattern rules.

Fixes #901

---
*PR created automatically by Jules for task [9754922138867038239](https://jules.google.com/task/9754922138867038239) started by @arii*