### PR TITLE
docs: update agent workflows for unified td-cli dev-tools

### DIFF
--- a/.agent/workflows/dev-tools-cli-guide.md
+++ b/.agent/workflows/dev-tools-cli-guide.md
@@ -1,0 +1,60 @@
+> Follow `.agent/AGENT_CONTRACT.md` before reading anything else.
+
+# DevTools CLI Guide (`td-cli`)
+
+The `dev-tools` directory provides a unified CLI tool called `td-cli` that consolidates multiple repository automation workflows, GitHub integrations, AI reviews, and agent interactions.
+
+## Environment Setup
+
+Before using `td-cli`, you must set up the Python environment:
+
+```bash
+# 1. Run the verification and setup script
+bash dev-tools/verify.sh
+
+# 2. Activate the virtual environment
+source .venv/bin/activate
+
+# 3. Export PYTHONPATH
+export PYTHONPATH=$(pwd)/dev-tools
+```
+
+Once activated, you can run the `td-cli` command. You can also pass `--json` to any command for structured JSON output.
+
+## Command Groups
+
+### GitHub Operations (`td-cli gh`)
+
+- `td-cli gh view <pr_number>`: View summary and diff stats for a PR.
+- `td-cli gh resolve <file>`: Attempt conflict resolution on a file.
+- `td-cli gh audit`: Run a headless UI audit.
+- `td-cli gh audit-gate`: Check current anti-patterns against the baseline.
+- `td-cli gh audit-pr <pr_number>`: Generate PR context (`--fetch`), run AI review (`--audit`), or submit (`--submit`).
+- `td-cli gh validate-issue --issue-number <num>`: Validate issue quality, required fields, and anti-patterns.
+- `td-cli gh conflicts --base <branch>`: Perform conflict handling and snapshot updates.
+- `td-cli gh detect-conflicts --pr <pr_number>`: Detect potential merge conflicts for open PRs.
+- `td-cli gh status-board`: Print a summary board of open agent PRs.
+- `td-cli gh migrate-tokens --find <token> --migrate <old> <new>`: Search or automatically replace deprecated tokens.
+- `td-cli gh update-issues`: Scan open issues and comment regarding deprecated paths/assets or anti-patterns.
+- `td-cli gh manage-reviews`: Check PRs that need review or check unaddressed review comments.
+- `td-cli gh track-review --pr <pr> --status <status> --auditor <name>`: Update the `REVIEW_TRACKING.md` file.
+- `td-cli gh ratchet-any --baseline-file <file> --update`: Check and update the TypeScript 'any' count baseline.
+- `td-cli gh bundle-size --baseline-file <file> --update`: Check and update the bundle size baseline.
+- `td-cli gh pre-submit`: Run all pre-submission checks (TypeScript, lint, audits, baseline checks, and PR scope).
+
+### AI Operations (`td-cli ai`)
+
+- `td-cli ai review <pr_number>`: Produce an AI code review from a PR diff using templates.
+- `td-cli ai analyze <file>`: Focus AI analysis and recommendations on a specific file.
+
+### Agent Operations (`td-cli jules`)
+
+- `td-cli jules dispatch <branch> <task>`: Create an AI agent session and attach context for a specific task.
+- `td-cli jules sync`: Poll active agent sessions.
+- `td-cli jules fix-ci --pr-number <num>`: Automatically initialize an AI repair session to fix CI failures.
+- `td-cli jules repair --logs <file> [--worktree]`: Run an autonomous local repair agent based on CI logs.
+- `td-cli jules repair-context --log <log> --file <file>`: Generate repair prompt context from logs.
+
+## Legacy Compatibility
+
+Some workflows may previously reference `python3 dev-tools/td_cli.py <command>`. The new Typer-based CLI wraps these commands identically using the groups listed above. Use `td-cli --help` or `td-cli <group> --help` to explore all available parameters for a command.

--- a/.agent/workflows/mass-audit-prs.md
+++ b/.agent/workflows/mass-audit-prs.md
@@ -25,6 +25,13 @@ This workflow standardizes the process for auditing multiple open Pull Requests,
 
 // turbo-all
 
+0. **Environment Setup**: Set up the environment to use `td-cli`.
+```bash
+bash dev-tools/verify.sh
+source .venv/bin/activate
+export PYTHONPATH=$(pwd)/dev-tools
+```
+
 1. **Fetch open PRs**:
 ```bash
 gh pr list --state open --json number,title,author --jq '.[] | "- #\(.number) \(.title) (@\(.author.login))"'
@@ -32,7 +39,7 @@ gh pr list --state open --json number,title,author --jq '.[] | "- #\(.number) \(
 
 2. **Check for conflicts**:
 ```bash
-python3 dev-tools/td_cli.py conflicts
+td-cli gh conflicts
 ```
 Review output and determine safe merge order before proceeding.
 
@@ -40,7 +47,7 @@ Review output and determine safe merge order before proceeding.
 
 4. **Generate Review Context & Output Templates**: For a selected batch of PRs, run the fetch script. This will generate a read-only `pr-context-<PR>.md` and a writeable `pr-review-<PR>.md` for each.
 ```bash
-python3 dev-tools/td_cli.py audit-pr PR_NUMBER --fetch
+td-cli gh audit-pr PR_NUMBER --fetch
 ```
 
 5. **Audit the PRs**: For each PR, READ the instructions in `.agent/workflows/REVIEW_INSTRUCTIONS.md` and the diffs in `pr-context-<PR_NUMBER>.md`.
@@ -53,7 +60,7 @@ python3 dev-tools/td_cli.py audit-pr PR_NUMBER --fetch
 
 7. **Submit the Review**: Run the submission script against the populated review file.
 ```bash
-python3 dev-tools/td_cli.py audit-pr PR_NUMBER --submit
+td-cli gh audit-pr PR_NUMBER --submit
 ```
 
 8. **Track & Repeat**: Update `REVIEW_TRACKING.md` with the outcome ("Approved", "Changes Requested") and proceed to the next PR.

--- a/.agent/workflows/review-pr.md
+++ b/.agent/workflows/review-pr.md
@@ -23,15 +23,19 @@ A step is only complete when its output file exists and contains non-placeholder
 
 // turbo-all
 
-0. **Pre-flight validation**:
+0. **Environment Setup & Pre-flight validation**:
 ```bash
-python3 dev-tools/td_cli.py conflicts --pr PR_NUMBER
-python3 dev-tools/td_cli.py validate-issue --issue-number RELATED_ISSUE_NUMBER
+bash dev-tools/verify.sh
+source .venv/bin/activate
+export PYTHONPATH=$(pwd)/dev-tools
+
+td-cli gh conflicts --pr PR_NUMBER
+td-cli gh validate-issue --issue-number RELATED_ISSUE_NUMBER
 ```
 
 1. **Generate the review documents**:
 ```bash
-python3 dev-tools/td_cli.py audit-pr PR_NUMBER --fetch
+td-cli gh audit-pr PR_NUMBER --fetch
 ```
 (This creates `dev-tools/logs/reviews/pr-context-PR_NUMBER.md` for reading, and `dev-tools/logs/reviews/pr-review-PR_NUMBER.md` for writing).
 
@@ -48,5 +52,5 @@ python3 dev-tools/td_cli.py audit-pr PR_NUMBER --fetch
 
 4. **Submit & Cleanup**: Parse the document and submit the review in one step. Use `--cleanup` to remove the working files on success:
 ```bash
-python3 dev-tools/td_cli.py audit-pr PR_NUMBER --submit --cleanup
+td-cli gh audit-pr PR_NUMBER --submit --cleanup
 ```


### PR DESCRIPTION
This update aligns the agent documentation and automated workflows with the newly unified `td-cli` inside the `dev-tools` directory. It removes raw `python3 dev-tools/td_cli.py` instructions and provides a comprehensive guide for all agent CLI operations.

---
*PR created automatically by Jules for task [18111085968468065757](https://jules.google.com/task/18111085968468065757) started by @arii*