### PR TITLE
Fix ModuleNotFoundError in Self-Healing CI workflow

### DIFF
--- a/.github/workflows/self-healing.yml
+++ b/.github/workflows/self-healing.yml
@@ -170,3 +170,7 @@ jobs:
           else
             echo "No changes to commit."
           fi
+
+      - name: Cleanup repair tool
+        if: always()
+        run: rm -rf /tmp/repair-tool

--- a/.github/workflows/self-healing.yml
+++ b/.github/workflows/self-healing.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Prepare trusted repair script
         run: |
           mkdir -p /tmp/repair-tool
-          cp dev-tools/repair.py /tmp/repair-tool/repair.py
+          cp -r dev-tools/. /tmp/repair-tool/
           chmod +x /tmp/repair-tool/repair.py
 
       - name: Checkout failing branch
@@ -97,7 +97,7 @@ jobs:
 
       - name: Fetch Logs & Run Repair
         env:
-          PYTHONPATH: ${{ github.workspace }}/dev-tools
+          PYTHONPATH: /tmp/repair-tool
         run: |
           if [ "$EVENT_NAME" == "workflow_run" ]; then
             TARGET_RUN_ID="$WORKFLOW_RUN_ID"


### PR DESCRIPTION
The Self-Healing CI workflow was failing with a `ModuleNotFoundError: No module named 'utils'` because `repair.py` was being copied to `/tmp/repair-tool/` without its sibling dependencies, and `PYTHONPATH` was pointing to the workspace which might have untrusted code.

This fix:
1. Updates `.github/workflows/self-healing.yml` to copy the entire `dev-tools/` directory to `/tmp/repair-tool/`.
2. Updates the `PYTHONPATH` in the `Fetch Logs & Run Repair` step to point to `/tmp/repair-tool`.

This ensures all modules (`utils.py`, `error_rag.py`, etc.) and the `tdw_services` package are available to the trusted repair script, while maintaining strict security isolation from the failing branch's workspace.

Fixes #975

---
*PR created automatically by Jules for task [12495369920544503487](https://jules.google.com/task/12495369920544503487) started by @arii*