### PR TITLE
Fix invalid github action versions in workflows

### DIFF
--- a/.github/workflows/auto-conflict-resolver.yml
+++ b/.github/workflows/auto-conflict-resolver.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Create or update comment
         if: env.PR_NUMBER && env.PR_NUMBER != '0'
-        uses: peter-evans/create-or-update-comment@v5
+        uses: peter-evans/create-or-update-comment@v4
         with:
           issue-number: ${{ env.PR_NUMBER }}
           body: |
@@ -88,7 +88,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout base repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -124,7 +124,7 @@ jobs:
 
       - name: Comment on validation failure
         if: steps.validate_branches.outputs.skipped == 'true' && env.PR_NUMBER && env.PR_NUMBER != '0'
-        uses: peter-evans/create-or-update-comment@v5
+        uses: peter-evans/create-or-update-comment@v4
         with:
           issue-number: ${{ env.PR_NUMBER }}
           body: |
@@ -208,7 +208,7 @@ jobs:
 
       - name: Update comment on success
         if: steps.validate_branches.outputs.skipped != 'true' && steps.merge.outputs.merge_failed != 'true' && success() && steps.resolve.outputs.unresolved-files == '' && env.PR_NUMBER && env.PR_NUMBER != '0'
-        uses: peter-evans/create-or-update-comment@v5
+        uses: peter-evans/create-or-update-comment@v4
         with:
           issue-number: ${{ env.PR_NUMBER }}
           body: |
@@ -219,7 +219,7 @@ jobs:
 
       - name: Update comment on failure
         if: steps.validate_branches.outputs.skipped != 'true' && steps.merge.outputs.merge_failed != 'true' && steps.resolve.outputs.unresolved-files != '' && env.PR_NUMBER && env.PR_NUMBER != '0'
-        uses: peter-evans/create-or-update-comment@v5
+        uses: peter-evans/create-or-update-comment@v4
         with:
           issue-number: ${{ env.PR_NUMBER }}
           body: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,15 +51,15 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           cache: pnpm
@@ -103,15 +103,15 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           cache: pnpm
@@ -150,13 +150,13 @@ jobs:
     timeout-minutes: 40
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           cache: pnpm
@@ -184,7 +184,7 @@ jobs:
 
       - name: Cache Playwright Browsers
         id: playwright-cache
-        uses: actions/cache@v5
+        uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
@@ -216,7 +216,7 @@ jobs:
 
       - name: Upload Test Results
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: playwright-report
           path: playwright-report/

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@v4
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v4

--- a/.github/workflows/conflict-check.yml
+++ b/.github/workflows/conflict-check.yml
@@ -13,7 +13,7 @@ jobs:
   conflict-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,13 +22,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
@@ -182,7 +182,7 @@ jobs:
           clean: true
 
       - name: Update Deployment Feedback
-        uses: actions/github-script@v9
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/issue_to_pr.yml
+++ b/.github/workflows/issue_to_pr.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: '3.x'
 
@@ -71,7 +71,7 @@ jobs:
               f.write(f"SAFE_TITLE={safe_title}\n")
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "docs: add content from issue #${{ github.event.issue.number }}"

--- a/.github/workflows/jules-fix-trigger.yml
+++ b/.github/workflows/jules-fix-trigger.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: '3.x'
 

--- a/.github/workflows/ollama-chatops.yml
+++ b/.github/workflows/ollama-chatops.yml
@@ -69,7 +69,7 @@ jobs:
         run: |
           PR_JSON=$(gh pr view "${{ github.event.issue.number }}" --json headRefName)
           HEAD_REF=$(echo "$PR_JSON" | jq -r .headRefName)
-          echo "HEAD_REF=$HEAD_REF" >> $GITHUB_ENV
+          echo "HEAD_REF=$HEAD_REF" >> "$GITHUB_ENV"
           gh pr checkout "${{ github.event.issue.number }}"
 
       - name: Execute Command

--- a/.github/workflows/ollama-chatops.yml
+++ b/.github/workflows/ollama-chatops.yml
@@ -79,9 +79,9 @@ jobs:
           COMMAND_BODY: ${{ github.event.comment.body }}
         run: |
           python3 dev-tools/td_cli.py ai comment \
-            --pr ${{ github.event.issue.number }} \
+            --pr "${{ github.event.issue.number }}" \
             --command "$COMMAND_BODY" \
-            --comment-id ${{ github.event.comment.id }}
+            --comment-id "${{ github.event.comment.id }}"
 
       - name: Commit Fixes
         if: startsWith(github.event.comment.body, '/ollama-fix')

--- a/.github/workflows/prune-stale-previews.yml
+++ b/.github/workflows/prune-stale-previews.yml
@@ -16,7 +16,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout gh-pages
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           ref: gh-pages
           path: gh-pages-branch

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -30,13 +30,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -68,7 +68,7 @@ jobs:
       image: returntocorp/semgrep
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Semgrep Scan
         run: semgrep scan --config auto --error

--- a/.github/workflows/self-healing.yml
+++ b/.github/workflows/self-healing.yml
@@ -33,7 +33,7 @@ jobs:
       OLLAMA_MODEL: "qwen2.5-coder:1.5b"
     steps:
       - name: Checkout trusted code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
@@ -59,10 +59,10 @@ jobs:
           gh pr checkout "$ISSUE_NUMBER"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           cache: pnpm

--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: Create initial comment
         id: initial-comment
-        uses: peter-evans/create-or-update-comment@v5
+        uses: peter-evans/create-or-update-comment@v4
         with:
           issue-number: ${{ github.event.issue.number }}
           body: |
@@ -35,7 +35,7 @@ jobs:
             --jq '"HEAD_REF=" + .head.ref, "HEAD_REPO=" + .head.repo.full_name' >> "$GITHUB_ENV"
 
       - name: Checkout source branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           ref: ${{ env.HEAD_REF }}
           repository: ${{ env.HEAD_REPO }}
@@ -43,10 +43,10 @@ jobs:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           cache: pnpm
@@ -82,7 +82,7 @@ jobs:
 
       - name: Update comment on success
         if: success()
-        uses: peter-evans/create-or-update-comment@v5
+        uses: peter-evans/create-or-update-comment@v4
         with:
           comment-id: ${{ steps.initial-comment.outputs.comment-id }}
           body: |
@@ -92,7 +92,7 @@ jobs:
 
       - name: Update comment on failure
         if: failure()
-        uses: peter-evans/create-or-update-comment@v5
+        uses: peter-evans/create-or-update-comment@v4
         with:
           comment-id: ${{ steps.initial-comment.outputs.comment-id }}
           body: |

--- a/.github/workflows/validate_issue.yml
+++ b/.github/workflows/validate_issue.yml
@@ -12,8 +12,8 @@ jobs:
       issues: write
       contents: read
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
       - run: pip install PyGithub click

--- a/.github/workflows/wcs_etl.yml
+++ b/.github/workflows/wcs_etl.yml
@@ -13,12 +13,12 @@ jobs:
       contents: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           lfs: true
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -30,7 +30,7 @@ jobs:
 
       - name: Cache Playwright Browsers
         id: cache-playwright
-        uses: actions/cache@v5
+        uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
           key: playwright-etl-${{ runner.os }}-chromium-v1

--- a/.github/workflows/workflow-validation.yml
+++ b/.github/workflows/workflow-validation.yml
@@ -23,7 +23,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Download actionlint
         id: get_actionlint


### PR DESCRIPTION
Fix invalid github action versions in workflows

Many `.github/workflows` files were pointing to non-existent major versions of actions such as `actions/checkout@v6`, `actions/setup-node@v6`, etc. This commit rolls them back to the stable and valid versions (e.g., `v4`, `v5`) to prevent CI checks from failing immediately.

---
*PR created automatically by Jules for task [4605918413780211366](https://jules.google.com/task/4605918413780211366) started by @arii*