### PR TITLE
Consolidate SVG Styles and Unique IDs

### DIFF
--- a/boomtick_logo.svg
+++ b/boomtick_logo.svg
@@ -1,16 +1,23 @@
 <svg viewBox="0 0 450 110" fill="none" xmlns="http://www.w3.org/2000/svg" class="h-full w-auto max-w-none overflow-visible" aria-hidden="true" preserveAspectRatio="xMidYMid meet">
   <style>
-    :root {
-      --brand-bg: #020617;
-      --brand-accent: #22d3ee;
-      --brand-accent-hero: #22d3ee;
-      --brand-accent-purple: #8b5cf6;
+    .brand-stop-accent { stop-color: #22d3ee; }
+    .brand-stop-purple { stop-color: #8b5cf6; }
+    .brand-text-accent { fill: #22d3ee; }
+    .brand-text-muted { fill: rgba(241, 245, 249, 0.6); }
+    .brand-b-mark {
+      font-family: 'Playfair Display', serif;
+      font-weight: 900;
+      font-style: italic;
+    }
+    .brand-wordmark {
+      font-family: 'Bricolage Grotesque', sans-serif;
+      font-weight: 800;
     }
   </style>
   <defs>
     <linearGradient id="logo-grad" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#22d3ee" />
-      <stop offset="100%" stop-color="#8b5cf6" />
+      <stop offset="0%" class="brand-stop-accent" stop-color="#22d3ee" />
+      <stop offset="100%" class="brand-stop-purple" stop-color="#8b5cf6" />
     </linearGradient>
     <filter id="logo-glow" x="-50%" y="-50%" width="200%" height="200%">
       <feGaussianBlur stdDeviation="3" result="blur" />
@@ -19,19 +26,17 @@
   </defs>
 
   <g transform="translate(10, 85)">
-    <!-- The "B" Mark - Playfair Display Serif -->
+    <!-- The "B" Mark -->
     <text
       x="0"
       y="0"
-      font-family="'Playfair Display', 'Bodoni MT', 'Bodoni 72', serif"
-      font-weight="900"
-      font-style="italic"
       font-size="85"
       fill="white"
       transform="skewX(-8)"
+      class="brand-b-mark"
     >B</text>
     
-    <!-- The Glowing Gradient Dot - Brand colors -->
+    <!-- The Glowing Gradient Dot -->
     <circle
       cx="82"
       cy="-28"
@@ -41,10 +46,10 @@
     />
   </g>
 
-  <!-- Wordmark - Height calibrated for icon to be 2x proportion -->
-  <text x="130" y="78" font-family="'Bricolage Grotesque', Arial, Helvetica, sans-serif" font-weight="800" font-size="52" letter-spacing="-1.5">
+  <!-- Wordmark -->
+  <text x="130" y="78" font-size="52" letter-spacing="-1.5" class="brand-wordmark">
     <tspan fill="white">boom</tspan>
-    <tspan fill="#22d3ee">tick</tspan>
-    <tspan fill="rgba(255,255,255,0.6)" font-weight="300">.blog</tspan>
+    <tspan class="brand-text-accent" fill="#22d3ee">tick</tspan>
+    <tspan class="brand-text-muted" fill="rgba(241,245,249,0.6)" font-weight="300">.blog</tspan>
   </text>
 </svg>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,17 +1,24 @@
 <svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
   <style>
-    :root {
-      --brand-bg: #020617;
-      --brand-accent: #22d3ee;
-      --brand-accent-hero: #22d3ee;
-      --brand-accent-purple: #8b5cf6;
+    .brand-stop-accent { stop-color: #22d3ee; }
+    .brand-stop-purple { stop-color: #8b5cf6; }
+    .brand-text-accent { fill: #22d3ee; }
+    .brand-text-muted { fill: rgba(241, 245, 249, 0.6); }
+    .brand-b-mark {
+      font-family: 'Playfair Display', serif;
+      font-weight: 900;
+      font-style: italic;
+    }
+    .brand-wordmark {
+      font-family: 'Bricolage Grotesque', sans-serif;
+      font-weight: 800;
     }
   </style>
   <rect width="64" height="64" rx="14" fill="#020617"/>
   <defs>
     <linearGradient id="favicon-grad" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#22d3ee" />
-      <stop offset="100%" stop-color="#8b5cf6" />
+      <stop offset="0%" class="brand-stop-accent" stop-color="#22d3ee" />
+      <stop offset="100%" class="brand-stop-purple" stop-color="#8b5cf6" />
     </linearGradient>
     <filter id="favicon-glow" x="-50%" y="-50%" width="200%" height="200%">
       <feGaussianBlur stdDeviation="2" result="blur" />
@@ -20,19 +27,17 @@
   </defs>
   
   <g transform="translate(8, 50)">
-    <!-- The "B" Mark - Playfair Display Serif, Italic -->
+    <!-- The "B" Mark -->
     <text
       x="0"
       y="0"
-      font-family="'Playfair Display', 'Bodoni MT', 'Bodoni 72', serif"
-      font-weight="900"
-      font-style="italic"
       font-size="44"
       fill="white"
       transform="skewX(-8)"
+      class="brand-b-mark"
     >B</text>
     
-    <!-- The Glowing Gradient Dot - Brand colors -->
+    <!-- The Glowing Gradient Dot -->
     <circle
       cx="42"
       cy="-14"

--- a/scripts/generate-assets.ts
+++ b/scripts/generate-assets.ts
@@ -87,7 +87,6 @@ function updateSVGContent(content: string, tokens: DesignTokens) {
   // 1. Extract old hex values from the first matching .brand-stop-accent or similar
   const oldAccentMatch = content.match(/\.brand-stop-accent\s*{\s*stop-color:\s*([^;]+);/);
   const oldPurpleMatch = content.match(/\.brand-stop-purple\s*{\s*stop-color:\s*([^;]+);/);
-  const oldBgMatch = content.match(/fill="([^"]+)"/); // Simplistic for bg rect
 
   // 2. Replace the entire <style> block
   const sharedStyles = getSharedSVGStyles(tokens);

--- a/scripts/generate-assets.ts
+++ b/scripts/generate-assets.ts
@@ -24,11 +24,18 @@ interface DesignTokens {
 function getSharedSVGStyles(tokens: DesignTokens) {
   return `
   <style>
-    :root {
-      --brand-bg: ${tokens.rawColorBg};
-      --brand-accent: ${tokens.heroAccent};
-      --brand-accent-hero: ${tokens.heroAccent};
-      --brand-accent-purple: ${tokens.accentPurple};
+    .brand-stop-accent { stop-color: ${tokens.heroAccent}; }
+    .brand-stop-purple { stop-color: ${tokens.accentPurple}; }
+    .brand-text-accent { fill: ${tokens.heroAccent}; }
+    .brand-text-muted { fill: rgba(241, 245, 249, 0.6); }
+    .brand-b-mark {
+      font-family: 'Playfair Display', serif;
+      font-weight: 900;
+      font-style: italic;
+    }
+    .brand-wordmark {
+      font-family: 'Bricolage Grotesque', sans-serif;
+      font-weight: 800;
     }
   </style>`;
 }
@@ -72,92 +79,56 @@ export function getTokens(): DesignTokens | null {
 }
 
 /**
- * Safely updates SVG content by injecting shared styles and targeting specific color attributes.
- * Strictly replaces the entire <style> tag contents based on the generated template.
+ * Updates SVG content with latest tokens while preserving utility class structure.
  */
-function updateSVGContent(content: string, tokens: DesignTokens, specificMap: Record<string, string | null>) {
+function updateSVGContent(content: string, tokens: DesignTokens) {
   let updatedContent = content;
-  const oldValues: Record<string, string> = {};
 
-  // 1. Extract old values using Regex from the existing style block if it exists
-  const styleMatch = updatedContent.match(/<style>([\s\S]*?)<\/style>/);
-  if (styleMatch) {
-    const styleContent = styleMatch[1];
-    const declRegex = /(--[\w-]+):\s*([^;]+);/g;
-    let match;
-    while ((match = declRegex.exec(styleContent)) !== null) {
-      oldValues[match[1]] = match[2].trim();
-    }
-  }
+  // 1. Extract old hex values from the first matching .brand-stop-accent or similar
+  const oldAccentMatch = content.match(/\.brand-stop-accent\s*{\s*stop-color:\s*([^;]+);/);
+  const oldPurpleMatch = content.match(/\.brand-stop-purple\s*{\s*stop-color:\s*([^;]+);/);
+  const oldBgMatch = content.match(/fill="([^"]+)"/); // Simplistic for bg rect
 
-  // 2. Strictly replace the entire <style> tag contents with the shared template
+  // 2. Replace the entire <style> block
   const sharedStyles = getSharedSVGStyles(tokens);
-  if (styleMatch) {
-    updatedContent = updatedContent.replace(/<style>[\s\S]*?<\/style>/, sharedStyles.trim());
-  } else {
-    updatedContent = updatedContent.replace(/(<svg[^>]*>)/, `$1\n${sharedStyles}`);
-  }
+  updatedContent = updatedContent.replace(/<style>[\s\S]*?<\/style>/i, sharedStyles.trim());
 
-  // 3. Targeted replacement in attributes based on extracted old values
-  for (const [variableName, newValue] of Object.entries(specificMap)) {
-    const oldValue = oldValues[variableName];
-    if (oldValue && newValue && oldValue !== newValue) {
-      const escapedOldValue = oldValue.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-      // Targeted replacement in attributes to avoid corrupting path data or other non-color strings
-      const attrRegex = new RegExp(`(fill|stop-color|stroke)="(${escapedOldValue})"`, 'gi');
-      updatedContent = updatedContent.replace(attrRegex, `$1="${newValue}"`);
-    }
+  // 3. Targeted replacement of hex values in attributes for maximum compatibility
+  if (oldAccentMatch && tokens.heroAccent) {
+    const oldAccent = oldAccentMatch[1].trim();
+    const attrRegex = new RegExp(`(fill|stop-color|stroke)="(${oldAccent.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')})"`, 'gi');
+    updatedContent = updatedContent.replace(attrRegex, `$1="${tokens.heroAccent}"`);
+  }
+  if (oldPurpleMatch && tokens.accentPurple) {
+    const oldPurple = oldPurpleMatch[1].trim();
+    const attrRegex = new RegExp(`(fill|stop-color|stroke)="(${oldPurple.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')})"`, 'gi');
+    updatedContent = updatedContent.replace(attrRegex, `$1="${tokens.accentPurple}"`);
   }
 
   return updatedContent;
 }
 
 async function updateLogo(tokens: DesignTokens) {
-  if (!fs.existsSync(LOGO_SVG_PATH)) {
-    console.warn(`Warning: Logo SVG not found at ${LOGO_SVG_PATH}`);
-    return;
-  }
-
+  if (!fs.existsSync(LOGO_SVG_PATH)) return;
   const content = fs.readFileSync(LOGO_SVG_PATH, 'utf-8');
-  const updatedContent = updateSVGContent(content, tokens, {
-    '--brand-accent-hero': tokens.heroAccent,
-    '--brand-accent-purple': tokens.accentPurple
-  });
-
+  const updatedContent = updateSVGContent(content, tokens);
   fs.writeFileSync(LOGO_SVG_PATH, updatedContent);
   console.log(`Updated ${LOGO_SVG_PATH}`);
 }
 
 async function updateFaviconAndPNGs(tokens: DesignTokens) {
-  if (!fs.existsSync(FAVICON_SVG_PATH)) {
-    console.warn(`Warning: Favicon SVG not found at ${FAVICON_SVG_PATH}`);
-    return;
-  }
-
+  if (!fs.existsSync(FAVICON_SVG_PATH)) return;
   const content = fs.readFileSync(FAVICON_SVG_PATH, 'utf-8');
-  const updatedContent = updateSVGContent(content, tokens, {
-    '--brand-bg': tokens.rawColorBg,
-    '--brand-accent': tokens.heroAccent,
-    '--brand-accent-purple': tokens.accentPurple
-  });
-
+  const updatedContent = updateSVGContent(content, tokens);
   fs.writeFileSync(FAVICON_SVG_PATH, updatedContent);
   console.log(`Updated ${FAVICON_SVG_PATH}`);
 
   // Generate PNGs
   try {
     const svgBuffer = Buffer.from(updatedContent);
-
-    await sharp(svgBuffer)
-      .resize(192, 192)
-      .png()
-      .toFile(PWA_192_PATH);
+    await sharp(svgBuffer).resize(192, 192).png().toFile(PWA_192_PATH);
     console.log(`Generated ${PWA_192_PATH}`);
-
-    await sharp(svgBuffer)
-      .resize(512, 512)
-      .png()
-      .toFile(PWA_512_PATH);
+    await sharp(svgBuffer).resize(512, 512).png().toFile(PWA_512_PATH);
     console.log(`Generated ${PWA_512_PATH}`);
   } catch (error) {
     console.error('Error generating PNGs:', error);
@@ -188,7 +159,6 @@ async function main() {
   }
 }
 
-// Only run main if this script is executed directly
 const isMain = process.argv[1] && (process.argv[1] === fileURLToPath(import.meta.url) || process.argv[1].endsWith('generate-assets.ts'));
 if (isMain) {
   main().catch(console.error);

--- a/src/components/ui/BrandDefs.tsx
+++ b/src/components/ui/BrandDefs.tsx
@@ -1,0 +1,32 @@
+import { useId } from 'react';
+
+interface BrandDefsProps {
+  gradientId?: string;
+  filterId?: string;
+}
+
+/**
+ * Shared SVG definitions for brand assets.
+ * Consolidates gradients and filters to a single source.
+ * Supports custom IDs with a fallback to useId for uniqueness.
+ */
+export function BrandDefs({ gradientId, filterId }: BrandDefsProps) {
+  const generatedGradientId = useId();
+  const generatedFilterId = useId();
+
+  const finalGradientId = gradientId || `brand-grad-${generatedGradientId}`;
+  const finalFilterId = filterId || `brand-glow-${generatedFilterId}`;
+
+  return (
+    <defs>
+      <linearGradient id={finalGradientId} x1="0%" y1="0%" x2="0%" y2="100%">
+        <stop offset="0%" className="brand-stop-accent" />
+        <stop offset="100%" className="brand-stop-purple" />
+      </linearGradient>
+      <filter id={finalFilterId} x="-50%" y="-50%" width="200%" height="200%">
+        <feGaussianBlur stdDeviation="3" result="blur" />
+        <feComposite in="SourceGraphic" in2="blur" operator="over" />
+      </filter>
+    </defs>
+  );
+}

--- a/src/components/ui/Logo.tsx
+++ b/src/components/ui/Logo.tsx
@@ -1,5 +1,6 @@
 import { useId } from 'react';
 import { cn } from '@/lib/utils';
+import { BrandDefs } from './BrandDefs';
 
 interface LogoProps {
   className?: string;
@@ -9,7 +10,7 @@ interface LogoProps {
 /**
  * High-fidelity SVG Logo for BoomTick.
  * Featuring the serif "B" mark with a glowing gradient dot.
- * Uses CSS variables for brand colors to ensure consistency.
+ * Uses shared brand definitions and utility classes for consistency.
  */
 export function Logo({ className, showText = true }: LogoProps) {
   const titleId = useId();
@@ -26,16 +27,7 @@ export function Logo({ className, showText = true }: LogoProps) {
       preserveAspectRatio="xMidYMid meet"
     >
       <title id={titleId}>BoomTick Logo</title>
-      <defs>
-        <linearGradient id={gradientId} x1="0%" y1="0%" x2="0%" y2="100%">
-          <stop offset="0%" stopColor="var(--raw-color-accent-brand, #22d3ee)" />
-          <stop offset="100%" stopColor="var(--raw-color-accent-purple, #8b5cf6)" />
-        </linearGradient>
-        <filter id={filterId} x="-50%" y="-50%" width="200%" height="200%">
-          <feGaussianBlur stdDeviation="3" result="blur" />
-          <feComposite in="SourceGraphic" in2="blur" operator="over" />
-        </filter>
-      </defs>
+      <BrandDefs gradientId={gradientId} filterId={filterId} />
 
       <g transform="translate(10, 82)">
         {/* The "B" Mark - Serif, Bold, Italic */}
@@ -44,17 +36,12 @@ export function Logo({ className, showText = true }: LogoProps) {
           y="0"
           fill="currentColor"
           transform="skewX(-8)"
-          style={{
-            fontSize: '85px',
-            fontWeight: 700,
-            fontStyle: 'italic',
-            fontFamily: '"Playfair Display", "Bodoni MT", "Bodoni 72", serif',
-          }}
+          className="brand-b-mark text-[85px]"
         >
           B
         </text>
 
-        {/* The Glowing Dot - Sized to match text (2x wordmark height mathematically) */}
+        {/* The Glowing Dot */}
         <circle
           cx="82"
           cy="-28"
@@ -69,14 +56,9 @@ export function Logo({ className, showText = true }: LogoProps) {
           x="125"
           y="78"
           fill="currentColor"
-          style={{
-            fontSize: '52px',
-            fontWeight: 800,
-            fontFamily: '"Bricolage Grotesque", "Albert Sans", sans-serif',
-            letterSpacing: '-1.5px'
-          }}
+          className="brand-wordmark text-[52px] tracking-[-1.5px]"
         >
-          boom<tspan fill="var(--raw-color-accent-brand, #22d3ee)">tick</tspan><tspan fill="var(--logo-muted-text, rgba(241, 245, 249, 0.6))" fontWeight="300">.blog</tspan>
+          boom<tspan className="brand-text-accent">tick</tspan><tspan className="brand-text-muted font-light">.blog</tspan>
         </text>
       )}
     </svg>

--- a/src/index.css
+++ b/src/index.css
@@ -125,6 +125,21 @@
     background-size: 20px 20px;
   }
 
+  /* Brand SVG Utilities */
+  .brand-b-mark {
+    font-family: var(--raw-font-serif);
+    font-weight: 900;
+    font-style: italic;
+  }
+  .brand-wordmark {
+    font-family: var(--raw-font-display);
+    font-weight: 800;
+  }
+  .brand-text-accent { fill: var(--raw-color-accent-brand); }
+  .brand-text-muted { fill: var(--logo-muted-text); }
+  .brand-stop-accent { stop-color: var(--raw-color-accent-brand); }
+  .brand-stop-purple { stop-color: var(--raw-color-accent-purple); }
+
   /* Wordmark Utilities */
   .wordmark-base {
     @apply font-extrabold text-white flex items-center tracking-[0.05em];


### PR DESCRIPTION
This change consolidates SVG styling by moving internal styles to shared utility classes in `src/index.css`. It also ensures that SVG elements like gradients and filters have strictly unique IDs by using the `useId` hook in a new `BrandDefs` component, which is shared by the `Logo` component. Standalone SVG assets (`boomtick_logo.svg`, `favicon.svg`) are updated to use the standard `class` attribute and maintain internal styles for compatibility with browser rendering outside of the React context. The asset generation script is also updated to keep these files in sync with design tokens.

Fixes #875

---
*PR created automatically by Jules for task [17304956979083945896](https://jules.google.com/task/17304956979083945896) started by @arii*