### PR TITLE
Add Automated UX/Console Error Smoke Test

### DIFF
--- a/tests/crawl.spec.ts
+++ b/tests/crawl.spec.ts
@@ -1,0 +1,109 @@
+import { test, expect } from '@playwright/test';
+
+function isInternal(url: string, baseUrl: string): boolean {
+  try {
+    const u = new URL(url, baseUrl);
+    const b = new URL(baseUrl);
+    return u.origin === b.origin && u.pathname.startsWith(b.pathname);
+  } catch {
+    return false;
+  }
+}
+
+function cleanUrl(url: string): string {
+  const u = new URL(url);
+  u.hash = '';
+  u.search = '';
+  return u.toString();
+}
+
+const IGNORED_ERRORS = [
+  "Stack is not defined",
+  "Failed to load resource",
+  "Vercel Web Analytics",
+  "gtag is not defined",
+  "chrome-extension",
+];
+
+function isIgnored(msg: string): boolean {
+  return IGNORED_ERRORS.some(ignored => msg.includes(ignored));
+}
+
+test.describe('Automated UX/Console Error Crawler', () => {
+  test('crawls routes and verifies no errors', async ({ page, baseURL }) => {
+    if (!baseURL) throw new Error('baseURL is required for crawling');
+
+    // State is local to the test to ensure isolation during retries
+    const visited = new Set<string>();
+    const toVisit: string[] = [baseURL];
+
+    // Limit the number of pages to crawl to prevent excessive run times
+    const MAX_PAGES = 50;
+    let pageCount = 0;
+
+    // Ensure newsletter banner doesn't interfere (added once per page instance)
+    await page.addInitScript(() => {
+      window.sessionStorage.setItem('td-newsletter-dismissed', 'true');
+    });
+
+    while (toVisit.length > 0 && pageCount < MAX_PAGES) {
+      const currentUrl = toVisit.shift()!;
+      const normalizedUrl = cleanUrl(currentUrl);
+
+      if (visited.has(normalizedUrl)) continue;
+      visited.add(normalizedUrl);
+      pageCount++;
+
+      console.log(`Crawling (${pageCount}/${MAX_PAGES}): ${normalizedUrl}`);
+
+      const currentConsoleErrors: string[] = [];
+      const currentPageErrors: string[] = [];
+
+      page.on('console', msg => {
+        if (msg.type() === 'error' && !isIgnored(msg.text())) {
+          currentConsoleErrors.push(msg.text());
+        }
+      });
+
+      page.on('pageerror', err => {
+        if (!isIgnored(err.message)) {
+          currentPageErrors.push(err.message);
+        }
+      });
+
+      const response = await page.goto(normalizedUrl, { waitUntil: 'networkidle' });
+
+      // Verify status code
+      if (response) {
+        expect(response.status(), `Page ${normalizedUrl} returned status ${response.status()}`).toBeLessThan(400);
+      }
+
+      // Verify main content is visible
+      await expect(page.locator('main'), `Page ${normalizedUrl} does not have a <main> element`).toBeVisible({ timeout: 5000 });
+
+      // Collect links for further crawling
+      const links = await page.$$eval('a[href]', (anchors) =>
+        anchors.map(a => (a as HTMLAnchorElement).href)
+      );
+
+      for (const link of links) {
+        if (isInternal(link, baseURL)) {
+          const cleanLink = cleanUrl(new URL(link, baseURL).toString());
+          if (!visited.has(cleanLink) && !toVisit.includes(cleanLink)) {
+            toVisit.push(cleanLink);
+          }
+        }
+      }
+
+      // Assert no errors for this page
+      expect(currentConsoleErrors, `Console errors on ${normalizedUrl}:\n${currentConsoleErrors.join('\n')}`).toHaveLength(0);
+      expect(currentPageErrors, `Page errors on ${normalizedUrl}:\n${currentPageErrors.join('\n')}`).toHaveLength(0);
+
+      // Remove listeners for next page
+      page.removeAllListeners('console');
+      page.removeAllListeners('pageerror');
+    }
+
+    console.log(`Crawling complete. Visited ${pageCount} pages.`);
+  });
+});

--- a/tests/crawl.spec.ts
+++ b/tests/crawl.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { setupErrorMonitoring } from './fixtures/error-monitoring';
 
 function isInternal(url: string, baseUrl: string): boolean {
   try {
@@ -17,16 +18,6 @@ function cleanUrl(url: string): string {
   return u.toString();
 }
 
-const IGNORED_ERRORS = [
-  "Vercel Web Analytics",
-  "gtag is not defined",
-  "chrome-extension",
-];
-
-function isIgnored(msg: string): boolean {
-  return IGNORED_ERRORS.some(ignored => msg.includes(ignored));
-}
-
 test.describe('Automated UX/Console Error Crawler', () => {
   test('crawls routes and verifies no errors', async ({ page, baseURL }) => {
     if (!baseURL) throw new Error('baseURL is required for crawling');
@@ -38,6 +29,8 @@ test.describe('Automated UX/Console Error Crawler', () => {
     // Limit the number of pages to crawl to prevent excessive run times
     const MAX_PAGES = 50;
     let pageCount = 0;
+
+    const { consoleErrors, pageErrors, clearErrors } = setupErrorMonitoring(page);
 
     // Ensure newsletter banner doesn't interfere (added once per page instance)
     await page.addInitScript(() => {
@@ -54,20 +47,8 @@ test.describe('Automated UX/Console Error Crawler', () => {
 
       console.log(`Crawling (${pageCount}/${MAX_PAGES}): ${normalizedUrl}`);
 
-      const currentConsoleErrors: string[] = [];
-      const currentPageErrors: string[] = [];
-
-      page.on('console', msg => {
-        if (msg.type() === 'error' && !isIgnored(msg.text())) {
-          currentConsoleErrors.push(msg.text());
-        }
-      });
-
-      page.on('pageerror', err => {
-        if (!isIgnored(err.message)) {
-          currentPageErrors.push(err.message);
-        }
-      });
+      // Clear errors from previous navigation before going to next page
+      clearErrors();
 
       const response = await page.goto(normalizedUrl, { waitUntil: 'networkidle' });
 
@@ -94,12 +75,8 @@ test.describe('Automated UX/Console Error Crawler', () => {
       }
 
       // Assert no errors for this page
-      expect(currentConsoleErrors, `Console errors on ${normalizedUrl}:\n${currentConsoleErrors.join('\n')}`).toHaveLength(0);
-      expect(currentPageErrors, `Page errors on ${normalizedUrl}:\n${currentPageErrors.join('\n')}`).toHaveLength(0);
-
-      // Remove listeners for next page
-      page.removeAllListeners('console');
-      page.removeAllListeners('pageerror');
+      expect(consoleErrors, `Console errors on ${normalizedUrl}:\n${consoleErrors.join('\n')}`).toHaveLength(0);
+      expect(pageErrors, `Page errors on ${normalizedUrl}:\n${pageErrors.join('\n')}`).toHaveLength(0);
     }
 
     console.log(`Crawling complete. Visited ${pageCount} pages.`);

--- a/tests/crawl.spec.ts
+++ b/tests/crawl.spec.ts
@@ -18,8 +18,6 @@ function cleanUrl(url: string): string {
 }
 
 const IGNORED_ERRORS = [
-  "Stack is not defined",
-  "Failed to load resource",
   "Vercel Web Analytics",
   "gtag is not defined",
   "chrome-extension",

--- a/tests/crawl.spec.ts
+++ b/tests/crawl.spec.ts
@@ -1,6 +1,32 @@
 import { test, expect } from '@playwright/test';
 import { setupErrorMonitoring } from './fixtures/error-monitoring';
 
+/**
+ * Normalizes a URL for crawling.
+ * Preserves essential query parameters while stripping tracking tokens.
+ */
+function cleanUrl(url: string): string {
+  const u = new URL(url);
+  u.hash = '';
+
+  // Define tracking parameters to strip
+  const trackingParams = ['utm_', 'fbclid', 'gclid', 'msclkid', '_hsenc', '_hsmi'];
+
+  const params = new URLSearchParams(u.search);
+  const keysToDelete: string[] = [];
+
+  for (const key of params.keys()) {
+    if (trackingParams.some(p => key.startsWith(p))) {
+      keysToDelete.push(key);
+    }
+  }
+
+  keysToDelete.forEach(key => params.delete(key));
+  u.search = params.toString();
+
+  return u.toString();
+}
+
 function isInternal(url: string, baseUrl: string): boolean {
   try {
     const u = new URL(url, baseUrl);
@@ -9,13 +35,6 @@ function isInternal(url: string, baseUrl: string): boolean {
   } catch {
     return false;
   }
-}
-
-function cleanUrl(url: string): string {
-  const u = new URL(url);
-  u.hash = '';
-  u.search = '';
-  return u.toString();
 }
 
 test.describe('Automated UX/Console Error Crawler', () => {

--- a/tests/fixtures/error-monitoring.ts
+++ b/tests/fixtures/error-monitoring.ts
@@ -1,18 +1,23 @@
 import { Page, ConsoleMessage } from '@playwright/test';
+import { IGNORED_ERROR_PATTERNS } from '../test-constants';
 
-export const IGNORED_ERRORS = [
-  "Vercel Web Analytics",
-  "gtag is not defined",
-  "chrome-extension",
-];
-
-export function isIgnored(msg: string): boolean {
-  return IGNORED_ERRORS.some(ignored => msg.includes(ignored));
+export interface ErrorMonitoringOptions {
+  ignoredPatterns?: (string | RegExp)[];
+  customFilter?: (msg: string) => boolean;
 }
 
-export function setupErrorMonitoring(page: Page) {
+export function setupErrorMonitoring(page: Page, options: ErrorMonitoringOptions = {}) {
   const consoleErrors: string[] = [];
   const pageErrors: string[] = [];
+
+  const patterns = options.ignoredPatterns || IGNORED_ERROR_PATTERNS;
+
+  const isIgnored = (msg: string) => {
+    if (options.customFilter && options.customFilter(msg)) return true;
+    return patterns.some(pattern =>
+      pattern instanceof RegExp ? pattern.test(msg) : msg.includes(pattern)
+    );
+  };
 
   page.on('console', (msg: ConsoleMessage) => {
     if (msg.type() === 'error' && !isIgnored(msg.text())) {

--- a/tests/fixtures/error-monitoring.ts
+++ b/tests/fixtures/error-monitoring.ts
@@ -1,0 +1,37 @@
+import { Page, ConsoleMessage } from '@playwright/test';
+
+export const IGNORED_ERRORS = [
+  "Vercel Web Analytics",
+  "gtag is not defined",
+  "chrome-extension",
+];
+
+export function isIgnored(msg: string): boolean {
+  return IGNORED_ERRORS.some(ignored => msg.includes(ignored));
+}
+
+export function setupErrorMonitoring(page: Page) {
+  const consoleErrors: string[] = [];
+  const pageErrors: string[] = [];
+
+  page.on('console', (msg: ConsoleMessage) => {
+    if (msg.type() === 'error' && !isIgnored(msg.text())) {
+      consoleErrors.push(`[CONSOLE ERROR @ ${page.url()}] ${msg.text()}`);
+    }
+  });
+
+  page.on('pageerror', (err: Error) => {
+    if (!isIgnored(err.message)) {
+      pageErrors.push(`[PAGE ERROR @ ${page.url()}] ${err.message}`);
+    }
+  });
+
+  return {
+    consoleErrors,
+    pageErrors,
+    clearErrors: () => {
+      consoleErrors.length = 0;
+      pageErrors.length = 0;
+    }
+  };
+}

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -1,9 +1,7 @@
-import { test, expect, Page, ConsoleMessage } from '@playwright/test';
+import { test, expect } from '@playwright/test';
+import { setupErrorMonitoring } from './fixtures/error-monitoring';
 
-// Use a WeakMap to store console errors per page to avoid global state leakage
-const errorsByPage = new WeakMap<Page, string[]>();
-
-async function validateUrlNavigation(page: Page, href: string) {
+async function validateUrlNavigation(page: any, href: string) {
   if (href.includes('#')) {
     const [baseUrl, fragment] = href.split('#');
     if (page.url() !== baseUrl && page.url() !== baseUrl + '/') {
@@ -21,93 +19,60 @@ async function validateUrlNavigation(page: Page, href: string) {
   }
 }
 
-function getPageErrors(page: Page): string[] {
-  if (!errorsByPage.has(page)) {
-    errorsByPage.set(page, []);
-  }
-  return errorsByPage.get(page)!;
-}
+test.describe('Navigation Smoke Tests', () => {
+  let errorMonitor: any;
 
-async function collectErrors(page: Page) {
-  const errors = getPageErrors(page);
-  page.on('console', (msg: ConsoleMessage) => {
-    if (msg.type() === 'error') {
-      errors.push(`[${page.url()}] ${msg.text()}`);
-    }
+  test.beforeEach(async ({ page }) => {
+    errorMonitor = setupErrorMonitoring(page);
   });
-  page.on('pageerror', (err: Error) => {
-    errors.push(`[PAGE ERROR @ ${page.url()}] ${err.message}`);
-  });
-}
 
-test.beforeEach(async ({ page }) => {
-  await collectErrors(page);
-});
-
-test('homepage loads without console errors', async ({ page }) => {
-  await page.goto('./');
-  await expect(page.locator('main')).toBeVisible();
-  const errors = getPageErrors(page);
-  // Filter out known environment-specific errors
-  const filteredErrors = errors.filter(e =>
-    !e.includes("Vercel Web Analytics")
-  );
-  expect(filteredErrors).toHaveLength(0);
-});
-
-test('all nav links are reachable and error-free', async ({ page }) => {
-  await page.goto('./');
-  await expect(page.locator('main')).toBeVisible();
-
-  const links = await page.$$eval('nav a[href]', (anchors) =>
-    anchors
-      .map((a) => (a as HTMLAnchorElement).href)
-      .filter((href) => href.startsWith(window.location.origin))
-  );
-
-  for (const href of links) {
-    const errors = getPageErrors(page);
-    errors.length = 0;
-
-    await validateUrlNavigation(page, href);
-
-    const filteredErrors = errors.filter(e =>
-      !e.includes("Vercel Web Analytics")
-    );
-    expect(filteredErrors, `Console errors at ${href}: ${errors.join(', ')}`).toHaveLength(0);
-  }
-});
-
-test('all post/content pages load without errors', async ({ page }) => {
-  const contentIndexes = ['./blog', './gear', './research'];
-
-  for (const index of contentIndexes) {
-    await page.goto(index);
+  test('homepage loads without console errors', async ({ page }) => {
+    await page.goto('./');
     await expect(page.locator('main')).toBeVisible();
-    const exists = await page.$('main');
-    if (!exists) continue;
+    expect(errorMonitor.consoleErrors).toHaveLength(0);
+    expect(errorMonitor.pageErrors).toHaveLength(0);
+  });
 
+  test('all nav links are reachable and error-free', async ({ page }) => {
+    await page.goto('./');
+    await expect(page.locator('main')).toBeVisible();
 
-    const contentLinks = await page.$$eval('a[href]', (anchors) =>
+    const links = await page.$$eval('nav a[href]', (anchors) =>
       anchors
         .map((a) => (a as HTMLAnchorElement).href)
         .filter((href) => href.startsWith(window.location.origin))
-        .filter((href, i, arr) => arr.indexOf(href) === i) // dedupe
     );
 
-    for (const href of contentLinks) {
-      const errors = getPageErrors(page);
-      errors.length = 0;
-
+    for (const href of links) {
+      errorMonitor.clearErrors();
       await validateUrlNavigation(page, href);
-
-      const filteredErrors = errors.filter(e =>
-        !e.includes("Vercel Web Analytics")
-      );
-      expect(
-        filteredErrors,
-        `Console errors at ${href}:\n${errors.join('\n')}`
-      ).toHaveLength(0);
+      expect(errorMonitor.consoleErrors, `Errors at ${href}: ${errorMonitor.consoleErrors.join(', ')}`).toHaveLength(0);
+      expect(errorMonitor.pageErrors, `Errors at ${href}: ${errorMonitor.pageErrors.join(', ')}`).toHaveLength(0);
     }
-  }
+  });
+
+  test('all post/content pages load without errors', async ({ page }) => {
+    const contentIndexes = ['./blog', './gear', './research'];
+
+    for (const index of contentIndexes) {
+      await page.goto(index);
+      await expect(page.locator('main')).toBeVisible();
+      const exists = await page.$('main');
+      if (!exists) continue;
+
+      const contentLinks = await page.$$eval('a[href]', (anchors) =>
+        anchors
+          .map((a) => (a as HTMLAnchorElement).href)
+          .filter((href) => href.startsWith(window.location.origin))
+          .filter((href, i, arr) => arr.indexOf(href) === i) // dedupe
+      );
+
+      for (const href of contentLinks) {
+        errorMonitor.clearErrors();
+        await validateUrlNavigation(page, href);
+        expect(errorMonitor.consoleErrors, `Errors at ${href}: ${errorMonitor.consoleErrors.join(', ')}`).toHaveLength(0);
+        expect(errorMonitor.pageErrors, `Errors at ${href}: ${errorMonitor.pageErrors.join(', ')}`).toHaveLength(0);
+      }
+    }
+  });
 });

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -1,7 +1,7 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 import { setupErrorMonitoring } from './fixtures/error-monitoring';
 
-async function validateUrlNavigation(page: any, href: string) {
+async function validateUrlNavigation(page: Page, href: string) {
   if (href.includes('#')) {
     const [baseUrl, fragment] = href.split('#');
     if (page.url() !== baseUrl && page.url() !== baseUrl + '/') {
@@ -20,7 +20,7 @@ async function validateUrlNavigation(page: any, href: string) {
 }
 
 test.describe('Navigation Smoke Tests', () => {
-  let errorMonitor: any;
+  let errorMonitor: ReturnType<typeof setupErrorMonitoring>;
 
   test.beforeEach(async ({ page }) => {
     errorMonitor = setupErrorMonitoring(page);

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -50,8 +50,6 @@ test('homepage loads without console errors', async ({ page }) => {
   const errors = getPageErrors(page);
   // Filter out known environment-specific errors
   const filteredErrors = errors.filter(e =>
-    !e.includes("Stack is not defined") &&
-    !e.includes("Failed to load resource") &&
     !e.includes("Vercel Web Analytics")
   );
   expect(filteredErrors).toHaveLength(0);
@@ -74,8 +72,6 @@ test('all nav links are reachable and error-free', async ({ page }) => {
     await validateUrlNavigation(page, href);
 
     const filteredErrors = errors.filter(e =>
-      !e.includes("Stack is not defined") &&
-      !e.includes("Failed to load resource") &&
       !e.includes("Vercel Web Analytics")
     );
     expect(filteredErrors, `Console errors at ${href}: ${errors.join(', ')}`).toHaveLength(0);
@@ -106,8 +102,6 @@ test('all post/content pages load without errors', async ({ page }) => {
       await validateUrlNavigation(page, href);
 
       const filteredErrors = errors.filter(e =>
-        !e.includes("Stack is not defined") &&
-        !e.includes("Failed to load resource") &&
         !e.includes("Vercel Web Analytics")
       );
       expect(

--- a/tests/test-constants.ts
+++ b/tests/test-constants.ts
@@ -1,0 +1,10 @@
+/**
+ * Patterns for console and page errors that should be ignored during smoke tests.
+ * These are typically environment-specific noise or known external script issues.
+ */
+export const IGNORED_ERROR_PATTERNS = [
+  /Vercel Web Analytics/,
+  /gtag is not defined/,
+  /chrome-extension/,
+  /Failed to load resource: net::ERR_BLOCKED_BY_CLIENT/, // Common adblocker/extension interference
+];


### PR DESCRIPTION
Created a new Playwright-based smoke test in `tests/crawl.spec.ts` that performs a breadth-first search (BFS) crawl of the application's internal routes. It verifies that each page loads successfully (HTTP status < 400), renders the mandatory `<main>` element, and remains free of console errors and uncaught exceptions. The test includes robust error filtering for environment-specific noise and handles state isolation for reliability during retries.

Fixes #1095

---
*PR created automatically by Jules for task [3111523203801414691](https://jules.google.com/task/3111523203801414691) started by @arii*