### PR TITLE
[FE] Shared CVA Variants for UXAuditor and ResearchAnalytics

### DIFF
--- a/src/features/research/ResearchAnalytics.tsx
+++ b/src/features/research/ResearchAnalytics.tsx
@@ -5,6 +5,7 @@ import { Box, Stack, Text, Grid } from '@/layouts/Primitives';
 import { SEO } from '@/components/SEO';
 import { PageHeader } from '@/components/ui/PageHeader';
 import { useResearch } from './useResearch';
+import { cardVariants } from '@/lib/variants';
 
 export default function ResearchAnalytics() {
   const navigate = useNavigate();
@@ -36,14 +37,11 @@ export default function ResearchAnalytics() {
                 as="button"
                 onClick={() => navigate(tool.id === 'ux-auditor' ? '/ux-auditor' : `/research/${tool.id}`)}
                 padding={6}
-                radius="lg"
-                border
                 gap={4}
                 height="full"
-                cursor="pointer"
-                surface="surface"
                 align="start"
                 textAlign="left"
+                className={cardVariants({ interactive: true })}
               >
                 <Stack gap={4} width="full">
                   <Box display="flex" justify="between" align="start" width="full">
@@ -84,12 +82,9 @@ export default function ResearchAnalytics() {
                 <Stack
                   key={study.slug}
                   padding={8}
-                  radius="lg"
-                  border
-                  surface="surface"
                   gap={4}
-                  cursor="pointer"
                   onClick={() => navigate(`/research/${study.slug}`)}
+                  className={cardVariants({ interactive: true })}
                 >
                   <Box display="flex" justify="between" align="center">
                     <Text variant="mono" size="micro" color="accent" weight="font-bold" uppercase tracking="widest">{study.category}</Text>

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -68,3 +68,68 @@ export const buttonVariants = cva(
     },
   }
 );
+
+/**
+ * Shared variants for Console-style action buttons (compact, high-contrast)
+ */
+export const actionButtonVariants = cva(
+  "font-bold transition-all text-sm shrink-0 flex items-center gap-2 disabled:opacity-50",
+  {
+    variants: {
+      variant: {
+        default: "hover:text-text-main",
+        primary: "bg-accent text-bg hover:opacity-90 shadow-md",
+        ghost: "hover:bg-line/10 text-text-dim hover:text-text-main",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+);
+
+/**
+ * Card variants for reports, tools, and callout blocks
+ */
+export const cardVariants = cva(
+  "bg-surface rounded-lg shadow-sm border border-line transition-all",
+  {
+    variants: {
+      interactive: {
+        true: "hover:border-accent cursor-pointer",
+        false: "",
+      },
+      overflow: {
+        hidden: "overflow-hidden",
+        visible: "overflow-visible",
+      },
+      span: {
+        1: "col-span-1",
+        2: "col-span-2",
+        3: "col-span-3",
+      }
+    },
+    defaultVariants: {
+      interactive: false,
+      overflow: "visible",
+    }
+  }
+);
+
+/**
+ * List row variants for interactive lists (e.g., Audit History)
+ */
+export const listRowVariants = cva(
+  "text-left transition-all border-l-4 w-full",
+  {
+    variants: {
+      active: {
+        true: "bg-bg border-accent",
+        false: "border-transparent hover:bg-surface",
+      },
+    },
+    defaultVariants: {
+      active: false,
+    }
+  }
+);

--- a/src/pages/UXAuditor.tsx
+++ b/src/pages/UXAuditor.tsx
@@ -1,43 +1,4 @@
-import { cva } from 'class-variance-authority';
 import { Icon } from '@/components/ui/Icon';
-
-const actionButtonVariants = cva(
-  "font-bold transition-all text-sm shrink-0 flex items-center gap-2",
-  {
-    variants: {
-      variant: {
-        default: "hover:text-text-main",
-        primary: "bg-accent text-bg hover:opacity-90 shadow-md disabled:opacity-50",
-      },
-    },
-    defaultVariants: {
-      variant: "default",
-    },
-  }
-);
-
-const reportCardVariants = cva(
-  "bg-surface rounded-lg shadow-sm border border-line",
-  {
-    variants: {
-      interactive: {
-        true: "hover:border-accent transition-all cursor-pointer",
-        false: "",
-      },
-      overflow: {
-        hidden: "overflow-hidden",
-      },
-      span: {
-        1: "col-span-1",
-        2: "col-span-2",
-        3: "col-span-3",
-      }
-    },
-    defaultVariants: {
-      interactive: false,
-    }
-  }
-);
 import { useState, useEffect, ChangeEvent } from 'react';
 import {
   Camera, CheckCircle, RefreshCw,
@@ -50,6 +11,7 @@ import { PageHeader } from '@/components/ui/PageHeader';
 import { SEO } from '@/components/SEO';
 import { EmptyState } from '@/components/ui/EmptyState';
 import { Skeleton } from '@/components/ui/Skeleton';
+import { actionButtonVariants, cardVariants, listRowVariants } from '@/lib/variants';
 
 const viewportIcons = {
   Mobile: <Icon icon={Smartphone} size="md" />,
@@ -165,7 +127,7 @@ export default function UXAuditor() {
           align="center"
           gap={3}
           padding={2}
-          className={reportCardVariants()}
+          className={cardVariants()}
         >
           <Box
             as="input"
@@ -205,7 +167,7 @@ export default function UXAuditor() {
           <Text variant="sans" size="xs" weight="font-bold" uppercase tracking="widest" color="dim" paddingX={1}>
             Audit History
           </Text>
-          <Stack className={`${reportCardVariants({ overflow: "hidden" })} divide-y divide-line`} minWidth={0}>
+          <Stack className={`${cardVariants({ overflow: "hidden" })} divide-y divide-line`} minWidth={0}>
             {reports.length === 0 && (
               <EmptyState
                 compact
@@ -220,9 +182,7 @@ export default function UXAuditor() {
                 direction="row"
                 onClick={() => setActiveReport(report)}
                 width="full" align="center" gap={3} padding={4} 
-                className={`text-left hover:bg-surface transition-all ${
-                  activeReport?.id === report.id ? 'bg-bg border-l-4 border-accent' : 'border-l-4 border-transparent'
-                }`}
+                className={listRowVariants({ active: activeReport?.id === report.id })}
               >
                 <Box
                   width={9}
@@ -254,7 +214,7 @@ export default function UXAuditor() {
             <>
               <Stack
                 padding={6}
-                className={reportCardVariants()}
+                className={cardVariants()}
                 justify="between" align={{ base: "start", md: "center" }} 
                 gap={6} direction={{ base: "col", md: "row" }}
               >
@@ -307,7 +267,7 @@ export default function UXAuditor() {
                   const imgUrl = activeReport[`image_${vp.name.toLowerCase()}`];
 
                   return (
-                    <Box className={reportCardVariants({ overflow: "hidden" })}>
+                    <Box key={vp.name} className={cardVariants({ overflow: "hidden" })}>
                       <Stack padding={4} border="b" direction="row" align="center" justify="between" surface="muted">
                         <Stack direction="row" align="center" gap={3}>
                           <Box width={9} height={9} surface="default" radius="lg" shadow="sm" color="accent" display="flex" align="center" justify="center" shrink={0}>
@@ -360,7 +320,7 @@ export default function UXAuditor() {
                               </Box>
                               <Stack gap={4}>
                                 {data.improvements?.map((imp, idx) => (
-                                  <Box key={idx} padding={4} className={reportCardVariants({ interactive: true })}>
+                                  <Box key={idx} padding={4} className={cardVariants({ interactive: true })}>
                                     <Box display="flex" justify="between" align="start" marginBottom={2}>
                                       <Stack direction="row" align="center" gap={2}>
                                         <Box width={2} height={2} radius="full" className={imp.severity > 7 ? 'bg-error shadow-sm' : 'bg-accent-purple shadow-sm'} />


### PR DESCRIPTION
This PR centralizes and standardizes UI variants for the Systems Console features (UX Auditor and Research Analytics) as recommended in Phase 1 of the FRONTEND_DESIGN_REVIEW.md.

Key changes:
1.  **Shared Variants**: Created `actionButtonVariants`, `cardVariants`, and `listRowVariants` in `src/lib/variants.ts` using `class-variance-authority`.
2.  **UXAuditor Refactor**: Removed locally defined CVA styles in `UXAuditor.tsx` and replaced them with the shared variants. This ensures consistency and reduces code duplication.
3.  **ResearchAnalytics Refactor**: Applied `cardVariants` to the tool and study cards, replacing manual props like `radius`, `border`, and `surface`.
4.  **Consistency**: Ensures a unified look and feel for cards, rows, and action buttons across different features.
5.  **Quality**: Verified with type-checks, unit tests, and the anti-pattern audit (which now passes with 0 violations for the touched files). Visual verification was performed via Playwright screenshots.

Fixes #1084

---
*PR created automatically by Jules for task [13693920154445553590](https://jules.google.com/task/13693920154445553590) started by @arii*