### PR TITLE
Cleanup stale CI documentation

### DIFF
--- a/.github/PULL_REQUEST_REVIEW_TEMPLATE.md
+++ b/.github/PULL_REQUEST_REVIEW_TEMPLATE.md
@@ -134,5 +134,5 @@ After completing every file block above, fill in the body below and run the comm
 Command:
 
 ```bash
-python3 dev-tools/submit_pr_review_data.py plan-pr-review-{{NUMBER}}.md
+python3 dev-tools/td_cli.py gh audit-pr {{NUMBER}} --submit --cleanup
 ```


### PR DESCRIPTION
I have scanned the repository documentation for references to removed Python validation scripts. I identified a stale reference to `submit_pr_review_data.py` in `.github/PULL_REQUEST_REVIEW_TEMPLATE.md`, which I updated to use the modern unified CLI command `python3 dev-tools/td_cli.py gh audit-pr {{NUMBER}} --submit --cleanup`. I also verified other documentation files and did not find further stale references to Python validation scripts that required removal.

Fixes #1169

---
*PR created automatically by Jules for task [3588400761122341880](https://jules.google.com/task/3588400761122341880) started by @arii*