### PR TITLE
Consolidate initial data pattern and refactor to useQuery

### DIFF
--- a/src/features/dashboard/useHome.ts
+++ b/src/features/dashboard/useHome.ts
@@ -8,25 +8,11 @@ export function useHome() {
   const { data: recentPosts = [] } = useQuery({
     queryKey: ['posts', 'recent'],
     queryFn: () => getPosts().slice(0, 3),
-    initialData: () => {
-      try {
-        return getPosts().slice(0, 3);
-      } catch {
-        return [];
-      }
-    },
   });
 
   const { data: upcomingEvents = [] } = useQuery({
     queryKey: ['events', 'upcoming'],
     queryFn: () => getEvents().slice(0, 3),
-    initialData: () => {
-      try {
-        return getEvents().slice(0, 3);
-      } catch {
-        return [];
-      }
-    },
   });
 
   const dancerPaths = [

--- a/src/features/lab/wsdc-reminders/WSDCReminders.tsx
+++ b/src/features/lab/wsdc-reminders/WSDCReminders.tsx
@@ -1,6 +1,7 @@
 // impeccable-ignore-file
 import { useState, useMemo } from 'react';
 import { Download, Globe, AlertCircle } from 'lucide-react';
+import { useQuery } from '@tanstack/react-query';
 import { Box, Stack, Text, Button } from '@/layouts/Primitives';
 import { getEvents } from '@/lib/content';
 import { calculateTimeline } from './lib/timeline-engine';
@@ -11,8 +12,20 @@ import { EventSelector } from './EventSelector';
 import { CustomEventForm } from './CustomEventForm';
 
 export default function WSDCReminders() {
-  const events = useMemo(() => getEvents().filter(e => e.startDate && e.earlyBirdDate && e.hotelCutoffDate), []);
-  const [selectedEventId, setSelectedEventId] = useState<string>(events[0]?.slug || 'custom');
+  const { data: events = [] } = useQuery({
+    queryKey: ['events', 'reminders'],
+    queryFn: () => getEvents().filter(e => e.startDate && e.earlyBirdDate && e.hotelCutoffDate),
+  });
+
+  const [selectedEventId, setSelectedEventId] = useState<string>('custom');
+
+  // Sync initial selection when events load
+  const [hasInitialized, setHasInitialized] = useState(false);
+  if (!hasInitialized && events.length > 0 && selectedEventId === 'custom' && !customEvent.title) {
+    setSelectedEventId(events[0].slug);
+    setHasInitialized(true);
+  }
+
   const [customEvent, setCustomEvent] = useState<EventAnchors>({
     title: '',
     startDate: '',

--- a/src/features/lab/wsdc-reminders/WSDCReminders.tsx
+++ b/src/features/lab/wsdc-reminders/WSDCReminders.tsx
@@ -18,14 +18,6 @@ export default function WSDCReminders() {
   });
 
   const [selectedEventId, setSelectedEventId] = useState<string>('custom');
-
-  // Sync initial selection when events load
-  const [hasInitialized, setHasInitialized] = useState(false);
-  if (!hasInitialized && events.length > 0 && selectedEventId === 'custom' && !customEvent.title) {
-    setSelectedEventId(events[0].slug);
-    setHasInitialized(true);
-  }
-
   const [customEvent, setCustomEvent] = useState<EventAnchors>({
     title: '',
     startDate: '',
@@ -33,6 +25,13 @@ export default function WSDCReminders() {
     hotelCutoffDate: '',
     url: ''
   });
+
+  // Sync initial selection when events load
+  const [hasInitialized, setHasInitialized] = useState(false);
+  if (!hasInitialized && events.length > 0 && selectedEventId === 'custom' && !customEvent.title) {
+    setSelectedEventId(events[0].slug);
+    setHasInitialized(true);
+  }
 
   const activeEvent = useMemo(() => {
     if (selectedEventId === 'custom') return customEvent;


### PR DESCRIPTION
This PR consolidates the initial data pattern by removing synchronous data fetching calls (like `getEvents()` or `getPosts()`) from the initial render path or `initialData` of `useQuery`. This helps prevent potential hydration mismatches in SSR/SSG environments.

Key changes:
- In `src/features/dashboard/useHome.ts`, removed the `initialData` property which performed synchronous content lookups.
- In `src/features/lab/wsdc-reminders/WSDCReminders.tsx`, replaced a synchronous `useMemo` call with a `useQuery` hook and updated the component logic to handle the asynchronous loading state correctly while maintaining valid React patterns (avoiding illegal `setState` in effects or uninitialized state access).
- Verified that the `INITIAL_EVENTS` constant mentioned in the task description does not exist in the current codebase, but addressed the same pattern wherever found.

Fixes #1175

---
*PR created automatically by Jules for task [9090340977542084576](https://jules.google.com/task/9090340977542084576) started by @arii*