### PR TITLE
fix: repair YAML syntax error in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,8 +16,6 @@ concurrency:
   group: "gh-pages-publish"
   cancel-in-progress: false
 
-env:
-
 jobs:
   build_and_deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Removed the empty 'env:' block at line 19 which was causing a parsing error.