### PR TITLE
Fix pnpm version mismatch in GitHub Actions workflows

### DIFF
--- a/.github/workflows/mass-audit-prs.yml
+++ b/.github/workflows/mass-audit-prs.yml
@@ -32,8 +32,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 10
 
       - name: Install Node dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/mergellama.yml
+++ b/.github/workflows/mergellama.yml
@@ -27,8 +27,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 10
 
       - name: Setup Ollama
         uses: ai-action/setup-ollama@v2


### PR DESCRIPTION
Fixed pnpm version mismatch issues in GitHub Actions workflows by removing hardcoded version specifications. This ensures that the CI environment always uses the pnpm version defined in package.json.

Changes:
- Removed `with: version: 10` from `.github/workflows/mass-audit-prs.yml`
- Removed `with: version: 10` from `.github/workflows/mergellama.yml`

Fixes #1098

---
*PR created automatically by Jules for task [14814531951502640562](https://jules.google.com/task/14814531951502640562) started by @arii*