### PR TITLE
Consolidate .no-scrollbar utility into Tailwind configuration

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -177,6 +177,14 @@
   }
 }
 
+@utility no-scrollbar {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+
 @layer base {
   html {
     scroll-behavior: smooth;


### PR DESCRIPTION
The `.no-scrollbar` utility was previously used in the project (e.g., in `FilterBar.tsx`) but was not formally defined in the Tailwind configuration. This PR adds the utility definition to `src/index.css` using the Tailwind CSS v4 `@utility` directive.

Implementation:
```css
@utility no-scrollbar {
  -ms-overflow-style: none;
  scrollbar-width: none;
  &::-webkit-scrollbar {
    display: none;
  }
}
```

Verification:
- `pnpm run build` completed successfully (confirming `@utility` is correctly handled by Tailwind v4).
- `pnpm run audit` passed with no anti-pattern violations.
- `pnpm test` passed all unit tests.
- Visual verification using Playwright confirmed that the `FilterBar` in both desktop and mobile views remains functional and visually correct (scrollbars are hidden as intended).

Note: The issue mentioned removing a manual CSS block from `index.css`, but no such block was found in the current state of the file. The utility was added to provide the missing definition.

Fixes #1177

---
*PR created automatically by Jules for task [9806054183237573468](https://jules.google.com/task/9806054183237573468) started by @arii*