### PR TITLE
Enhance PR Audit: Integrate CI status and test failure analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ dev-tools/config.json
 __pycache__/
 *.py[cod]
 *$py.class
+*.egg-info/
 .venv/
 venv/
 ENV/

--- a/dev-tools/REVIEW_INSTRUCTIONS.md
+++ b/dev-tools/REVIEW_INSTRUCTIONS.md
@@ -17,9 +17,9 @@ You are responsible for performing high-fidelity technical audits of pull reques
 
 ## 3. Review Status Mapping
 
-- **Approved**: Zero violations.
+- **Approved**: Zero violations AND all critical CI checks passing.
 - **Approved with Minor Changes**: Minor non-breaking violations (e.g., import bloat, trivial token leakage).
-- **Not Approved**: Architectural regressions, breaking changes, or major token violations.
+- **Not Approved**: Architectural regressions, breaking changes, major token violations, OR failing CI checks.
 
 ## 4. Failure Modes (Avoid These)
 

--- a/dev-tools/tdw_services.egg-info/PKG-INFO
+++ b/dev-tools/tdw_services.egg-info/PKG-INFO
@@ -1,0 +1,12 @@
+Metadata-Version: 2.4
+Name: tdw_services
+Version: 0.1.0
+Summary: Tech-Dancer DevTools SDK
+Author: Tech-Dancer Team
+Requires-Python: >=3.8
+Requires-Dist: requests>=2.0.0
+Requires-Dist: google-genai
+Requires-Dist: python-dotenv
+Requires-Dist: pydantic
+Requires-Dist: click
+Requires-Dist: PyGithub

--- a/dev-tools/tdw_services.egg-info/SOURCES.txt
+++ b/dev-tools/tdw_services.egg-info/SOURCES.txt
@@ -1,0 +1,17 @@
+README.md
+pyproject.toml
+tdw_services/__init__.py
+tdw_services/cli.py
+tdw_services/orchestrator.py
+tdw_services.egg-info/PKG-INFO
+tdw_services.egg-info/SOURCES.txt
+tdw_services.egg-info/dependency_links.txt
+tdw_services.egg-info/entry_points.txt
+tdw_services.egg-info/requires.txt
+tdw_services.egg-info/top_level.txt
+tdw_services/handlers/__init__.py
+tdw_services/handlers/command_handler.py
+tdw_services/services/__init__.py
+tdw_services/services/gemini.py
+tdw_services/services/github.py
+tdw_services/services/jules.py

--- a/dev-tools/tdw_services.egg-info/entry_points.txt
+++ b/dev-tools/tdw_services.egg-info/entry_points.txt
@@ -1,0 +1,2 @@
+[console_scripts]
+td-cli = tdw_services.cli:cli

--- a/dev-tools/tdw_services.egg-info/requires.txt
+++ b/dev-tools/tdw_services.egg-info/requires.txt
@@ -1,0 +1,6 @@
+requests>=2.0.0
+google-genai
+python-dotenv
+pydantic
+click
+PyGithub

--- a/dev-tools/tdw_services.egg-info/top_level.txt
+++ b/dev-tools/tdw_services.egg-info/top_level.txt
@@ -1,0 +1,1 @@
+tdw_services

--- a/dev-tools/tdw_services/orchestrator.py
+++ b/dev-tools/tdw_services/orchestrator.py
@@ -62,6 +62,7 @@ class Orchestrator:
         Fetches a PR, its diff, and generates a code review using LocalAI/Gemini.
         """
         pr_details = self.github.fetch_pr_details(pr_number)
+        pr_details['checkResults'] = self.github.fetch_check_runs(pr_details.get('head', {}).get('sha'))
         pr_diff = self.github.fetch_pr_diff(pr_number)
         diff_hash = self._hash_content(pr_diff)
         cache_file = f"/tmp/review_cache_{pr_number}_{diff_hash}.json"
@@ -293,7 +294,24 @@ class Orchestrator:
         if fetch:
             repo = get_github_client().get_repo(get_repo_name()); pr = repo.get_pull(pr_number)
             title = pr.title; author = pr.user.login; desc = pr.body or '_No description provided._'
-            context_lines = [f"# PR Context: #{pr.number} — {title}", f"**Author:** @{author}\n", f"## Description\n{desc}\n", "## Files Changed"]
+            context_lines = [f"# PR Context: #{pr.number} — {title}", f"**Author:** @{author}\n", f"## Description\n{desc}\n", "## CI Status"]
+
+            check_runs = self.github.fetch_check_runs(pr.head.sha)
+            if check_runs:
+                for run in check_runs:
+                    status_icon = '✅' if run.get('conclusion') == 'success' else '❌' if run.get('conclusion') == 'failure' else '⏳'
+                    context_lines.append(f"- {status_icon} **{run.get('name')}**: {run.get('status')} ({run.get('conclusion') or 'in_progress'})")
+                    if run.get('conclusion') == 'failure':
+                        logs = self.github.fetch_check_run_logs(run.get('id'))
+                        # Extract a snippet of the logs (last 50 lines or search for 'error')
+                        log_lines = logs.splitlines()
+                        error_lines = [l for l in log_lines if 'error' in l.lower() or 'fail' in l.lower()]
+                        snippet = "\n".join(error_lines[-20:] if error_lines else log_lines[-30:])
+                        context_lines.append(f"  <details><summary>Failure Logs Snippet</summary>\n\n  ```\n  {snippet}\n  ```\n  </details>")
+            else:
+                context_lines.append("_No check runs found._")
+
+            context_lines.extend(["\n## Files Changed"])
             for f in pr.get_files(): context_lines.append(f"- {'🟢' if f.status=='added' else '🔴' if f.status=='removed' else '🟡'} `{f.filename}`")
             context_lines.append("\n## Diffs")
             for f in pr.get_files():
@@ -469,17 +487,36 @@ class Orchestrator:
 
     def fix_ci(self, pr_number=None, branch=None, api_key=None, dry_run=True):
         repo_name = get_repo_name(); g = get_github_client(); repo = g.get_repo(repo_name)
-        if pr_number: pr = repo.get_pull(int(pr_number)); branch = pr.head.ref
+        if pr_number:
+            pr = repo.get_pull(int(pr_number))
+            branch = pr.head.ref
         elif branch: pulls = list(repo.get_pulls(state='open', head=f"{repo.owner.login}:{branch}")); pr = pulls[0] if pulls else None
         else:
             branch = run_command(['git', 'branch', '--show-current']).strip()
             pulls = list(repo.get_pulls(state='open', head=f"{repo.owner.login}:{branch}")); pr = pulls[0] if pulls else None
+
+        if not pr:
+            raise CLIError(f"Could not find PR for branch {branch}")
+
         if api_key: self.jules.api_key = api_key
+
+        # Analyze failing check runs
+        check_runs = self.github.fetch_check_runs(pr.head.sha)
+        failing_logs = []
+        for run in check_runs:
+            if run.get('conclusion') == 'failure':
+                logs = self.github.fetch_check_run_logs(run.get('id'))
+                failing_logs.append(f"Check Run: {run.get('name')}\nLogs:\n{logs[-2000:]}") # Last 2000 chars
+
+        prompt = "Analyze the failing CI logs and fix the errors."
+        if failing_logs:
+            prompt += "\n\nFailing Logs:\n" + "\n---\n".join(failing_logs)
+
         source_id = self.get_env_or_gha("JULES_SOURCE_ID") or self.jules.discover_source_id(repo_name)
         if not source_id: raise CLIError("JULES_SOURCE_ID missing and auto-discovery failed.")
         session_name = "dry-run-session"
         if not dry_run:
-            res = self.jules.create_session_from_source(source_id, branch, "Analyze the failing CI logs and fix the errors.")
+            res = self.jules.create_session_from_source(source_id, branch, prompt)
             if res: session_name = res.get("name")
             else: raise CLIError("Jules API session creation failed")
         feedback = f"🤖 **Jules is on it!**\n\nInitialized autonomous repair session (`{session_name}`) for branch `{branch}`."

--- a/dev-tools/tdw_services/services/gemini.py
+++ b/dev-tools/tdw_services/services/gemini.py
@@ -111,6 +111,11 @@ class LocalAIClient:
         prompt = f"""Perform Code Review for PR #{pr.get('number')} - "{pr.get('title')}".
 Description: {pr.get('body', 'No description')}
 Checks: {checks_summary}
+
+IMPORTANT:
+- If ANY critical CI check has failed (conclusion='failure'), you MUST NOT recommend 'Approved'.
+- Analyze any failing test logs provided in the description or check results to suggest specific fixes.
+
 Diff: {diff[:45000]}"""
 
         schema = {
@@ -127,6 +132,14 @@ Diff: {diff[:45000]}"""
         try:
             # Clean markdown JSON block if Ollama returned it
             res = self.clean_llm_output(res)
-            return json.loads(res)
+            review = json.loads(res)
+
+            # Enforce CI status check logic
+            has_failures = any(c.get('conclusion') == 'failure' for c in pr.get('checkResults', []))
+            if has_failures and review.get('recommendation') == 'Approved':
+                 review['recommendation'] = 'Not Approved'
+                 review['reviewComment'] = "CI checks are failing. Review recommendation downgraded to 'Not Approved'.\n\n" + review['reviewComment']
+
+            return review
         except Exception:
             return {"reviewComment": "Failed to parse AI review", "labels": [], "recommendation": "Not Approved"}

--- a/dev-tools/tdw_services/services/github.py
+++ b/dev-tools/tdw_services/services/github.py
@@ -76,6 +76,7 @@ class GitHubClient:
         try:
             data = self._request('GET', f'/repos/{self.repo}/commits/{ref}/check-runs')
             return [{
+                'id': run.get('id'),
                 'name': run.get('name'),
                 'status': run.get('status'),
                 'conclusion': run.get('conclusion'),
@@ -83,6 +84,14 @@ class GitHubClient:
             } for run in data.get('check_runs', [])]
         except:
             return []
+
+    def fetch_check_run_logs(self, check_run_id: int) -> str:
+        """Fetches logs for a specific check run."""
+        try:
+            # GitHub API returns a 302 redirect to a URL that expires after a few minutes
+            return self._request('GET', f'/repos/{self.repo}/check-runs/{check_run_id}/logs', is_text=True)
+        except Exception as e:
+            return f"Failed to fetch logs for check run {check_run_id}: {str(e)}"
 
     def create_issue_comment(self, number: int, body: str) -> Dict[str, Any]:
         return self._request('POST', f'/repos/{self.repo}/issues/{number}/comments', json_data={'body': body})


### PR DESCRIPTION
This PR enhances the automated PR audit and repair workflows by integrating real-time CI check status from GitHub Actions. 

Key changes:
- **CI Data Integration**: The `GitHubClient` now retrieves check run IDs and logs. The `Orchestrator` uses this to append a "CI Status" section to the PR context file, including snippets of logs for failing runs.
- **Programmatic Approval Guard**: The `LocalAIClient` now programmatically downgrades any AI-generated "Approved" recommendation to "Not Approved" if any critical CI checks have failed.
- **Actionable Repair**: The `fix-ci` command now fetches logs from failing check runs and injects them into the Jules repair prompt, enabling more accurate autonomous fixes.
- **Process Updates**: Technical audit instructions were updated to include CI status as a blocking requirement for approval. Added `.egg-info/` to `.gitignore`.

Fixes #1209

---
*PR created automatically by Jules for task [3162656202401259781](https://jules.google.com/task/3162656202401259781) started by @arii*