### PR TITLE
Fix ESLint failure caused by unused import

### DIFF
--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -1,7 +1,6 @@
 import { test, expect } from './fixtures/visual';
 import type { Page } from '@playwright/test';
 import { IGNORED_ERROR_PATTERNS } from './test-constants';
-import { setupErrorMonitoring } from './fixtures/error-monitoring';
 function isIgnored(msg: string) {
   return IGNORED_ERROR_PATTERNS.some(pattern =>
     pattern instanceof RegExp ? pattern.test(msg) : msg.includes(pattern)


### PR DESCRIPTION
Removes the unused `setupErrorMonitoring` import from `tests/smoke.spec.ts` which was causing `eslint` to fail. All tests and linting steps are now passing.

---
*PR created automatically by Jules for task [8295934985024655691](https://jules.google.com/task/8295934985024655691) started by @arii*