### PR TITLE
chore: improve auto-conflict-resolver failure reporting

### DIFF
--- a/.github/workflows/auto-conflict-resolver.yml
+++ b/.github/workflows/auto-conflict-resolver.yml
@@ -232,6 +232,14 @@ jobs:
             <!-- id: conflict-resolver-bot -->
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Fail the workflow if conflicts were not resolved
+      - name: Fail on merge error
+        if: steps.validate_branches.outputs.skipped != 'true' && steps.merge.outputs.merge_failed == 'true'
+        run: |
+          echo "::error::Merge failed due to a non-conflict error. Manual intervention required."
+          exit 1
+
+      - name: Notify partial resolution
         if: steps.validate_branches.outputs.skipped != 'true' && steps.merge.outputs.merge_failed != 'true' && steps.resolve.outputs.unresolved-files != ''
-        run: exit 1
+        run: |
+          echo "::warning::Auto-resolver could not fully resolve conflicts. Manual review required."
+          exit 0

--- a/.github/workflows/auto-conflict-resolver.yml
+++ b/.github/workflows/auto-conflict-resolver.yml
@@ -241,5 +241,15 @@ jobs:
       - name: Notify partial resolution
         if: steps.validate_branches.outputs.skipped != 'true' && steps.merge.outputs.merge_failed != 'true' && steps.resolve.outputs.unresolved-files != ''
         run: |
-          echo "::warning::Auto-resolver could not fully resolve conflicts. Manual review required."
+          UNRESOLVED="${{ steps.resolve.outputs.unresolved-files }}"
+          # Count lines by counting characters then removing everything except newlines, or use wc -l
+          # If it's comma separated, we can count commas.
+          # Based on the bot comment usage, it's in a code block, likely one per line.
+          COUNT=$(echo "$UNRESOLVED" | grep -c '^' || echo 0)
+          echo "::warning::$COUNT files still have conflicts and require manual resolution. Auto-resolver could not fully resolve all conflicts."
+          echo "### Conflict Resolution Summary" >> $GITHUB_STEP_SUMMARY
+          echo "⚠️ $COUNT files require manual attention:" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "$UNRESOLVED" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
           exit 0


### PR DESCRIPTION
The Auto Conflict Resolver workflow previously exited with a failure status (exit 1) whenever any conflicts remained, even if some files were successfully resolved. This created "red" noise in the GitHub Actions UI for an expected condition that simply requires manual review.

This change:
1. Replaces the final mandatory failure step with two conditional steps.
2. Adds a "Fail on merge error" step that exits with 1 only if a non-conflict merge error occurred (e.g., git/infrastructure issues).
3. Adds a "Notify partial resolution" step that uses GitHub's `::warning::` annotation and exits with 0 when conflicts remain, showing a yellow/neutral status in the UI instead of a red failure.
4. Preserves the PR comment behavior that notifies authors of the need for manual intervention.

Fixes #976

---
*PR created automatically by Jules for task [15270584093097119649](https://jules.google.com/task/15270584093097119649) started by @arii*