### PR TITLE
Refactor EventCard to use semantic button

### DIFF
--- a/src/components/ui/EventCard.tsx
+++ b/src/components/ui/EventCard.tsx
@@ -5,16 +5,23 @@ interface EventCardProps {
   name: string;
   location: string;
   schedule: string;
+  onClick?: () => void;
 }
 
-export function EventCard({ name, location, schedule }: EventCardProps) {
+export function EventCard({ name, location, schedule, onClick }: EventCardProps) {
   return (
     <Stack
+      as={onClick ? "button" : "div"}
+      type={onClick ? "button" : undefined}
+      onClick={onClick}
       padding={8}
       radius="md"
       border
       gap={4}
       height="full"
+      width="full"
+      textAlign="left"
+      cursor={onClick ? "pointer" : "default"}
       className="bg-surface hover:border-accent/40 transition-all duration-300 hover:-translate-y-0.5"
     >
       <Box display="flex" align="center" gap={2}>
@@ -25,7 +32,7 @@ export function EventCard({ name, location, schedule }: EventCardProps) {
       </Box>
 
       <Stack gap={1}>
-        <Text as="h4" variant="body" size="lg" weight="font-bold" className="text-text-main leading-tight">
+        <Text variant="body" size="lg" weight="font-bold" className="text-text-main leading-tight">
           {name}
         </Text>
         <Text size="sm" color="dim">

--- a/src/features/dashboard/Dashboard.tsx
+++ b/src/features/dashboard/Dashboard.tsx
@@ -11,7 +11,7 @@ import { EventCard } from '@/components/ui/EventCard';
 import { motionTokens } from '@/styles/motion';
 
 export default function Home() {
-  const { recentPosts, upcomingEvents } = useHome();
+  const { recentPosts, upcomingEvents, handleNavigate } = useHome();
 
   return (
     <Box as="section">
@@ -106,12 +106,15 @@ export default function Home() {
             <Grid cols={{ base: 1, sm: 2, lg: 3 }} gap={4}>
               {upcomingEvents.map((event) => (
                 <Box
-                  key={event.name}
+                  key={event.slug}
                   as={motion.div}
                   variants={motionTokens.staggerItem}
                   className="h-full"
                 >
-                  <EventCard {...event} />
+                  <EventCard
+                    {...event}
+                    onClick={() => handleNavigate(`/events/${event.slug}`)}
+                  />
                 </Box>
               ))}
             </Grid>

--- a/src/features/dashboard/useHome.ts
+++ b/src/features/dashboard/useHome.ts
@@ -47,6 +47,7 @@ export function useHome() {
   return { 
     recentPosts, 
     upcomingEvents: upcomingEvents.map(event => ({
+      slug: event.slug,
       name: event.title,
       location: event.location,
       schedule: event.schedule,

--- a/src/features/events/components/RelatedEvents.tsx
+++ b/src/features/events/components/RelatedEvents.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from 'react-router-dom';
 import { Event } from '@/lib/content';
 import { Stack, Grid } from '@/layouts/Primitives';
 import { SectionHeader } from '@/components/ui/SectionHeader';
@@ -9,6 +10,7 @@ interface RelatedEventsProps {
 }
 
 export function RelatedEvents({ title = "Related Events", events }: RelatedEventsProps) {
+  const navigate = useNavigate();
   if (!events || events.length === 0) return null;
 
   return (
@@ -21,6 +23,7 @@ export function RelatedEvents({ title = "Related Events", events }: RelatedEvent
             name={event.title}
             location={event.location}
             schedule={event.schedule}
+            onClick={() => navigate(`/events/${event.slug}`)}
           />
         ))}
       </Grid>


### PR DESCRIPTION
The EventCard component was refactored to use a semantic `<button type="button">` element instead of a generic `div` when it is interactive. This change improves accessibility for screen reader users and keyboard navigation. To maintain HTML validity, the event name within the card was changed from a heading (`h4`) to a styled `span` (via the `Text` primitive), as headings are not permitted inside button elements. 

Additionally, the `useHome` hook and the `Dashboard` component were updated to correctly handle event navigation, and the `RelatedEvents` component was similarly updated. The implementation was verified through design system audits, unit tests, and end-to-end visual regression tests.

Fixes #1176

---
*PR created automatically by Jules for task [15115218665572300871](https://jules.google.com/task/15115218665572300871) started by @arii*