### PR TITLE
Improve Preview Server Lifecycle Management

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "postbuild": "tsx scripts/generate-robots.ts && tsx scripts/generate-spa-stubs.mjs",
     "build:analyze": "ANALYZE=true vite build",
     "build:profile": "vite build --profile",
+    "prepreview": "node scripts/cleanup-ports.mjs",
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/scripts/cleanup-ports.mjs
+++ b/scripts/cleanup-ports.mjs
@@ -43,7 +43,7 @@ for (const port of ports) {
         execSync(`kill -9 ${pids.join(' ')}`, { stdio: 'ignore' });
       }
     }
-  } catch (error) {
+  } catch {
     // Expected if no processes are found on the port
   }
 }

--- a/scripts/cleanup-ports.mjs
+++ b/scripts/cleanup-ports.mjs
@@ -1,0 +1,51 @@
+import { execSync } from 'node:child_process';
+import { platform } from 'node:os';
+
+/**
+ * Cleanup stale processes on specified ports.
+ * This ensures that pnpm run preview and Playwright/Lighthouse
+ * always start with a clean slate.
+ *
+ * Supports both Unix-like systems (via lsof/kill) and Windows (via netstat/taskkill).
+ */
+const ports = [4173, 4174];
+const isWindows = platform() === 'win32';
+
+console.log('🧹 Cleaning up stale preview processes...');
+
+for (const port of ports) {
+  try {
+    if (isWindows) {
+      // Windows implementation
+      const stdout = execSync(`netstat -ano | findstr :${port}`, { stdio: ['ignore', 'pipe', 'ignore'] });
+      const lines = stdout.toString().trim().split('\n');
+      const pids = new Set();
+
+      for (const line of lines) {
+        const parts = line.trim().split(/\s+/);
+        const pid = parts[parts.length - 1];
+        if (pid && pid !== '0' && !isNaN(pid)) {
+          pids.add(pid);
+        }
+      }
+
+      for (const pid of pids) {
+        console.log(`  - Found process on port ${port}: ${pid}. Killing...`);
+        execSync(`taskkill /F /PID ${pid}`, { stdio: 'ignore' });
+      }
+    } else {
+      // Unix-like implementation
+      const stdout = execSync(`lsof -t -i :${port}`, { stdio: ['ignore', 'pipe', 'ignore'] });
+      const pids = stdout.toString().trim().split('\n').filter(Boolean);
+
+      if (pids.length > 0) {
+        console.log(`  - Found processes on port ${port}: ${pids.join(', ')}. Killing...`);
+        execSync(`kill -9 ${pids.join(' ')}`, { stdio: 'ignore' });
+      }
+    }
+  } catch (error) {
+    // Expected if no processes are found on the port
+  }
+}
+
+console.log('✅ Port cleanup complete.');

--- a/scripts/cleanup-ports.mjs
+++ b/scripts/cleanup-ports.mjs
@@ -17,7 +17,18 @@ for (const port of ports) {
   try {
     if (isWindows) {
       // Windows implementation
-      const stdout = execSync(`netstat -ano | findstr :${port}`, { stdio: ['ignore', 'pipe', 'ignore'] });
+      let stdout;
+      try {
+        stdout = execSync(`netstat -ano | findstr :${port}`, {
+          stdio: ['ignore', 'pipe', 'ignore'],
+          timeout: 5000
+        });
+      } catch (error) {
+        // findstr exits with code 1 if no match is found, which is expected
+        if (error.status === 1) continue;
+        throw error;
+      }
+
       const lines = stdout.toString().trim().split('\n');
       const pids = new Set();
 
@@ -31,20 +42,37 @@ for (const port of ports) {
 
       for (const pid of pids) {
         console.log(`  - Found process on port ${port}: ${pid}. Killing...`);
-        execSync(`taskkill /F /PID ${pid}`, { stdio: 'ignore' });
+        execSync(`taskkill /F /PID ${pid}`, {
+          stdio: 'ignore',
+          timeout: 5000
+        });
       }
     } else {
       // Unix-like implementation
-      const stdout = execSync(`lsof -t -i :${port}`, { stdio: ['ignore', 'pipe', 'ignore'] });
+      let stdout;
+      try {
+        stdout = execSync(`lsof -t -i :${port}`, {
+          stdio: ['ignore', 'pipe', 'ignore'],
+          timeout: 5000
+        });
+      } catch (error) {
+        // lsof exits with code 1 if no processes are found, which is expected
+        if (error.status === 1) continue;
+        throw error;
+      }
+
       const pids = stdout.toString().trim().split('\n').filter(Boolean);
 
       if (pids.length > 0) {
         console.log(`  - Found processes on port ${port}: ${pids.join(', ')}. Killing...`);
-        execSync(`kill -9 ${pids.join(' ')}`, { stdio: 'ignore' });
+        execSync(`kill -9 ${pids.join(' ')}`, {
+          stdio: 'ignore',
+          timeout: 5000
+        });
       }
     }
-  } catch {
-    // Expected if no processes are found on the port
+  } catch (error) {
+    console.error(`❌ Unexpected error cleaning up port ${port}:`, error.message);
   }
 }
 


### PR DESCRIPTION
This PR improves the preview server lifecycle by automatically cleaning up stale processes on ports 4173 and 4174. 

Key changes:
1. **New Cleanup Script**: Added `scripts/cleanup-ports.mjs` which identifies and kills processes listening on the standard Vite preview ports. It includes logic for both Unix-like systems and Windows.
2. **Lifecycle Integration**: Added a `prepreview` script to `package.json`. Since `pnpm run preview` is used by Playwright's `webServer` and Lighthouse CI, this ensures that every test run starts with a clean slate, preventing `EADDRINUSE` errors and "outdated code" bugs.
3. **Cross-platform Compatibility**: The script detects the platform and uses appropriate commands (`lsof`/`kill` vs `netstat`/`taskkill`).

Verification:
- Manually verified on Unix that `pnpm run preview` kills existing dummy listeners on port 4173.
- Verified that `pnpm run test:e2e` invokes the cleanup script.
- Confirmed that the script fails gracefully (silently) if no processes are found, as intended for a lifecycle hook.

Fixes #1039

---
*PR created automatically by Jules for task [7455734928117012185](https://jules.google.com/task/7455734928117012185) started by @arii*