### PR TITLE
Refine cryptic loading text in Search Modal

### DIFF
--- a/src/components/GlobalSearch.tsx
+++ b/src/components/GlobalSearch.tsx
@@ -16,7 +16,7 @@ interface SearchResult {
 }
 
 export function GlobalSearch() {
-  const { query, setQuery, results, isOpen, open, close } = useGlobalSearch();
+  const { query, setQuery, results, isOpen, open, close, isLoading } = useGlobalSearch();
   const inputRef = useRef<HTMLInputElement>(null);
   const navigate = useNavigate();
 
@@ -217,8 +217,12 @@ export function GlobalSearch() {
               <Box padding={20} display="flex" align="center" justify="center">
                 <Stack align="center" gap={4} className="opacity-60">
                   <Sparkles className="w-10 h-10 text-accent animate-pulse" />
-                  <Text variant="mono" size="tiny" color="dim" tracking="widest" uppercase weight="font-bold">
-                     {query ? "No coordinates found" : "Calibrating Variance..."}
+                  <Text variant="mono" size="xs" color="dim" tracking="widest" uppercase weight="font-bold">
+                    {isLoading
+                      ? "Searching..."
+                      : query
+                        ? "No results found"
+                        : "Ready to search"}
                   </Text>
                 </Stack>
               </Box>

--- a/src/hooks/useGlobalSearch.ts
+++ b/src/hooks/useGlobalSearch.ts
@@ -2,6 +2,7 @@ import { useMemo, useCallback } from 'react';
 import { useSearchParam } from './useSearchParam';
 import { useQueries } from '@tanstack/react-query';
 import { getPosts, getResources, getStudies } from '@/lib/content';
+import { withSimulationDelay } from '@/lib/utils';
 import Fuse from 'fuse.js';
 
 export function useGlobalSearch() {
@@ -20,39 +21,9 @@ export function useGlobalSearch() {
 
   const queries = useQueries({
     queries: [
-      {
-        queryKey: ['posts'],
-        queryFn: async () => {
-          const simulate = import.meta.env.VITE_SIMULATE_LOADING ||
-            (typeof window !== 'undefined' && (window as Window & { __SIMULATE_LOADING?: boolean }).__SIMULATE_LOADING);
-          if (simulate) {
-            await new Promise(r => setTimeout(r, 1000));
-          }
-          return getPosts();
-        }
-      },
-      {
-        queryKey: ['resources'],
-        queryFn: async () => {
-          const simulate = import.meta.env.VITE_SIMULATE_LOADING ||
-            (typeof window !== 'undefined' && (window as Window & { __SIMULATE_LOADING?: boolean }).__SIMULATE_LOADING);
-          if (simulate) {
-            await new Promise(r => setTimeout(r, 1000));
-          }
-          return getResources();
-        }
-      },
-      {
-        queryKey: ['studies'],
-        queryFn: async () => {
-          const simulate = import.meta.env.VITE_SIMULATE_LOADING ||
-            (typeof window !== 'undefined' && (window as Window & { __SIMULATE_LOADING?: boolean }).__SIMULATE_LOADING);
-          if (simulate) {
-            await new Promise(r => setTimeout(r, 1000));
-          }
-          return getStudies();
-        }
-      },
+      { queryKey: ['posts'], queryFn: withSimulationDelay(getPosts) },
+      { queryKey: ['resources'], queryFn: withSimulationDelay(getResources) },
+      { queryKey: ['studies'], queryFn: withSimulationDelay(getStudies) },
     ],
   });
 

--- a/src/hooks/useGlobalSearch.ts
+++ b/src/hooks/useGlobalSearch.ts
@@ -20,9 +20,24 @@ export function useGlobalSearch() {
 
   const queries = useQueries({
     queries: [
-      { queryKey: ['posts'], queryFn: getPosts },
-      { queryKey: ['resources'], queryFn: getResources },
-      { queryKey: ['studies'], queryFn: getStudies },
+      { queryKey: ['posts'], queryFn: async () => {
+        if (import.meta.env.VITE_SIMULATE_LOADING || (typeof window !== 'undefined' && (window as any).__SIMULATE_LOADING)) {
+          await new Promise(r => setTimeout(r, 1000));
+        }
+        return getPosts();
+      } },
+      { queryKey: ['resources'], queryFn: async () => {
+        if (import.meta.env.VITE_SIMULATE_LOADING || (typeof window !== 'undefined' && (window as any).__SIMULATE_LOADING)) {
+          await new Promise(r => setTimeout(r, 1000));
+        }
+        return getResources();
+      } },
+      { queryKey: ['studies'], queryFn: async () => {
+        if (import.meta.env.VITE_SIMULATE_LOADING || (typeof window !== 'undefined' && (window as any).__SIMULATE_LOADING)) {
+          await new Promise(r => setTimeout(r, 1000));
+        }
+        return getStudies();
+      } },
     ],
   });
 

--- a/src/hooks/useGlobalSearch.ts
+++ b/src/hooks/useGlobalSearch.ts
@@ -20,24 +20,39 @@ export function useGlobalSearch() {
 
   const queries = useQueries({
     queries: [
-      { queryKey: ['posts'], queryFn: async () => {
-        if (import.meta.env.VITE_SIMULATE_LOADING || (typeof window !== 'undefined' && (window as any).__SIMULATE_LOADING)) {
-          await new Promise(r => setTimeout(r, 1000));
+      {
+        queryKey: ['posts'],
+        queryFn: async () => {
+          const simulate = import.meta.env.VITE_SIMULATE_LOADING ||
+            (typeof window !== 'undefined' && (window as Window & { __SIMULATE_LOADING?: boolean }).__SIMULATE_LOADING);
+          if (simulate) {
+            await new Promise(r => setTimeout(r, 1000));
+          }
+          return getPosts();
         }
-        return getPosts();
-      } },
-      { queryKey: ['resources'], queryFn: async () => {
-        if (import.meta.env.VITE_SIMULATE_LOADING || (typeof window !== 'undefined' && (window as any).__SIMULATE_LOADING)) {
-          await new Promise(r => setTimeout(r, 1000));
+      },
+      {
+        queryKey: ['resources'],
+        queryFn: async () => {
+          const simulate = import.meta.env.VITE_SIMULATE_LOADING ||
+            (typeof window !== 'undefined' && (window as Window & { __SIMULATE_LOADING?: boolean }).__SIMULATE_LOADING);
+          if (simulate) {
+            await new Promise(r => setTimeout(r, 1000));
+          }
+          return getResources();
         }
-        return getResources();
-      } },
-      { queryKey: ['studies'], queryFn: async () => {
-        if (import.meta.env.VITE_SIMULATE_LOADING || (typeof window !== 'undefined' && (window as any).__SIMULATE_LOADING)) {
-          await new Promise(r => setTimeout(r, 1000));
+      },
+      {
+        queryKey: ['studies'],
+        queryFn: async () => {
+          const simulate = import.meta.env.VITE_SIMULATE_LOADING ||
+            (typeof window !== 'undefined' && (window as Window & { __SIMULATE_LOADING?: boolean }).__SIMULATE_LOADING);
+          if (simulate) {
+            await new Promise(r => setTimeout(r, 1000));
+          }
+          return getStudies();
         }
-        return getStudies();
-      } },
+      },
     ],
   });
 

--- a/src/hooks/useGlobalSearch.ts
+++ b/src/hooks/useGlobalSearch.ts
@@ -18,13 +18,17 @@ export function useGlobalSearch() {
     setSearchState('');
   }, [setSearchState]);
 
-  const [postsQuery, resourcesQuery, studiesQuery] = useQueries({
+  const queries = useQueries({
     queries: [
       { queryKey: ['posts'], queryFn: getPosts },
       { queryKey: ['resources'], queryFn: getResources },
       { queryKey: ['studies'], queryFn: getStudies },
     ],
   });
+
+  const [postsQuery, resourcesQuery, studiesQuery] = queries;
+
+  const isLoading = queries.some(q => q.isLoading);
 
   const allContent = useMemo(() => {
     return [
@@ -58,6 +62,7 @@ export function useGlobalSearch() {
     results,
     isOpen,
     open,
-    close
+    close,
+    isLoading
   };
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -85,3 +85,20 @@ export function formatCategory(cat: string): string {
   if (cat === 'All') return 'All Posts';
   return cat.split('-').map(word => word.charAt(0).toUpperCase() + word.slice(1)).join(' ');
 }
+
+/**
+ * Wraps a fetch function with an artificial delay if simulation is active.
+ * Used for testing loading transitions in E2E.
+ */
+export function withSimulationDelay<T>(fn: () => Promise<T>): () => Promise<T> {
+  return async () => {
+    const isSimulated = typeof import.meta !== 'undefined' && import.meta.env.VITE_SIMULATE_LOADING;
+    const isE2ESimulated = typeof window !== 'undefined' &&
+      (window as Window & { __SIMULATE_LOADING?: boolean }).__SIMULATE_LOADING;
+
+    if (isSimulated || isE2ESimulated) {
+      await new Promise(r => setTimeout(r, 1000));
+    }
+    return fn();
+  };
+}

--- a/tests/search_ux.spec.ts
+++ b/tests/search_ux.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Global Search Modal UX Refinement', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('./');
+    await expect(page.locator('main')).toBeVisible();
+  });
+
+  test('should show "READY TO SEARCH" when modal is opened with no query', async ({ page }) => {
+    const searchButton = page.getByRole('navigation', { name: 'Main Navigation' }).getByRole('button', { name: 'Search' });
+    await searchButton.click();
+
+    // We expect "READY TO SEARCH" (uppercase because of variant="mono" which has uppercase: true in some contexts or just the text itself)
+    // Actually I wrote "Ready to search" in code, but Text component with variant="mono" might uppercase it if configured.
+    // Let's check GlobalSearch.tsx again.
+    // <Text variant="mono" size="xs" color="dim" tracking="widest" uppercase weight="font-bold">
+    // So it will be uppercased.
+
+    await expect(page.getByText('READY TO SEARCH')).toBeVisible();
+  });
+
+  test('should show "NO RESULTS FOUND" when query has no matches', async ({ page }) => {
+    const searchButton = page.getByRole('navigation', { name: 'Main Navigation' }).getByRole('button', { name: 'Search' });
+    await searchButton.click();
+
+    const searchInput = page.getByPlaceholder('SEARCH REPOSITORY // FILTER BLOG & GEAR');
+    await searchInput.fill('nonexistent-query-xyz-123');
+
+    await expect(page.getByText('NO RESULTS FOUND')).toBeVisible();
+  });
+
+  // Loading state "SEARCHING..." is hard to catch reliably in a fast local environment
+  // without mocking the network/queries to stay in loading state.
+});

--- a/tests/search_ux.spec.ts
+++ b/tests/search_ux.spec.ts
@@ -25,7 +25,7 @@ test.describe('Global Search Modal UX Refinement', () => {
   test('should show "SEARCHING..." state when simulated loading is active', async ({ page }) => {
     // Enable simulated loading via window property
     await page.addInitScript(() => {
-      (window as any).__SIMULATE_LOADING = true;
+      (window as Window & { __SIMULATE_LOADING?: boolean }).__SIMULATE_LOADING = true;
     });
 
     // Reload to ensure the init script takes effect for any immediate queries

--- a/tests/search_ux.spec.ts
+++ b/tests/search_ux.spec.ts
@@ -9,13 +9,6 @@ test.describe('Global Search Modal UX Refinement', () => {
   test('should show "READY TO SEARCH" when modal is opened with no query', async ({ page }) => {
     const searchButton = page.getByRole('navigation', { name: 'Main Navigation' }).getByRole('button', { name: 'Search' });
     await searchButton.click();
-
-    // We expect "READY TO SEARCH" (uppercase because of variant="mono" which has uppercase: true in some contexts or just the text itself)
-    // Actually I wrote "Ready to search" in code, but Text component with variant="mono" might uppercase it if configured.
-    // Let's check GlobalSearch.tsx again.
-    // <Text variant="mono" size="xs" color="dim" tracking="widest" uppercase weight="font-bold">
-    // So it will be uppercased.
-
     await expect(page.getByText('READY TO SEARCH')).toBeVisible();
   });
 
@@ -29,6 +22,23 @@ test.describe('Global Search Modal UX Refinement', () => {
     await expect(page.getByText('NO RESULTS FOUND')).toBeVisible();
   });
 
-  // Loading state "SEARCHING..." is hard to catch reliably in a fast local environment
-  // without mocking the network/queries to stay in loading state.
+  test('should show "SEARCHING..." state when simulated loading is active', async ({ page }) => {
+    // Enable simulated loading via window property
+    await page.addInitScript(() => {
+      (window as any).__SIMULATE_LOADING = true;
+    });
+
+    // Reload to ensure the init script takes effect for any immediate queries
+    await page.reload();
+    await expect(page.locator('main')).toBeVisible();
+
+    const searchButton = page.getByRole('navigation', { name: 'Main Navigation' }).getByRole('button', { name: 'Search' });
+    await searchButton.click();
+
+    // The "SEARCHING..." text should be visible because of the 1s delay
+    await expect(page.getByText('SEARCHING...')).toBeVisible();
+
+    // After delay, it should transition to READY TO SEARCH (since query is empty)
+    await expect(page.getByText('READY TO SEARCH')).toBeVisible({ timeout: 5000 });
+  });
 });


### PR DESCRIPTION
Refined the Search Modal UX by replacing the cryptic "CALIBRATING VARIANCE..." loading text with clearer, more standard messaging.

Key changes:
- **`useGlobalSearch` Hook**: Now computes and returns an `isLoading` property by checking the status of the underlying content queries (posts, resources, studies).
- **`GlobalSearch` Component**: 
    - Consumes the `isLoading` state to provide contextual feedback.
    - Displays "READY TO SEARCH" when the modal is first opened.
    - Displays "SEARCHING..." while data is being fetched.
    - Displays "NO RESULTS FOUND" when a query returns no matches.
    - Font size for these messages was increased from `tiny` (10px) to `xs` (12px) to improve legibility.
- **Testing**: Added `tests/search_ux.spec.ts` to ensure these new states are correctly rendered and visible to the user. Verified all search-related tests pass.

Fixes #1102

---
*PR created automatically by Jules for task [9169400738349647005](https://jules.google.com/task/9169400738349647005) started by @arii*