### PR TITLE
Add UX review workflow doc and Playwright setup/review scripts

### DIFF
--- a/UX_AUDIT_REVIEW_UX_WORKFLOW.md
+++ b/UX_AUDIT_REVIEW_UX_WORKFLOW.md
@@ -1,0 +1,49 @@
+# UX Audit: review-ux workflow (2026-05-12)
+
+## Scope
+Routes targeted by workflow:
+- /
+- /about
+- /blog
+- /gear
+- /research
+- Search modal
+
+## Execution Summary
+- ✅ Dependency install completed (`pnpm install`).
+- ✅ UX anti-pattern scan passed (`pnpm run audit`).
+- ✅ Dev server started successfully and served local app on port 3000.
+- ⚠️ Playwright interactive visual audit could not be executed because browser download was blocked (403 from `cdn.playwright.dev`).
+- ✅ Route availability spot-check returned HTTP 200 for all required routes via `curl`.
+
+## Findings
+
+### [P1 / High] Playwright-based UX workflow is blocked in this environment
+- **Observation**: `playwright-cli install --skills` repeatedly failed trying to download Chromium with `403 Domain forbidden`.
+- **Heuristic / Principle Violated**: Interaction & Motion / Review Process Reliability (tooling should reliably support required UX verification).
+- **Impact**: Desktop/mobile visual verification, modal overlap checks, typography consistency checks, and screenshot artifact capture cannot be completed as required by workflow.
+- **Recommendation**: Add a fallback path in workflow docs for preinstalled browsers or mirror URL config (e.g., set `PLAYWRIGHT_DOWNLOAD_HOST` or use pre-baked browser binaries in CI/dev containers).
+
+### [P2 / Medium] Workflow step asks to run dev server without log piping, but automated/non-interactive execution requires log capture strategy
+- **Observation**: Workflow recommends running `pnpm run dev` without piping to log for manual inspection, which conflicts with non-interactive automation.
+- **Heuristic / Principle Violated**: Cognitive Load & UX Writing (instructions should be unambiguous across execution contexts).
+- **Impact**: Agents may either block indefinitely or miss startup/runtime errors unless they improvise process management.
+- **Recommendation**: Add an explicit “automation-safe” variant in the workflow (e.g., `pnpm run dev` in PTY + bounded health check command), plus a standardized way to stop the process.
+
+## Proposed GitHub Issues
+
+1. **High: Unblock Playwright browser provisioning in agent/container environments**
+   - Include failure logs and 403 host details.
+   - Acceptance criteria: `playwright-cli install --skills` succeeds in clean environment.
+
+2. **Medium: Add non-interactive execution path to `.agent/workflows/review-ux.md`**
+   - Document process lifecycle commands and health checks.
+   - Acceptance criteria: workflow can be executed headlessly while still surfacing runtime errors.
+
+## Evidence Commands
+- `pnpm install`
+- `npm install -g @playwright/cli@latest`
+- `playwright-cli install --skills`
+- `pnpm run audit`
+- `pnpm run dev`
+- `curl http://localhost:3000/{route}` for route checks

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
+    "setup:playwright": "./dev-tools/setup-playwright.sh",
     "dev": "shx mkdir -p public/data && shx cp etl/data/wcs_prelims.parquet public/data/wcs_prelims.parquet && vite --port=3000 --host=0.0.0.0",
     "prebuild": "tsx scripts/generate-assets.ts",
     "build": "shx mkdir -p public/data && shx cp etl/data/wcs_prelims.parquet public/data/wcs_prelims.parquet && pnpm run type-check && vite build",
@@ -24,6 +25,9 @@
     "knip": "knip",
     "type-check": "tsc --noEmit",
     "audit": "node scripts/detect-antipatterns.mjs",
+    "review:ux:prep": "pnpm run setup:playwright && pnpm run audit",
+    "review:ux:desktop": "playwright open http://localhost:3000/ --device=\"Desktop Chrome\"",
+    "review:ux:mobile": "playwright open http://localhost:3000/ --device=\"iPhone 12\"",
     "repair-context": "PYTHONPATH=$PYTHONPATH:dev-tools python3 dev-tools/td_cli.py repair-context"
   },
   "dependencies": {


### PR DESCRIPTION
### Motivation
- Provide a documented UX audit / review workflow and helper scripts to make Playwright-based visual/manual checks reproducible.
- Surface environment-specific blockers and recommend fallbacks for browser provisioning and non-interactive dev server execution.

### Description
- Add `UX_AUDIT_REVIEW_UX_WORKFLOW.md` containing scope, execution summary, findings, recommendations, and evidence commands for the UX review process.
- Add a `setup:playwright` script that runs `./dev-tools/setup-playwright.sh` and add `review:ux:prep`, `review:ux:desktop`, and `review:ux:mobile` scripts to `package.json` to prepare and launch Playwright checks.
- Wire `review:ux:prep` to run `setup:playwright` then `audit`, and add `review:ux:desktop`/`review:ux:mobile` to open Playwright against `http://localhost:3000/` with desktop and mobile device presets.

### Testing
- Ran `pnpm install` and `pnpm run audit`, and the UX anti-pattern scan completed successfully.
- Started the dev server with `pnpm run dev` and verified routes with `curl`, which returned HTTP 200 for all targeted routes.
- Attempted `npm install -g @playwright/cli@latest` and `playwright-cli install --skills`, but browser provisioning failed with a `403 Domain forbidden`, preventing the interactive Playwright visual audit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0284abce348325ba990f10792bfc32)