### PR TITLE
Fix: E2E Flakiness caused by Base Path Drift

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,7 +1,8 @@
 import { defineConfig, devices } from '@playwright/test';
+import { getBasePath } from './scripts/base-path.js';
 
 const PORT = process.env.PORT || 4173;
-const BASE_PATH = process.env.VITE_BASE_PATH || '/tech-dancer/';
+const BASE_PATH = getBasePath();
 
 export default defineConfig({
   testDir: './tests',

--- a/scripts/base-path.js
+++ b/scripts/base-path.js
@@ -1,0 +1,31 @@
+/**
+ * Normalizes a path to ensure it starts and ends with a single slash
+ * @param {string} p
+ * @returns {string}
+ */
+export const normalizePath = (p) => ("/" + p + "/").replace(/\/+/g, "/");
+
+/**
+ * Resolves the base path based on environment variables
+ * @returns {string}
+ */
+export const getBasePath = () => {
+  const isVercel = process.env.VERCEL === '1' || !!process.env.VERCEL;
+  const isGHAction = process.env.GITHUB_ACTIONS === 'true';
+  const ghBranch = process.env.GITHUB_REF_NAME;
+  const isMainBranch = ghBranch === 'main' || !ghBranch;
+
+  let base = process.env.VITE_BASE_PATH;
+  if (!base) {
+    if (isVercel) {
+      base = '/';
+    } else if (isGHAction) {
+      // If we're on a branch other than main in GH Actions, include the branch name in the base path
+      base = isMainBranch ? '/tech-dancer/' : `/tech-dancer/${ghBranch}/`;
+    } else {
+      base = '/';
+    }
+  }
+
+  return normalizePath(base);
+};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,33 +7,18 @@ import Inspect from 'vite-plugin-inspect';
 import { ViteImageOptimizer } from 'vite-plugin-image-optimizer';
 import Sitemap from 'vite-plugin-sitemap';
 import { getAllRoutes } from './src/lib/routes-discovery';
+import { getBasePath } from './scripts/base-path.js';
 
 export default defineConfig(({mode}) => {
   const env = loadEnv(mode, process.cwd(), '');
   const isProd = mode === 'production';
 
-  // Dynamic base path for GitHub Pages vs Vercel vs Local Override
+  // Standardized base path resolution
+  const base = getBasePath();
+
   const isVercel = process.env.VERCEL === '1' || !!process.env.VERCEL;
-  const isGHAction = process.env.GITHUB_ACTIONS === 'true';
   const analyze = env.ANALYZE === 'true' || process.env.ANALYZE === 'true';
   const inspect = env.VITE_INSPECT === 'true' || process.env.VITE_INSPECT === 'true';
-
-  // Determine the GitHub branch for base path constructing
-  const ghBranch = process.env.GITHUB_REF_NAME;
-  const isMainBranch = ghBranch === 'main' || !ghBranch;
-
-  // Use VITE_BASE_PATH if specified, otherwise construct based on environment
-  let base = process.env.VITE_BASE_PATH;
-  if (!base) {
-    if (isVercel) {
-      base = '/';
-    } else if (isGHAction) {
-      // If we're on a branch other than main in GH Actions, include the branch name in the base path
-      base = isMainBranch ? '/tech-dancer/' : `/tech-dancer/${ghBranch}/`;
-    } else {
-      base = '/';
-    }
-  }
 
   const resolveHostname = () => {
     if (env.VITE_APP_URL) return env.VITE_APP_URL;


### PR DESCRIPTION
This PR fixes flakiness in E2E tests by ensuring that the Vite build and Playwright test runner always use the exact same base path logic. 

Previously, the logic was duplicated and slightly divergent between `vite.config.ts` and `playwright.config.ts`, leading to issues where assets would fail to load or the test runner would point to the wrong URL in CI (especially for branch previews).

Changes:
- Added `scripts/base-path.js` to provide a single source of truth for base path resolution.
- Updated `vite.config.ts` and `playwright.config.ts` to import and use this shared logic.
- Added path normalization to ensure base paths always have consistent leading/trailing slashes, which is critical for Vite subpath stability.

Fixes #1038

---
*PR created automatically by Jules for task [13021578602505954899](https://jules.google.com/task/13021578602505954899) started by @arii*