### PR TITLE
Fix GitHub Pages deployment target repository in CI/CD pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -171,8 +171,7 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           token: ${{ secrets.DEPLOY_TOKEN }}
-          repository-name: arii/arii.github.io
-          branch: main
+          branch: gh-pages
           folder: root-seo
           clean: false # Do not delete other files in arii.github.io
 
@@ -181,8 +180,7 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           token: ${{ secrets.DEPLOY_TOKEN }}
-          repository-name: arii/arii.github.io
-          branch: main
+          branch: gh-pages
           folder: dist
           target-folder: tech-dancer
           clean: true


### PR DESCRIPTION
The GitHub Actions deployment pipeline was failing with a 403 Access Denied error because it was explicitly targeting an external root repository (`arii/arii.github.io`) that the runner did not have permissions to push to.

This PR:
1. Removes `repository-name: arii/arii.github.io` from the `deploy.yml` workflow.
2. Updates the target `branch` from `main` to `gh-pages` for the deployment steps, ensuring artifacts are pushed to the correct local branch for project-page hosting.

These changes allow the workflow to default to the local `arii/tech-dancer` repository, resolving the permission issues while maintaining the desired subdirectory deployment structure.

Fixes #1181

---
*PR created automatically by Jules for task [2243731744067732140](https://jules.google.com/task/2243731744067732140) started by @arii*