### PR TITLE
Fix route resolution failure for research tools

### DIFF
--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -56,6 +56,16 @@ export const routes: RouteConfig[] = [
     skeleton: 'grid'
   },
   {
+    path: '/research/wcs-scraper',
+    lazy: () => import('@/pages/ResearchDetail').then(m => ({ Component: m.default })),
+    skeleton: 'post'
+  },
+  {
+    path: '/research/wsdc-event-reminders',
+    lazy: () => import('@/pages/ResearchDetail').then(m => ({ Component: m.default })),
+    skeleton: 'post'
+  },
+  {
     path: '/research/:id',
     lazy: () => import('@/pages/ResearchDetail').then(m => ({ Component: m.default })),
     skeleton: 'post'

--- a/src/features/research/ResearchDetail.tsx
+++ b/src/features/research/ResearchDetail.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import { Database, Activity, ArrowLeft, Search } from 'lucide-react';
 import { Box, Stack, Text, Grid } from '@/layouts/Primitives';
 import { StatusBadge } from '@/components/ui/StatusBadge';
@@ -20,9 +20,18 @@ const TOOL_REGISTRY: Record<string, ComponentType> = {
 };
 
 export default function ResearchDetail() {
-  const { id } = useParams();
+  const { id: paramId } = useParams();
   const navigate = useNavigate();
+  const { pathname } = useLocation();
   const { getTool, getStudy } = useResearch();
+
+  const id = useMemo(() => {
+    if (paramId) return paramId;
+    if (pathname.startsWith('/research/')) {
+      return pathname.split('/').filter(Boolean).pop();
+    }
+    return null;
+  }, [paramId, pathname]);
 
   const tool = id ? getTool(id) : null;
   const study = !tool && id ? getStudy(id) : null;


### PR DESCRIPTION
This PR fixes the route resolution failure for `/research/wcs-scraper` and other research tools. 

While dynamic routing `/research/:id` was in place, explicit routes are preferred for better SEO and static site generation (stubs). However, `react-router`'s `useParams` hook returns an empty object when an explicit route is matched instead of the parameterized one. 

I've updated `ResearchDetail.tsx` to fallback to manual pathname parsing to resolve the ID in these cases. I also added the requested explicit routes to `src/config/routes.ts`. 

Verified with unit tests and a Playwright visual verification script that navigates to the tool and confirms it renders correctly.

Fixes #1212

---
*PR created automatically by Jules for task [9847086690326593770](https://jules.google.com/task/9847086690326593770) started by @arii*