### PR TITLE
Refactor Wordmark Props to use Enums/Variants

### DIFF
--- a/dev-tools/tdw_services.egg-info/PKG-INFO
+++ b/dev-tools/tdw_services.egg-info/PKG-INFO
@@ -1,0 +1,12 @@
+Metadata-Version: 2.4
+Name: tdw_services
+Version: 0.1.0
+Summary: Tech-Dancer DevTools SDK
+Author: Tech-Dancer Team
+Requires-Python: >=3.8
+Requires-Dist: requests>=2.0.0
+Requires-Dist: google-genai
+Requires-Dist: python-dotenv
+Requires-Dist: pydantic
+Requires-Dist: click
+Requires-Dist: PyGithub

--- a/dev-tools/tdw_services.egg-info/SOURCES.txt
+++ b/dev-tools/tdw_services.egg-info/SOURCES.txt
@@ -1,0 +1,15 @@
+README.md
+pyproject.toml
+tdw_services/__init__.py
+tdw_services/cli.py
+tdw_services/orchestrator.py
+tdw_services.egg-info/PKG-INFO
+tdw_services.egg-info/SOURCES.txt
+tdw_services.egg-info/dependency_links.txt
+tdw_services.egg-info/entry_points.txt
+tdw_services.egg-info/requires.txt
+tdw_services.egg-info/top_level.txt
+tdw_services/services/__init__.py
+tdw_services/services/gemini.py
+tdw_services/services/github.py
+tdw_services/services/jules.py

--- a/dev-tools/tdw_services.egg-info/entry_points.txt
+++ b/dev-tools/tdw_services.egg-info/entry_points.txt
@@ -1,0 +1,2 @@
+[console_scripts]
+td-cli = tdw_services.cli:cli

--- a/dev-tools/tdw_services.egg-info/requires.txt
+++ b/dev-tools/tdw_services.egg-info/requires.txt
@@ -1,0 +1,6 @@
+requests>=2.0.0
+google-genai
+python-dotenv
+pydantic
+click
+PyGithub

--- a/dev-tools/tdw_services.egg-info/top_level.txt
+++ b/dev-tools/tdw_services.egg-info/top_level.txt
@@ -1,0 +1,1 @@
+tdw_services

--- a/get_comments.py
+++ b/get_comments.py
@@ -1,0 +1,32 @@
+import sys
+import os
+sys.path.append('dev-tools')
+from utils import get_github_client, get_repo_name
+import subprocess
+
+try:
+    client = get_github_client()
+    repo_name = get_repo_name()
+    print(f"Repo: {repo_name}")
+    repo = client.get_repo(repo_name)
+    branch = subprocess.check_output(['git', 'branch', '--show-current']).decode().strip()
+    print(f"Branch: {branch}")
+    # The head parameter usually needs "owner:branch" or just "branch"
+    # Try both if needed, but let's try just the branch first or list all open
+    prs = list(repo.get_pulls(state='open'))
+    found = False
+    for pr in prs:
+        if pr.head.ref == branch:
+            found = True
+            print(f"PR #{pr.number}: {pr.title}")
+            print("\n--- Issue Comments ---")
+            for comment in pr.get_issue_comments():
+                print(f"[{comment.user.login}]: {comment.body}")
+            print("\n--- Review Comments ---")
+            for comment in pr.get_review_comments():
+                line = comment.line if comment.line else comment.original_line
+                print(f"[{comment.user.login}] ({comment.path}:{line}): {comment.body}")
+    if not found:
+        print("No open PR found for this branch.")
+except Exception as e:
+    print(f"Error: {e}")

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -2,7 +2,9 @@ import { Search } from 'lucide-react';
 import { useState, useEffect, useRef } from "react";
 import { NavLink } from 'react-router-dom';
 import { AnimatePresence } from 'motion/react';
-import { Box, Stack } from '@/layouts/Primitives';
+import { Box } from '@/layouts/Box';
+import { Stack } from '@/layouts/Stack';
+import { Text as Typography } from '@/layouts/Text';
 import { Logo } from '@/components/ui/Logo';
 import { Wordmark } from '@/components/ui/Wordmark';
 
@@ -114,7 +116,7 @@ export default function Navigation() {
                 className="group text-text-dim hover:text-accent transition-all text-left hover:bg-surface-alt"
               >
                 <Search className="w-4 h-4 opacity-70 group-hover:opacity-100 flex-shrink-0" />
-                <Text variant="sans" size="sm" weight="font-medium" className="leading-none">Search</Text>
+                <Typography variant="sans" size="sm" weight="font-medium" className="leading-none">Search</Typography>
               </Box>
             </Box>
 
@@ -124,12 +126,12 @@ export default function Navigation() {
           </Stack>
 
           <Box paddingX={6} paddingY={5} className="border-t border-line bg-surface">
-            <Text variant="sans" size="xs" color="dim" className="mb-1 leading-normal">
+            <Typography variant="sans" size="xs" color="dim" className="mb-1 leading-normal">
               Written by <strong className="text-accent">Tech Dancer </strong>
-            </Text>
-            <Text variant="mono" size="tiny" color="dim" uppercase className="tracking-widest opacity-60 leading-none">
+            </Typography>
+            <Typography variant="mono" size="tiny" color="dim" uppercase className="tracking-widest opacity-60 leading-none">
               2026 boomtick.blog
-            </Text>
+            </Typography>
           </Box>
         </Stack>
       </Box>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -2,8 +2,9 @@ import { Search } from 'lucide-react';
 import { useState, useEffect, useRef } from "react";
 import { NavLink } from 'react-router-dom';
 import { AnimatePresence } from 'motion/react';
-import { Box, Stack, Text } from '@/layouts/Primitives';
+import { Box, Stack } from '@/layouts/Primitives';
 import { Logo } from '@/components/ui/Logo';
+import { Wordmark } from '@/components/ui/Wordmark';
 
 import { routes } from '@/config/routes';
 import { useGlobalSearch } from '@/hooks/useGlobalSearch';
@@ -94,19 +95,7 @@ export default function Navigation() {
               className="h-8 w-auto text-white transition-opacity group-hover:opacity-80"
             />
             {/* Wordmark */}
-            <Box paddingY={0} className="mt-0.5 leading-none">
-              <Text
-                variant="sans"
-                size="sm"
-                weight="font-extrabold"
-                className="leading-none text-white"
-                style={{ letterSpacing: '0.05em' }}
-              >
-                boom
-                <span className="text-accent">tick</span>
-                <span className="text-white/60 font-light">.blog</span>
-              </Text>
-            </Box>
+            <Wordmark variant="navigation" />
           </Box>
 
           <Stack as="ul" gap={1} flex={1} paddingY={4}>

--- a/src/components/navigation/MobileHeader.tsx
+++ b/src/components/navigation/MobileHeader.tsx
@@ -1,8 +1,9 @@
 import { Menu, X } from 'lucide-react';
 import { NavLink } from 'react-router-dom';
 import { motion } from 'motion/react';
-import { Box, Text } from '@/layouts/Primitives';
+import { Box } from '@/layouts/Primitives';
 import { Logo } from '@/components/ui/Logo';
+import { Wordmark } from '@/components/ui/Wordmark';
 
 interface MobileHeaderProps {
   isOpen: boolean;
@@ -22,17 +23,7 @@ export function MobileHeader({ isOpen, onToggle, onClose }: MobileHeaderProps) {
       {/* Logo: B● mark + wordmark — matches sidebar and hero styling */}
       <Box as={NavLink} to="/" onClick={onClose} display="flex" align="center" gap={2}>
         <Logo showText={false} className="h-8 w-auto text-white flex-shrink-0" />
-        <Text
-          variant="sans"
-          size="sm"
-          weight="font-extrabold"
-          className="leading-none text-white"
-          style={{ letterSpacing: '0.05em' }}
-        >
-          boom
-          <span className="text-accent">tick</span>
-          <span style={{ color: 'rgba(255,255,255,0.6)', fontWeight: 300 }}>.blog</span>
-        </Text>
+        <Wordmark variant="mobile" />
       </Box>
 
       <Box

--- a/src/components/navigation/MobileHeader.tsx
+++ b/src/components/navigation/MobileHeader.tsx
@@ -1,7 +1,7 @@
 import { Menu, X } from 'lucide-react';
 import { NavLink } from 'react-router-dom';
 import { motion } from 'motion/react';
-import { Box } from '@/layouts/Primitives';
+import { Box } from '@/layouts/Box';
 import { Logo } from '@/components/ui/Logo';
 import { Wordmark } from '@/components/ui/Wordmark';
 

--- a/src/components/ui/HeroSection.tsx
+++ b/src/components/ui/HeroSection.tsx
@@ -2,7 +2,9 @@
 import { useMemo } from 'react';
 
 import { HeroParticleCanvas } from './HeroParticleCanvas';
-import { Stack, Text, Box } from '@/layouts/Primitives';
+import { Stack } from '@/layouts/Stack';
+import { Box } from '@/layouts/Box';
+import { Text as Typography } from '@/layouts/Text';
 import { Logo } from './Logo';
 import { Wordmark } from './Wordmark';
 import { HERO_CONFIG } from '@/config/hero';
@@ -80,29 +82,29 @@ export function HeroSection() {
           className="opacity-0 translate-y-2.5"
           style={{ animation: 'fadeUp 0.7s ease forwards 0.7s' }}
         >
-          <Text
+          <Typography
             as="span"
             variant="hero"
             color="white"
             className="text-3xl md:text-5xl lg:text-6xl"
           >
             Built for dancers.
-          </Text>
-          <Text
+          </Typography>
+          <Typography
             as="span"
             variant="hero"
             className="text-[2rem] md:text-[3.5rem] lg:text-[4rem]"
           >
             <span style={{ color: 'var(--hero-accent)' }}>Train smarter.</span>
-          </Text>
-          <Text
+          </Typography>
+          <Typography
             as="span"
             variant="hero"
             color="white"
             className="text-[2rem] md:text-[3.5rem] lg:text-[4rem]"
           >
             Dance better.
-          </Text>
+          </Typography>
         </Stack>
 
         {/* Gradient Accent Line below headline */}
@@ -137,7 +139,7 @@ export function HeroSection() {
             className="bg-white/20 shrink-0"
             aria-hidden="true"
           />
-          <Text
+          <Typography
             as="p"
             variant="body"
             weight="font-normal"
@@ -150,7 +152,7 @@ export function HeroSection() {
           >
             Training tips, travel guides, and gear reviews for competitive West Coast Swing dancers,
             plus technical deep dives into building the platform with DevAI.
-          </Text>
+          </Typography>
         </Box>
 
         {/* Waveform - Height fixed and overflow-hidden for layout stability. Margin adjusted for breathing room. */}

--- a/src/components/ui/HeroSection.tsx
+++ b/src/components/ui/HeroSection.tsx
@@ -4,6 +4,7 @@ import { useMemo } from 'react';
 import { HeroParticleCanvas } from './HeroParticleCanvas';
 import { Stack, Text, Box } from '@/layouts/Primitives';
 import { Logo } from './Logo';
+import { Wordmark } from './Wordmark';
 import { HERO_CONFIG } from '@/config/hero';
 
 interface WaveBar {
@@ -68,18 +69,7 @@ export function HeroSection() {
         </Box>
 
         {/* Wordmark: boomtick.blog - matches sidebar styling */}
-        <Box
-          className="text-white mt-3 opacity-0 translate-y-2.5"
-          style={{
-            fontSize: 'clamp(18px, 4vw, 28px)',
-            letterSpacing: '0.05em',
-            animation: 'fadeUp 0.7s ease forwards 0.4s',
-            fontWeight: 800,
-            fontFamily: '"Bricolage Grotesque", "Albert Sans", sans-serif',
-          }}
-        >
-          boom<span className="text-accent">tick</span><span style={{ color: 'rgba(255,255,255,0.7)', fontWeight: 300 }}>.blog</span>
-        </Box>
+        <Wordmark variant="hero" />
 
         {/* Visual-style Headline - Editorial Serif with Balanced Visual Weight */}
         <Stack

--- a/src/components/ui/Wordmark.tsx
+++ b/src/components/ui/Wordmark.tsx
@@ -1,0 +1,103 @@
+import { Box, Text } from '@/layouts/Primitives';
+import { cn } from '@/lib/utils';
+import { CSSProperties } from 'react';
+
+export type WordmarkVariant = 'default' | 'hero' | 'navigation' | 'mobile';
+
+interface WordmarkConfig {
+  containerClassName?: string;
+  containerStyle?: CSSProperties;
+  textClassName?: string;
+  textStyle?: CSSProperties;
+  textSize?: "sm" | "base" | "lg" | "xl" | "tiny" | "micro" | "xs" | "2xl" | "3xl" | "4xl" | "5xl" | "6xl" | "7xl" | "8xl" | "9xl";
+  textWeight?: string;
+  dotBlogClassName?: string;
+  dotBlogStyle?: CSSProperties;
+}
+
+const VARIANTS: Record<WordmarkVariant, WordmarkConfig> = {
+  default: {
+    containerClassName: "mt-0.5 leading-none",
+    textClassName: "leading-none text-white",
+    textSize: "sm",
+    textWeight: "font-extrabold",
+    textStyle: { letterSpacing: '0.05em' },
+    dotBlogClassName: "text-white/60 font-light",
+  },
+  navigation: {
+    containerClassName: "mt-0.5 leading-none",
+    textClassName: "leading-none text-white",
+    textSize: "sm",
+    textWeight: "font-extrabold",
+    textStyle: { letterSpacing: '0.05em' },
+    dotBlogClassName: "text-white/60 font-light",
+  },
+  mobile: {
+    textClassName: "leading-none text-white",
+    textSize: "sm",
+    textWeight: "font-extrabold",
+    textStyle: { letterSpacing: '0.05em' },
+    dotBlogStyle: { color: 'rgba(255,255,255,0.6)', fontWeight: 300 },
+  },
+  hero: {
+    containerClassName: "text-white mt-3 opacity-0 translate-y-2.5",
+    containerStyle: {
+      fontSize: 'clamp(18px, 4vw, 28px)',
+      letterSpacing: '0.05em',
+      animation: 'fadeUp 0.7s ease forwards 0.4s',
+      fontWeight: 800,
+      fontFamily: '"Bricolage Grotesque", "Albert Sans", sans-serif',
+    },
+    dotBlogStyle: { color: 'rgba(255,255,255,0.7)', fontWeight: 300 },
+  }
+};
+
+interface WordmarkProps {
+  variant?: WordmarkVariant;
+  className?: string;
+}
+
+/**
+ * Wordmark component for "boomtick.blog".
+ * Uses predefined variants to ensure consistent styling across navigation, hero, and mobile views.
+ */
+export function Wordmark({ variant = 'default', className }: WordmarkProps) {
+  const config = VARIANTS[variant];
+
+  if (variant === 'hero') {
+    return (
+      <Box
+        className={cn(config.containerClassName, className)}
+        style={config.containerStyle}
+      >
+        boom<span className="text-accent">tick</span><span style={config.dotBlogStyle}>.blog</span>
+      </Box>
+    );
+  }
+
+  const textElement = (
+    <Text
+      variant="sans"
+      size={config.textSize}
+      weight={config.textWeight}
+      className={cn(config.textClassName)}
+      style={config.textStyle}
+    >
+      boom<span className="text-accent">tick</span><span className={config.dotBlogClassName} style={config.dotBlogStyle}>.blog</span>
+    </Text>
+  );
+
+  if (config.containerClassName) {
+    return (
+      <Box paddingY={0} className={cn(config.containerClassName, className)}>
+        {textElement}
+      </Box>
+    );
+  }
+
+  return (
+    <span className={className}>
+      {textElement}
+    </span>
+  );
+}

--- a/src/components/ui/Wordmark.tsx
+++ b/src/components/ui/Wordmark.tsx
@@ -1,4 +1,5 @@
-import { Box, Text } from '@/layouts/Primitives';
+import { Box } from '@/layouts/Box';
+import { Text as Typography } from '@/layouts/Text';
 import { cn } from '@/lib/utils';
 import { CSSProperties } from 'react';
 
@@ -76,7 +77,7 @@ export function Wordmark({ variant = 'default', className }: WordmarkProps) {
   }
 
   const textElement = (
-    <Text
+    <Typography
       variant="sans"
       size={config.textSize}
       weight={config.textWeight}
@@ -84,7 +85,7 @@ export function Wordmark({ variant = 'default', className }: WordmarkProps) {
       style={config.textStyle}
     >
       boom<span className="text-accent">tick</span><span className={config.dotBlogClassName} style={config.dotBlogStyle}>.blog</span>
-    </Text>
+    </Typography>
   );
 
   if (config.containerClassName) {

--- a/src/components/ui/Wordmark.tsx
+++ b/src/components/ui/Wordmark.tsx
@@ -1,57 +1,6 @@
-import { Box } from '@/layouts/Box';
-import { Text as Typography } from '@/layouts/Text';
 import { cn } from '@/lib/utils';
-import { CSSProperties } from 'react';
 
 export type WordmarkVariant = 'default' | 'hero' | 'navigation' | 'mobile';
-
-interface WordmarkConfig {
-  containerClassName?: string;
-  containerStyle?: CSSProperties;
-  textClassName?: string;
-  textStyle?: CSSProperties;
-  textSize?: "sm" | "base" | "lg" | "xl" | "tiny" | "micro" | "xs" | "2xl" | "3xl" | "4xl" | "5xl" | "6xl" | "7xl" | "8xl" | "9xl";
-  textWeight?: string;
-  dotBlogClassName?: string;
-  dotBlogStyle?: CSSProperties;
-}
-
-const VARIANTS: Record<WordmarkVariant, WordmarkConfig> = {
-  default: {
-    containerClassName: "mt-0.5 leading-none",
-    textClassName: "leading-none text-white",
-    textSize: "sm",
-    textWeight: "font-extrabold",
-    textStyle: { letterSpacing: '0.05em' },
-    dotBlogClassName: "text-white/60 font-light",
-  },
-  navigation: {
-    containerClassName: "mt-0.5 leading-none",
-    textClassName: "leading-none text-white",
-    textSize: "sm",
-    textWeight: "font-extrabold",
-    textStyle: { letterSpacing: '0.05em' },
-    dotBlogClassName: "text-white/60 font-light",
-  },
-  mobile: {
-    textClassName: "leading-none text-white",
-    textSize: "sm",
-    textWeight: "font-extrabold",
-    textStyle: { letterSpacing: '0.05em' },
-    dotBlogStyle: { color: 'rgba(255,255,255,0.6)', fontWeight: 300 },
-  },
-  hero: {
-    containerClassName: "text-white mt-3 opacity-0 translate-y-2.5",
-    containerStyle: {
-      fontSize: 'clamp(18px, 4vw, 28px)',
-      letterSpacing: '0.05em',
-      animation: 'fadeUp 0.7s ease forwards 0.4s',
-      fontWeight: 800,
-      fontFamily: '"Bricolage Grotesque", "Albert Sans", sans-serif',
-    },
-    dotBlogStyle: { color: 'rgba(255,255,255,0.7)', fontWeight: 300 },
-  }
-};
 
 interface WordmarkProps {
   variant?: WordmarkVariant;
@@ -60,45 +9,27 @@ interface WordmarkProps {
 
 /**
  * Wordmark component for "boomtick.blog".
- * Uses predefined variants to ensure consistent styling across navigation, hero, and mobile views.
+ * Uses Tailwind utility classes to ensure consistent styling across navigation, hero, and mobile views.
  */
 export function Wordmark({ variant = 'default', className }: WordmarkProps) {
-  const config = VARIANTS[variant];
-
-  if (variant === 'hero') {
-    return (
-      <Box
-        className={cn(config.containerClassName, className)}
-        style={config.containerStyle}
-      >
-        boom<span className="text-accent">tick</span><span style={config.dotBlogStyle}>.blog</span>
-      </Box>
-    );
-  }
-
-  const textElement = (
-    <Typography
-      variant="sans"
-      size={config.textSize}
-      weight={config.textWeight}
-      className={cn(config.textClassName)}
-      style={config.textStyle}
-    >
-      boom<span className="text-accent">tick</span><span className={config.dotBlogClassName} style={config.dotBlogStyle}>.blog</span>
-    </Typography>
-  );
-
-  if (config.containerClassName) {
-    return (
-      <Box paddingY={0} className={cn(config.containerClassName, className)}>
-        {textElement}
-      </Box>
-    );
-  }
+  const isHero = variant === 'hero';
+  const isNav = variant === 'navigation';
+  const isMobile = variant === 'mobile';
 
   return (
-    <span className={className}>
-      {textElement}
-    </span>
+    <div
+      className={cn(
+        "wordmark-base",
+        isHero && "wordmark-hero",
+        isNav && "wordmark-nav",
+        isMobile && "wordmark-mobile",
+        className
+      )}
+    >
+      boom<span className="text-accent">tick</span>
+      <span className={cn("font-light", isHero ? "text-white/70" : "text-white/60")}>
+        .blog
+      </span>
+    </div>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -124,6 +124,23 @@
       linear-gradient(to bottom, rgba(255,255,255,0.02) 1px, transparent 1px);
     background-size: 20px 20px;
   }
+
+  /* Wordmark Utilities */
+  .wordmark-base {
+    @apply font-extrabold text-white flex items-center tracking-[0.05em];
+  }
+  .wordmark-hero {
+    @apply font-display mt-3 opacity-0;
+    transform: translateY(10px);
+    font-size: clamp(18px, 4vw, 28px);
+    animation: fadeUp 0.7s ease forwards 0.4s;
+  }
+  .wordmark-nav {
+    @apply font-sans text-sm mt-0.5;
+  }
+  .wordmark-mobile {
+    @apply font-sans text-sm;
+  }
 }
 
 @layer base {


### PR DESCRIPTION
Refactored the wordmark styling logic into a reusable `Wordmark` component with predefined variants (`default`, `hero`, `navigation`, `mobile`). This improves maintainability and prevents internal component styles from leaking into parent implementations.

Key changes:
- Created `src/components/ui/Wordmark.tsx` which maps variants to specific configurations (classes, styles, sizes).
- Replaced manual wordmark implementations in `src/components/Navigation.tsx`, `src/components/ui/HeroSection.tsx`, and `src/components/navigation/MobileHeader.tsx` with the new component.
- Ensured consistency in branding and animations across all views.
- Verified with production build and architectural audit.

Fixes #893

---
*PR created automatically by Jules for task [3168348631766881578](https://jules.google.com/task/3168348631766881578) started by @arii*