### PR TITLE
Implement idempotent Vercel Log Drains configuration script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,10 @@
 # The URL where this applet is hosted
 VITE_APP_URL="https://boomtick.blog"
 VITE_CONTACT_FORM_ENDPOINT="https://boomtick.blog/api/contact"
+
+# Vercel Log Drains (Automation)
+# Required for scripts/configure-log-drains.mjs
+VERCEL_TOKEN=""
+VERCEL_PROJECT_ID=""
+LOG_DRAIN_URL="https://api.axiom.co/v1/datasets/boomtick-logs/ingest"
+LOG_DRAIN_TOKEN=""

--- a/VERCEL_LOG_DRAINS.md
+++ b/VERCEL_LOG_DRAINS.md
@@ -1,0 +1,71 @@
+# Vercel Log Forwarding (Drains) Configuration Guide
+
+To ensure long-term log retention and centralized observability for boomtick.blog, we use Vercel Log Drains to forward logs to an external destination.
+
+This guide details how to configure log forwarding, specifically using **Axiom** as the reference ingestion target.
+
+## 1. Prerequisites
+
+- Access to the Vercel Project (boomtick.blog) settings.
+- An Axiom account and a dataset created (e.g., `boomtick-logs`).
+- An Axiom API Token with `Ingest` permissions for the dataset.
+
+## 2. Ingestion Target: Axiom
+
+| Parameter | Value |
+|-----------|-------|
+| **Endpoint URL** | `https://api.axiom.co/v1/datasets/<YOUR_DATASET_NAME>/ingest` |
+| **Log Format** | `JSON` |
+| **Custom Headers** | `Authorization: Bearer <YOUR_AXIOM_API_TOKEN>` |
+
+## 3. Configuration Steps (Vercel Dashboard)
+
+1.  **Navigate to Drains**:
+    - Go to your Vercel Project: **boomtick.blog**.
+    - Navigate to **Settings** > **Drains**.
+2.  **Add Drain**:
+    - Click **Add Drain**.
+3.  **Configure Data Type**:
+    - Select **Logs** as the data type.
+4.  **Configure Sources & Environments**:
+    - **Environments**: Enable for `Production` (and optionally `Preview` for debugging).
+    - **Sources**: Select `build`, `edge`, `lambda` (Function logs), `static`, and `firewall`.
+5.  **Configure Destination**:
+    - Select **Custom Endpoint**.
+    - **Endpoint URL**: Enter your Axiom ingestion URL.
+    - **Format**: Select `JSON`.
+    - **Custom Headers**: Add `Authorization: Bearer <YOUR_AXIOM_API_TOKEN>`.
+6.  **Create Drain**:
+    - Click **Create Drain**.
+
+## 4. Verification
+
+After creating the drain, verify the setup:
+
+1.  **Test Payload**: Use the built-in **Test** button in the Vercel Drains settings.
+2.  **Axiom Logs Viewer**: Confirm that the test payload and real-time traffic logs appear in your Axiom dataset.
+3.  **Search & Alert**: Set up searches and alerts in Axiom to monitor for errors or anomalies.
+
+## 5. Automation
+
+For programmatic management, you can use the `scripts/configure-log-drains.mjs` script provided in this repository.
+
+### Setup
+
+1.  Ensure you have a Vercel Access Token.
+2.  Configure your environment variables:
+    ```bash
+    export VERCEL_TOKEN="your_vercel_token"
+    export VERCEL_PROJECT_ID="your_project_id"
+    export LOG_DRAIN_URL="https://api.axiom.co/v1/datasets/<dataset>/ingest"
+    export LOG_DRAIN_TOKEN="your_axiom_token"
+    ```
+3.  Run the configuration script:
+    ```bash
+    node scripts/configure-log-drains.mjs
+    ```
+
+## References
+
+- [Vercel Drains Documentation](https://vercel.com/docs/drains)
+- [Axiom Vercel Integration](https://axiom.co/docs/integrations/vercel)

--- a/scripts/configure-log-drains.mjs
+++ b/scripts/configure-log-drains.mjs
@@ -1,0 +1,163 @@
+/**
+ * Automation script to configure Vercel Log Drains via the REST API.
+ *
+ * Uses the Vercel Drains API (v1/drains) which supports PATCH for updates.
+ *
+ * Usage:
+ *   VERCEL_TOKEN=xxx \
+ *   VERCEL_PROJECT_ID=xxx \
+ *   LOG_DRAIN_URL=https://api.axiom.co/v1/datasets/xxx/ingest \
+ *   LOG_DRAIN_TOKEN=xxx \
+ *   node scripts/configure-log-drains.mjs
+ */
+
+import { env } from 'process';
+
+const {
+  VERCEL_TOKEN,
+  VERCEL_PROJECT_ID,
+  LOG_DRAIN_URL,
+  LOG_DRAIN_TOKEN,
+  VERCEL_TEAM_ID, // Optional: if working in a team scope
+} = env;
+
+const DRAIN_NAME = 'boomtick-axiom-logs';
+
+async function configureLogDrain() {
+  // Validate required environment variables
+  const missing = [];
+  if (!VERCEL_TOKEN) missing.push('VERCEL_TOKEN');
+  if (!VERCEL_PROJECT_ID) missing.push('VERCEL_PROJECT_ID');
+  if (!LOG_DRAIN_URL) missing.push('LOG_DRAIN_URL');
+  if (!LOG_DRAIN_TOKEN) missing.push('LOG_DRAIN_TOKEN');
+
+  if (missing.length > 0) {
+    console.error(`❌ Error: Missing required environment variables: ${missing.join(', ')}`);
+    process.exit(1);
+  }
+
+  const baseUrl = 'https://api.vercel.com/v1/drains';
+  const queryParams = new URLSearchParams();
+  if (VERCEL_TEAM_ID) queryParams.append('teamId', VERCEL_TEAM_ID);
+
+  const queryString = queryParams.toString();
+  const urlWithTeam = (url) => queryString ? `${url}?${queryString}` : url;
+
+  const headers = {
+    'Authorization': `Bearer ${VERCEL_TOKEN}`,
+    'Content-Type': 'application/json',
+  };
+
+  const targetHeaders = {
+    'Authorization': `Bearer ${LOG_DRAIN_TOKEN}`
+  };
+
+  try {
+    console.log(`🔍 Checking for existing Log Drain: ${DRAIN_NAME}...`);
+
+    const listResponse = await fetch(urlWithTeam(baseUrl), { headers });
+
+    if (!listResponse.ok) {
+      const errorData = await listResponse.json().catch(() => ({}));
+      throw new Error(`Failed to list drains: ${listResponse.status} ${JSON.stringify(errorData)}`);
+    }
+
+    const { drains } = await listResponse.json();
+    const existingDrain = drains.find(d => d.name === DRAIN_NAME);
+
+    if (existingDrain) {
+      console.log(`ℹ️ Found existing Log Drain "${DRAIN_NAME}" (ID: ${existingDrain.id}).`);
+
+      // Compare configuration for idempotency
+      const currentUrl = existingDrain.delivery?.endpoint;
+      const currentHeaders = existingDrain.delivery?.headers || {};
+      const currentProjectIds = existingDrain.projectIds || [];
+
+      const sortObject = (obj) => {
+        if (obj === null || typeof obj !== 'object') return obj;
+        return Object.keys(obj).sort().reduce((acc, key) => {
+          acc[key] = sortObject(obj[key]);
+          return acc;
+        }, {});
+      };
+
+      const isUrlMatch = currentUrl === LOG_DRAIN_URL;
+      const isHeadersMatch = JSON.stringify(sortObject(currentHeaders)) === JSON.stringify(sortObject(targetHeaders));
+      const isProjectMatch = currentProjectIds.includes(VERCEL_PROJECT_ID);
+
+      if (isUrlMatch && isHeadersMatch && isProjectMatch) {
+        console.log('✅ Configuration matches target. No updates required.');
+        return;
+      }
+
+      console.log('⚠️ Configuration mismatch detected. Updating existing drain via PATCH...');
+
+      const patchBody = {
+        projectIds: Array.from(new Set([...currentProjectIds, VERCEL_PROJECT_ID])),
+        delivery: {
+          type: 'http',
+          endpoint: LOG_DRAIN_URL,
+          encoding: 'json',
+          headers: targetHeaders
+        }
+      };
+
+      const patchResponse = await fetch(urlWithTeam(`${baseUrl}/${existingDrain.id}`), {
+        method: 'PATCH',
+        headers,
+        body: JSON.stringify(patchBody),
+      });
+
+      if (!patchResponse.ok) {
+        const errorData = await patchResponse.json().catch(() => ({}));
+        throw new Error(`Failed to update drain: ${patchResponse.status} ${JSON.stringify(errorData)}`);
+      }
+
+      console.log(`✨ Successfully synchronized Log Drain: ${existingDrain.id}`);
+      return;
+    }
+
+    console.log(`🚀 Creating new Log Drain: ${DRAIN_NAME}...`);
+
+    const body = {
+      name: DRAIN_NAME,
+      projectIds: [VERCEL_PROJECT_ID],
+      schemas: {
+        log: 'v1'
+      },
+      delivery: {
+        type: 'http',
+        endpoint: LOG_DRAIN_URL,
+        encoding: 'json',
+        headers: targetHeaders
+      },
+      sampling: [
+        {
+          type: 'head_sampling',
+          rate: 1, // 100% sampling (1.0)
+          env: 'production'
+        }
+      ]
+    };
+
+    const createResponse = await fetch(urlWithTeam(baseUrl), {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+    });
+
+    if (!createResponse.ok) {
+      const errorData = await createResponse.json().catch(() => ({}));
+      throw new Error(`Failed to create drain: ${createResponse.status} ${JSON.stringify(errorData)}`);
+    }
+
+    const result = await createResponse.json();
+    console.log(`✨ Successfully created Log Drain: ${result.id}`);
+
+  } catch (error) {
+    console.error(`❌ Error configuring Log Drain: ${error.message}`);
+    process.exit(1);
+  }
+}
+
+configureLogDrain();


### PR DESCRIPTION
I have implemented a new automation script, `scripts/configure-log-drains.mjs`, which manages Vercel Log Drains using the REST API. The script is designed to be idempotent: it checks for an existing drain named `boomtick-axiom-logs` and updates it via a `PATCH` request if the endpoint or headers differ from the desired configuration. To ensure stable comparisons, I've included a recursive key-sorting utility for JSON headers.

Additionally, I've provided a comprehensive guide in `VERCEL_LOG_DRAINS.md` and updated `.env.example` to help developers configure the necessary environment variables. All changes have been verified against the project's quality gates, including audits for anti-patterns and a full suite of end-to-end tests.

Fixes #1162

---
*PR created automatically by Jules for task [8849921559043765361](https://jules.google.com/task/8849921559043765361) started by @arii*