### PR TITLE
Fix search results layout overflow on mobile

### DIFF
--- a/src/components/GlobalSearch.tsx
+++ b/src/components/GlobalSearch.tsx
@@ -225,8 +225,17 @@ export function GlobalSearch() {
             )}
           </Box>
 
-          <Box border="t" paddingX={5} paddingY={3} surface="alt" display="flex" justify="between" align="center" className="pb-safe-area-search">
-            <Box display="flex" align="center" gap={6}>
+          <Box
+            border="t"
+            paddingX={{ base: 4, md: 5 }}
+            paddingY={3}
+            surface="alt"
+            display="flex"
+            justify={{ base: "center", md: "between" }}
+            align="center"
+            className="pb-safe-area-search"
+          >
+            <Box display={{ base: "none", md: "flex" }} align="center" gap={6}>
               <Box display="flex" align="center" gap={2}>
                 <Box border paddingX={1.5} paddingY={0.5} radius="industrial" surface="default" display="flex" align="center" justify="center" className="border-line">
                   <Text variant="mono" size="tiny" color="dim" className="leading-none">ESC</Text>
@@ -240,7 +249,7 @@ export function GlobalSearch() {
                 <Text variant="mono" size="micro" color="dim" className="leading-none opacity-70">SELECT</Text>
               </Box>
             </Box>
-            <Text variant="mono" size="micro" color="dim" weight="font-bold" tracking="widest" className="opacity-70">
+            <Text variant="mono" size="micro" color="dim" weight="font-bold" tracking="widest" className="opacity-70 whitespace-nowrap text-center">
               {results.length} RESULTS FOUND
             </Text>
           </Box>

--- a/src/components/GlobalSearch.tsx
+++ b/src/components/GlobalSearch.tsx
@@ -249,7 +249,7 @@ export function GlobalSearch() {
                 <Text variant="mono" size="micro" color="dim" className="leading-none opacity-70">SELECT</Text>
               </Box>
             </Box>
-            <Text variant="mono" size="micro" color="dim" weight="font-bold" tracking="widest" opacity={0.7} nowrap align="center">
+            <Text variant="mono" size="micro" color="dim" weight="font-bold" tracking="widest" nowrap align="center" className="opacity-70">
               {results.length} RESULTS FOUND
             </Text>
           </Box>

--- a/src/components/GlobalSearch.tsx
+++ b/src/components/GlobalSearch.tsx
@@ -249,7 +249,7 @@ export function GlobalSearch() {
                 <Text variant="mono" size="micro" color="dim" className="leading-none opacity-70">SELECT</Text>
               </Box>
             </Box>
-            <Text variant="mono" size="micro" color="dim" weight="font-bold" tracking="widest" nowrap align="center" className="opacity-70">
+            <Text variant="mono" size="micro" color="dim" weight="font-bold" tracking="widest" align="center" className="opacity-70 whitespace-nowrap">
               {results.length} RESULTS FOUND
             </Text>
           </Box>

--- a/src/components/GlobalSearch.tsx
+++ b/src/components/GlobalSearch.tsx
@@ -249,7 +249,7 @@ export function GlobalSearch() {
                 <Text variant="mono" size="micro" color="dim" className="leading-none opacity-70">SELECT</Text>
               </Box>
             </Box>
-            <Text variant="mono" size="micro" color="dim" weight="font-bold" tracking="widest" className="opacity-70 whitespace-nowrap text-center">
+            <Text variant="mono" size="micro" color="dim" weight="font-bold" tracking="widest" opacity={0.7} nowrap align="center">
               {results.length} RESULTS FOUND
             </Text>
           </Box>

--- a/src/layouts/Text.tsx
+++ b/src/layouts/Text.tsx
@@ -22,6 +22,8 @@ export interface TextProps extends Omit<BaseProps, "align">, Omit<HTMLAttributes
   capitalize?: ResponsiveProp<boolean>
   clamp?: ResponsiveProp<number | boolean>
   truncate?: ResponsiveProp<boolean>
+  nowrap?: ResponsiveProp<boolean>
+  opacity?: ResponsiveProp<number | string>
   leading?: ResponsiveProp<"none" | "tight" | "snug" | "normal" | "relaxed" | "loose" | string>
   [key: string]: unknown
 }
@@ -31,7 +33,7 @@ export const Text = forwardRef<HTMLElement, TextProps>(
     className, as: Component = "span", 
     variant, intent, color = "main", size, weight, align, tracking, 
     uppercase, lowercase, capitalize,
-    clamp, truncate, leading,
+    clamp, truncate, nowrap, opacity: opacityProp, leading,
     ...props 
   }, ref) => {
     // Standard JIT fallback for arbitrary values
@@ -76,6 +78,8 @@ export const Text = forwardRef<HTMLElement, TextProps>(
           getResponsiveClasses(capitalize, "", (v) => v ? "capitalize" : "normal-case"),
           getResponsiveClasses(clamp, "", (v) => (typeof v === "number" ? `line-clamp-${v}` : (v ? "line-clamp-none" : ""))),
           getResponsiveClasses(truncate, "", (v) => v ? "truncate" : ""),
+          getResponsiveClasses(nowrap, "", (v) => v ? "whitespace-nowrap" : ""),
+          getResponsiveClasses(opacityProp, "opacity-", (v) => typeof v === "number" ? (v * 100).toString() : v as string),
           getResponsiveClasses(leading, "", (v) => resolveJIT(v as string | number, "leading")),
           className
         )}

--- a/src/layouts/Text.tsx
+++ b/src/layouts/Text.tsx
@@ -22,7 +22,6 @@ export interface TextProps extends Omit<BaseProps, "align">, Omit<HTMLAttributes
   capitalize?: ResponsiveProp<boolean>
   clamp?: ResponsiveProp<number | boolean>
   truncate?: ResponsiveProp<boolean>
-  nowrap?: ResponsiveProp<boolean>
   leading?: ResponsiveProp<"none" | "tight" | "snug" | "normal" | "relaxed" | "loose" | string>
   [key: string]: unknown
 }
@@ -32,7 +31,7 @@ export const Text = forwardRef<HTMLElement, TextProps>(
     className, as: Component = "span", 
     variant, intent, color = "main", size, weight, align, tracking, 
     uppercase, lowercase, capitalize,
-    clamp, truncate, nowrap, leading,
+    clamp, truncate, leading,
     ...props 
   }, ref) => {
     // Standard JIT fallback for arbitrary values
@@ -77,7 +76,6 @@ export const Text = forwardRef<HTMLElement, TextProps>(
           getResponsiveClasses(capitalize, "", (v) => v ? "capitalize" : "normal-case"),
           getResponsiveClasses(clamp, "", (v) => (typeof v === "number" ? `line-clamp-${v}` : (v ? "line-clamp-none" : ""))),
           getResponsiveClasses(truncate, "", (v) => v ? "truncate" : ""),
-          getResponsiveClasses(nowrap, "", (v) => v ? "whitespace-nowrap" : ""),
           getResponsiveClasses(leading, "", (v) => resolveJIT(v as string | number, "leading")),
           className
         )}

--- a/src/layouts/Text.tsx
+++ b/src/layouts/Text.tsx
@@ -23,7 +23,6 @@ export interface TextProps extends Omit<BaseProps, "align">, Omit<HTMLAttributes
   clamp?: ResponsiveProp<number | boolean>
   truncate?: ResponsiveProp<boolean>
   nowrap?: ResponsiveProp<boolean>
-  opacity?: ResponsiveProp<number | string>
   leading?: ResponsiveProp<"none" | "tight" | "snug" | "normal" | "relaxed" | "loose" | string>
   [key: string]: unknown
 }
@@ -33,7 +32,7 @@ export const Text = forwardRef<HTMLElement, TextProps>(
     className, as: Component = "span", 
     variant, intent, color = "main", size, weight, align, tracking, 
     uppercase, lowercase, capitalize,
-    clamp, truncate, nowrap, opacity: opacityProp, leading,
+    clamp, truncate, nowrap, leading,
     ...props 
   }, ref) => {
     // Standard JIT fallback for arbitrary values
@@ -79,7 +78,6 @@ export const Text = forwardRef<HTMLElement, TextProps>(
           getResponsiveClasses(clamp, "", (v) => (typeof v === "number" ? `line-clamp-${v}` : (v ? "line-clamp-none" : ""))),
           getResponsiveClasses(truncate, "", (v) => v ? "truncate" : ""),
           getResponsiveClasses(nowrap, "", (v) => v ? "whitespace-nowrap" : ""),
-          getResponsiveClasses(opacityProp, "opacity-", (v) => typeof v === "number" ? (v * 100).toString() : v as string),
           getResponsiveClasses(leading, "", (v) => resolveJIT(v as string | number, "leading")),
           className
         )}


### PR DESCRIPTION
The search results indicator in the Global Search modal was being partially cut off on small mobile devices (like the iPhone SE or 320px viewports) because it was competing for space with keyboard shortcut hints.

Changes:
- Hidden keyboard shortcut hints (ESC, SELECT) on mobile using `display={{ base: "none", md: "flex" }}`.
- Centered the "RESULTS FOUND" indicator on mobile.
- Adjusted horizontal padding for the footer using responsive props.
- Added `whitespace-nowrap` and `text-center` to the indicator text for robust layout.

Verified with Playwright screenshots on 320px and 1280px viewports. Existing search E2E tests pass.

Fixes #1103

---
*PR created automatically by Jules for task [5919997160188172631](https://jules.google.com/task/5919997160188172631) started by @arii*