### PR TITLE
fix: correctly construct target URL for previews test

### DIFF
--- a/tests/previews.spec.ts
+++ b/tests/previews.spec.ts
@@ -1,11 +1,17 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
+
+async function gotoPreviewDashboard(page: Page) {
+  // The previews dashboard is a static site independent of the React router.
+  // It exists at the root of the server, not nested under the BASE_PATH like the main app.
+  // We construct an absolute URL to avoid Playwright prepending the baseURL (which includes /tech-dancer/)
+  const host = new URL(page.context()._options.baseURL || 'http://localhost:4173').origin;
+  await page.goto(`${host}/previews/index.html`);
+  await page.waitForLoadState('networkidle');
+}
 
 test.describe('Preview Dashboard', () => {
   test('should load the dashboard and show initial elements', async ({ page }) => {
-    const baseURL = page.context()._options.baseURL || 'http://localhost:4173/';
-    const targetUrl = new URL('previews/index.html', baseURL).href;
-    await page.goto(targetUrl);
-    await page.waitForLoadState('networkidle');
+    await gotoPreviewDashboard(page);
 
     // Check title
     await expect(page).toHaveTitle(/Preview Environments/);
@@ -24,10 +30,7 @@ test.describe('Preview Dashboard', () => {
   });
 
   test('responsive layout check', async ({ page }) => {
-    const baseURL = page.context()._options.baseURL || 'http://localhost:4173/';
-    const targetUrl = new URL('previews/index.html', baseURL).href;
-    await page.goto(targetUrl);
-    await page.waitForLoadState('networkidle');
+    await gotoPreviewDashboard(page);
 
     // Desktop view
     await page.setViewportSize({ width: 1440, height: 900 });

--- a/tests/previews.spec.ts
+++ b/tests/previews.spec.ts
@@ -2,11 +2,9 @@ import { test, expect } from '@playwright/test';
 
 test.describe('Preview Dashboard', () => {
   test('should load the dashboard and show initial elements', async ({ page }) => {
-    // The previews dashboard is a static site independent of the React router.
-    // It exists at the root of the server, not nested under the BASE_PATH like the main app.
-    // We construct an absolute URL to avoid Playwright prepending the baseURL (which includes /tech-dancer/)
-    const host = new URL(page.context()._options.baseURL || 'http://localhost:4173').origin;
-    await page.goto(`${host}/previews/index.html`);
+    const baseURL = page.context()._options.baseURL || 'http://localhost:4173/';
+    const targetUrl = new URL('previews/index.html', baseURL).href;
+    await page.goto(targetUrl);
     await page.waitForLoadState('networkidle');
 
     // Check title
@@ -26,8 +24,9 @@ test.describe('Preview Dashboard', () => {
   });
 
   test('responsive layout check', async ({ page }) => {
-    const host = new URL(page.context()._options.baseURL || 'http://localhost:4173').origin;
-    await page.goto(`${host}/previews/index.html`);
+    const baseURL = page.context()._options.baseURL || 'http://localhost:4173/';
+    const targetUrl = new URL('previews/index.html', baseURL).href;
+    await page.goto(targetUrl);
     await page.waitForLoadState('networkidle');
 
     // Desktop view

--- a/tests/previews.spec.ts
+++ b/tests/previews.spec.ts
@@ -1,11 +1,10 @@
 import { test, expect, Page } from '@playwright/test';
 
 async function gotoPreviewDashboard(page: Page) {
-  // The previews dashboard is a static site independent of the React router.
-  // It exists at the root of the server, not nested under the BASE_PATH like the main app.
-  // We construct an absolute URL to avoid Playwright prepending the baseURL (which includes /tech-dancer/)
-  const host = new URL(page.context()._options.baseURL || 'http://localhost:4173').origin;
-  await page.goto(`${host}/previews/index.html`);
+  const baseURL = page.context()._options.baseURL || 'http://localhost:4173/';
+  // We resolve the previews path against the baseURL which includes the necessary VITE_BASE_PATH
+  const targetUrl = new URL('previews/index.html', baseURL).href;
+  await page.goto(targetUrl);
   await page.waitForLoadState('networkidle');
 }
 


### PR DESCRIPTION
The Playwright test suite was failing on `tests/previews.spec.ts` when a `VITE_BASE_PATH` was set.
This occurred because the test stripped `baseURL` to its origin and navigated to the root path (`/previews/index.html`), instead of resolving against the `baseURL` which incorporates the application's base path context (`/my-repo/previews/index.html`).

Changes:
- Replaced `.origin` with proper `new URL('...', baseURL)` resolution in `tests/previews.spec.ts` for both layout and initial element checks.
- Confirmed test reliability locally via `VITE_BASE_PATH=/my-repo/ pnpm run test:e2e`.

---
*PR created automatically by Jules for task [11302469766233253998](https://jules.google.com/task/11302469766233253998) started by @arii*