### PR TITLE
Icon Normalization Helper

### DIFF
--- a/src/components/ui/Icon.tsx
+++ b/src/components/ui/Icon.tsx
@@ -10,9 +10,11 @@ const iconVariants = cva("shrink-0 inline-flex items-center justify-center", {
       md: "w-5 h-5",
       lg: "w-6 h-6",
       xl: "w-8 h-8",
+      "2xl": "w-12 h-12",
+      "3xl": "w-16 h-16",
     },
     color: {
-      default: "text-text-main",
+      primary: "text-text-main",
       dim: "text-text-dim",
       accent: "text-accent",
       muted: "text-text-dim opacity-50",
@@ -20,7 +22,7 @@ const iconVariants = cva("shrink-0 inline-flex items-center justify-center", {
   },
   defaultVariants: {
     size: "md",
-    color: "default",
+    color: "primary",
   },
 })
 

--- a/src/features/research/ResearchAnalytics.tsx
+++ b/src/features/research/ResearchAnalytics.tsx
@@ -63,7 +63,7 @@ export default function ResearchAnalytics() {
                 </Stack>
                 <Box display="flex" align="center" gap={2} marginTop="auto">
                   <Text weight="font-bold" size="xs" uppercase tracking="widest" color="accent">Launch Console</Text>
-                  <Icon icon={ArrowRight} size="sm" color="accent" />
+                  <Icon icon={ArrowRight} size="md" color="accent" />
                 </Box>
               </Stack>
             ))}
@@ -108,7 +108,7 @@ export default function ResearchAnalytics() {
           ) : (
             <Box padding={6} border radius="lg" position="relative" overflow="hidden" surface="surface" textAlign="center">
               <Stack align="center" justify="center" gap={2}>
-                <Box color="dim">
+                <Box>
                   <Icon icon={Database} size="lg" color="muted" />
                 </Box>
                 <Stack gap={0.5}>

--- a/src/features/research/ResearchAnalytics.tsx
+++ b/src/features/research/ResearchAnalytics.tsx
@@ -45,8 +45,8 @@ export default function ResearchAnalytics() {
               >
                 <Stack gap={4} width="full">
                   <Box display="flex" justify="between" align="start" width="full">
-                    <Box width={10} height={10} surface="muted" border radius="md" display="flex" align="center" justify="center" color="dim">
-                      <Icon icon={Search} size="md" />
+                    <Box width={10} height={10} surface="muted" border radius="md" display="flex" align="center" justify="center">
+                      <Icon icon={Search} size="md" color="dim" />
                     </Box>
                     <Text size="micro" weight="font-bold" uppercase tracking="widest" color="accent">
                       {tool.status}
@@ -61,9 +61,9 @@ export default function ResearchAnalytics() {
                     </Text>
                   </Stack>
                 </Stack>
-                <Box display="flex" align="center" gap={2} marginTop="auto" color="accent">
-                  <Text weight="font-bold" size="xs" uppercase tracking="widest">Launch Console</Text>
-                  <Icon icon={ArrowRight} />
+                <Box display="flex" align="center" gap={2} marginTop="auto">
+                  <Text weight="font-bold" size="xs" uppercase tracking="widest" color="accent">Launch Console</Text>
+                  <Icon icon={ArrowRight} size="sm" color="accent" />
                 </Box>
               </Stack>
             ))}
@@ -98,9 +98,9 @@ export default function ResearchAnalytics() {
                       {study.excerpt}
                     </Text>
                   </Stack>
-                  <Box display="flex" align="center" gap={2} color="accent" marginTop="auto">
-                    <Text variant="mono" size="xs" weight="font-bold" uppercase tracking="widest">Read Study</Text>
-                    <Icon icon={FileText} size="sm" />
+                  <Box display="flex" align="center" gap={2} marginTop="auto">
+                    <Text variant="mono" size="xs" weight="font-bold" uppercase tracking="widest" color="accent">Read Study</Text>
+                    <Icon icon={FileText} size="sm" color="accent" />
                   </Box>
                 </Stack>
               ))}
@@ -108,8 +108,8 @@ export default function ResearchAnalytics() {
           ) : (
             <Box padding={6} border radius="lg" position="relative" overflow="hidden" surface="surface" textAlign="center">
               <Stack align="center" justify="center" gap={2}>
-                <Box color="dim" opacity={0.4}>
-                  <Icon icon={Database} size="lg" />
+                <Box color="dim">
+                  <Icon icon={Database} size="lg" color="muted" />
                 </Box>
                 <Stack gap={0.5}>
                   <Text as="h2" size="lg" weight="font-black" color="accent" uppercase tracking="tight">

--- a/src/pages/UXAuditor.tsx
+++ b/src/pages/UXAuditor.tsx
@@ -75,11 +75,11 @@ function CopyPromptButton({ suggestion }: { suggestion: string }) {
       className="hover:border-accent transition-colors hover:text-accent font-bold text-xs"
     >
       {isCopying ? (
-        <Icon icon={RefreshCw} className="w-3 h-3 animate-spin" />
+        <Icon icon={RefreshCw} size="xs" className="animate-spin" />
       ) : copied ? (
-        <Icon icon={CheckCircle} className="w-3 h-3" color="accent" />
+        <Icon icon={CheckCircle} size="xs" color="accent" />
       ) : (
-        <Icon icon={Copy} className="w-3 h-3" />
+        <Icon icon={Copy} size="xs" />
       )}
       <span>{isCopying ? 'Copying...' : copied ? 'Copied!' : 'Copy Prompt'}</span>
     </Box>
@@ -172,7 +172,7 @@ export default function UXAuditor() {
               <EmptyState
                 compact
                 title="No history"
-                icon={<Icon icon={RefreshCw} size="sm" className="opacity-30" />}
+                icon={<Icon icon={RefreshCw} size="sm" color="muted" />}
               />
             )}
             {reports.map((report) => (
@@ -296,7 +296,7 @@ export default function UXAuditor() {
                           ) : (
                             <Stack align="center" justify="center" color="dim" className="text-center">
                               <Box marginBottom={2}>
-                                <Icon icon={ImageIcon} className="w-12 h-12 opacity-20" />
+                                <Icon icon={ImageIcon} size="2xl" color="muted" />
                               </Box>
                               <Text variant="sans" size="xs" weight="font-bold" uppercase tracking="wider">
                                 Awaiting Frame...
@@ -374,7 +374,7 @@ export default function UXAuditor() {
           ) : (
             <EmptyState
               minHeight={500}
-              icon={<Icon icon={Camera} size="xl" className="opacity-10" />}
+              icon={<Icon icon={Camera} size="xl" color="muted" />}
               title="Ready to Audit"
               description="Enter a URL above to start the visual analysis across Mobile, Tablet, and Desktop."
             />


### PR DESCRIPTION
This change normalizes Lucide icon usage across the application by centralizing sizing and color logic into a shared `Icon` wrapper.

Key changes:
1. **Icon Component Enhancement**: Added semantic color tokens (`primary`, `dim`, `accent`, `muted`) and expanded size tiers (`xs` through `3xl`) in `src/components/ui/Icon.tsx`.
2. **UXAuditor Migration**: Replaced manual sizing classes and opacity overrides in `src/pages/UXAuditor.tsx` with semantic `Icon` props.
3. **ResearchAnalytics Migration**: Updated `src/features/research/ResearchAnalytics.tsx` to use the `Icon` component, ensuring consistent styling and fixing potential visual regressions by applying color tokens directly to components.
4. **Design System Alignment**: Aligned icon usage with the project's design system principles, reducing reliance on raw Tailwind classes for icon styling.

Verification included running full lint and build suites, and visual inspection via Playwright screenshots.

Fixes #1086

---
*PR created automatically by Jules for task [1412885856262221001](https://jules.google.com/task/1412885856262221001) started by @arii*