### PR TITLE
Optimize Mobile UI: Reduce Event Page vertical bloat

### DIFF
--- a/src/components/ui/EventSidebar.tsx
+++ b/src/components/ui/EventSidebar.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { motion } from 'motion/react';
 import { Plane, Calendar, Hotel, Users, ShieldAlert, ChevronDown, ChevronUp } from 'lucide-react';
 import { Box, Stack, Text } from '@/layouts/Primitives';
 import { Event } from '@/lib/content';

--- a/src/components/ui/EventSidebar.tsx
+++ b/src/components/ui/EventSidebar.tsx
@@ -1,4 +1,6 @@
-import { Plane, Calendar, Hotel, Users, ShieldAlert } from 'lucide-react';
+import { useState } from 'react';
+import { motion } from 'motion/react';
+import { Plane, Calendar, Hotel, Users, ShieldAlert, ChevronDown, ChevronUp } from 'lucide-react';
 import { Box, Stack, Text } from '@/layouts/Primitives';
 import { Event } from '@/lib/content';
 
@@ -25,6 +27,7 @@ interface EventSidebarProps {
 }
 
 export function EventSidebar({ event, startDate, earlyBirdDate, hotelCutoffDate }: EventSidebarProps) {
+  const [isOpen, setIsOpen] = useState(false);
   const finalStartDate = event?.startDate || startDate;
   const finalEarlyBirdDate = event?.earlyBirdDate || earlyBirdDate;
   const finalHotelCutoffDate = event?.hotelCutoffDate || hotelCutoffDate;
@@ -35,19 +38,40 @@ export function EventSidebar({ event, startDate, earlyBirdDate, hotelCutoffDate 
         {event && (
           <Box border radius="lg" padding={6} surface="surface-alt">
             <Stack gap={6}>
-              <Text variant="mono" size="micro" color="accent" weight="font-bold" uppercase tracking="widest">
-                Quick Intelligence
-              </Text>
-              <Stack gap={4}>
-                <Box>
-                  <Text variant="mono" size="micro" color="dim" uppercase>Category</Text>
-                  <Text variant="body" size="sm">{event.category}</Text>
+              <Box
+                display="flex"
+                align="center"
+                justify="between"
+                as="button"
+                onClick={() => setIsOpen(!isOpen)}
+                width="full"
+                className="lg:pointer-events-none"
+                aria-expanded={isOpen}
+                aria-controls="quick-intelligence-content"
+              >
+                <Text variant="mono" size="micro" color="accent" weight="font-bold" uppercase tracking="widest">
+                  Quick Intelligence
+                </Text>
+                <Box display={{ base: 'block', lg: 'none' }}>
+                  {isOpen ? <ChevronUp className="w-4 h-4 text-accent" /> : <ChevronDown className="w-4 h-4 text-accent" />}
                 </Box>
-                <Box>
-                  <Text variant="mono" size="micro" color="dim" uppercase>Registry Status</Text>
-                  <Text variant="body" size="sm">WSDC Verified</Text>
-                </Box>
-              </Stack>
+              </Box>
+
+              <Box
+                id="quick-intelligence-content"
+                display={{ base: isOpen ? "block" : "none", lg: "block" }}
+              >
+                <Stack gap={4}>
+                  <Box>
+                    <Text variant="mono" size="micro" color="dim" uppercase>Category</Text>
+                    <Text variant="body" size="sm">{event.category}</Text>
+                  </Box>
+                  <Box>
+                    <Text variant="mono" size="micro" color="dim" uppercase>Registry Status</Text>
+                    <Text variant="body" size="sm">WSDC Verified</Text>
+                  </Box>
+                </Stack>
+              </Box>
             </Stack>
           </Box>
         )}

--- a/src/features/events/EventGuide.tsx
+++ b/src/features/events/EventGuide.tsx
@@ -60,7 +60,7 @@ export default function EventGuide() {
       <EventNavigation />
 
       <Box maxWidth="screen-xl" marginX="auto" paddingX={{ base: 6, md: 12, lg: 24 }} paddingY={SECTION_SPACING}>
-        <Grid cols={{ base: 1, lg: 3 }} gap={16}>
+        <Grid cols={{ base: 1, lg: 3 }} gap={{ base: 8, lg: 16 }}>
           <Box className="lg:col-span-2">
             <Stack gap={SECTION_SPACING}>
               <EventDetails event={event} />

--- a/src/features/events/components/EventHero.tsx
+++ b/src/features/events/components/EventHero.tsx
@@ -21,7 +21,7 @@ export function EventHero({ title, location, date, image, eyebrow = "Event Guide
     <Box
       position="relative"
       width="full"
-      minHeight={{ base: "40vh", md: "50vh" }}
+      minHeight={{ base: "30vh", md: "50vh" }}
       display="flex"
       align="center"
       overflow="hidden"
@@ -60,7 +60,7 @@ export function EventHero({ title, location, date, image, eyebrow = "Event Guide
         zIndex={10}
         gap={6}
         paddingX={{ base: 6, md: 12, lg: 24 }}
-        paddingY={12}
+        paddingY={{ base: 8, md: 12 }}
         maxWidth="screen-xl"
         marginX="auto"
         width="full"
@@ -83,11 +83,11 @@ export function EventHero({ title, location, date, image, eyebrow = "Event Guide
           <Text
             as="h1"
             variant="headline"
-            size="fluid-9"
+            size="fluid-7"
             weight="font-black"
             color="white"
             leading="tight"
-            tracking="tighter"
+            tracking="tight"
           >
             {title}
           </Text>


### PR DESCRIPTION
This PR optimizes the event page UI for mobile devices to reduce vertical bloat and improve content discoverability.

Key changes:
- **EventHero**: Reduced `minHeight` from 40vh to 30vh and `paddingY` from 12 to 8 on the `base` breakpoint. Adjusted the heading size from `fluid-9` to `fluid-7` and tracking to `tight` for a more compact and standardized look.
- **EventGuide**: Updated the main content grid to use a responsive gap: `8` on mobile and `16` on desktop.
- **EventSidebar**: Added a collapsible toggle for the 'Quick Intelligence' section on mobile, allowing users to hide/show this metadata and pull other content higher up the viewport.

These changes collectively ensure that more high-priority information is visible above the fold on mobile screens.

Fixes #1214

---
*PR created automatically by Jules for task [10711695993855503399](https://jules.google.com/task/10711695993855503399) started by @arii*