### PR TITLE
Add devcontainer and one-step agent setup (Dockerfile, devcontainer.json, setup script, README)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,28 @@
+FROM mcr.microsoft.com/playwright:v1.44.0-jammy
+
+USER root
+
+ENV PNPM_VERSION=10.28.2
+ENV PLAYWRIGHT_BROWSERS_PATH=0
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    curl \
+    jq \
+    git \
+    gh \
+    python3 \
+    python3-pip \
+    python3-venv \
+    python3-setuptools \
+    python3-wheel \
+    build-essential \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g pnpm@${PNPM_VERSION}
+
+RUN mkdir -p /workspace && chown -R pwuser:pwuser /workspace
+
+USER pwuser
+
+WORKDIR /workspace

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,28 @@
+{
+  "name": "BoomTick Agent Dev Environment",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  "workspaceFolder": "/workspace",
+  "remoteUser": "pwuser",
+  "postCreateCommand": "bash ./dev-tools/setup-agent.sh",
+  "containerEnv": {
+    "CI": "1",
+    "PLAYWRIGHT_BROWSERS_PATH": "0",
+    "PNPM_VERSION": "10.28.2",
+    "NODE_MAJOR": "22",
+    "SKIP_APT": "1"
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-azuretools.vscode-docker",
+        "eamodio.gitlens",
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "bradlc.vscode-tailwindcss"
+      ]
+    }
+  }
+}

--- a/dev-tools/README.md
+++ b/dev-tools/README.md
@@ -34,7 +34,7 @@ This script installs and configures:
 |---|---|---|
 | `CODEX_GH_TOKEN` | **Recommended (preferred)** | Primary secret for Codex/Jules agent runs; setup maps it to `GH_TOKEN`/`GITHUB_TOKEN` for `gh` + dev-tools commands. |
 | `GITHUB_TOKEN` or `GH_TOKEN` | Required if `CODEX_GH_TOKEN` is not set | Auth for `gh` and `td_cli.py gh ...` commands (PR audits, comments, variables, status checks). |
-| `GITHUB_REPOSITORY` (`owner/repo`) | Recommended | Ensures deterministic `origin` remote auto-configuration when missing. |
+| `GITHUB_REPOSITORY` (`owner/repo`) | Recommended | Ensures deterministic `origin` remote auto-configuration when missing (or falls back to an existing non-origin remote URL). |
 | `JULES_API_KEY` | Optional | Enables `td_cli.py jules ...` cloud workflows. |
 | `GEMINI_API_KEY` | Optional | Enables Gemini-backed review/audit workflows. |
 | `OLLAMA_URL` | Optional | Override local Ollama endpoint (default shown by `snapshot.sh`). |

--- a/dev-tools/README.md
+++ b/dev-tools/README.md
@@ -114,6 +114,42 @@ Use raw `gh` only when `td_cli.py` does not expose the needed operation.
 
 If auth fails, do not run `gh auth login`. Instead, set a Codex secret named `CODEX_GH_TOKEN`.
 
+
+### Verification Commands (Post-Setup)
+
+Run these commands after setup to verify GitHub/dev-tools workflows:
+
+```bash
+source ./.agent-env.sh 2>/dev/null || true
+python3 dev-tools/td_cli.py gh --help
+python3 dev-tools/td_cli.py gh status-board
+python3 dev-tools/td_cli.py gh conflicts
+```
+
+For PR review flow (example PR number):
+
+```bash
+source ./.agent-env.sh 2>/dev/null || true
+python3 dev-tools/td_cli.py gh audit-pr 123 --fetch --audit
+```
+
+For issue workflow checks:
+
+```bash
+source ./.agent-env.sh 2>/dev/null || true
+python3 dev-tools/td_cli.py gh validate-issue --issue-number 123
+```
+
+If you need to create an issue and the repo CLI does not expose that operation directly, use raw `gh` as fallback:
+
+```bash
+gh issue create --title "<title>" --body "<details>"
+```
+
+If auth fails, report this exact issue (do not run interactive auth):
+
+> GitHub CLI is not authenticated. Please add a Codex environment secret named `CODEX_GH_TOKEN` with a repo-scoped GitHub token.
+
 ## 🚀 Repository CLI (`td_cli.py`)
 
 The unified entry point for all repository automation. It supports both human-readable terminal output and structured JSON for tool integration.

--- a/dev-tools/README.md
+++ b/dev-tools/README.md
@@ -6,6 +6,99 @@ This directory contains repository automation scripts and quality gate configura
 > The Repository CLI requires the `PyGithub` Python library. Install it with: `pip install PyGithub`.
 > It also requires the `gh` CLI to be authenticated for many operations.
 
+
+## 🧰 One-Step Agent Environment Bootstrap
+
+Use `dev-tools/setup-agent.sh` to fully bootstrap a fresh agent/devcontainer environment in one command.
+
+```bash
+./dev-tools/setup-agent.sh
+```
+
+This script installs and configures:
+- System tools needed by dev-tools (`git`, `curl`, `jq`, `gh`, Python toolchain, Node prerequisites).
+- `pnpm` via Corepack (or fallback global install), then project dependencies via `pnpm install --frozen-lockfile`.
+- Python dependencies for `dev-tools` (`pip install -e ./dev-tools`) and ETL (`etl/requirements.txt` when present).
+- Playwright CLI browser/runtime dependencies (`npx playwright install --with-deps chromium`).
+- Git remote origin (if missing) using `GITHUB_REPOSITORY` or a best-effort repo slug guess.
+
+> [!NOTE]
+> For deterministic remote configuration, set `GITHUB_REPOSITORY=<owner>/<repo>` before running the script in brand-new clones.
+
+> [!TIP]
+> In CI or secure agent environments, prefer injecting secrets as environment variables rather than hardcoding them.
+
+### Required / Recommended Environment Variables & Secrets
+
+| Variable | Required? | Purpose |
+|---|---|---|
+| `CODEX_GH_TOKEN` | **Recommended (preferred)** | Primary secret for Codex/Jules agent runs; setup maps it to `GH_TOKEN`/`GITHUB_TOKEN` for `gh` + dev-tools commands. |
+| `GITHUB_TOKEN` or `GH_TOKEN` | Required if `CODEX_GH_TOKEN` is not set | Auth for `gh` and `td_cli.py gh ...` commands (PR audits, comments, variables, status checks). |
+| `GITHUB_REPOSITORY` (`owner/repo`) | Recommended | Ensures deterministic `origin` remote auto-configuration when missing. |
+| `JULES_API_KEY` | Optional | Enables `td_cli.py jules ...` cloud workflows. |
+| `GEMINI_API_KEY` | Optional | Enables Gemini-backed review/audit workflows. |
+| `OLLAMA_URL` | Optional | Override local Ollama endpoint (default shown by `snapshot.sh`). |
+| `OLLAMA_MODEL` | Optional | Override local Ollama model selection. |
+
+**Secret handling guidance**
+- GitHub Actions / agent runners: store `CODEX_GH_TOKEN` (preferred), plus `JULES_API_KEY` and `GEMINI_API_KEY` in repository or org Secrets.
+- Dev containers/local shells: export secrets before running setup/CLI, for example:
+
+```bash
+export CODEX_GH_TOKEN="<token>"
+export GITHUB_REPOSITORY="owner/repo"
+# optional
+export JULES_API_KEY="<key>"
+export GEMINI_API_KEY="<key>"
+```
+
+
+### Setup Script Toggles
+
+`dev-tools/setup-agent.sh` supports optional environment toggles:
+
+- `SKIP_APT=1` — skip OS package installation.
+- `SKIP_PLAYWRIGHT=1` — skip Playwright browser installation.
+- `SKIP_VALIDATION=1` — skip post-install validation checks.
+- `SKIP_REMOTE_CONFIG=1` — skip `origin` remote auto-configuration.
+- `PNPM_VERSION` — override pnpm version (default `10.28.2`).
+- `NODE_MAJOR` — override Node major used for apt installation (default `22`).
+
+
+### Non-Traditional Workflows (Deploy, Jules, Ollama)
+
+After `./dev-tools/setup-agent.sh`, use the following workflow-specific setup:
+
+#### 1) Deploy / GitHub Automation Workflows
+- Ensure GitHub auth is present in env: `GITHUB_TOKEN` or `GH_TOKEN`.
+- Verify CLI auth and repo context:
+  - `gh auth status`
+  - `gh repo view`
+- Pre-submit quality gate before push/merge:
+  - `python3 dev-tools/td_cli.py gh pre-submit`
+
+#### 2) Jules Workflows
+- Required secret: `JULES_API_KEY`.
+- Optional context env vars:
+  - `JULES_SOURCE_ID` (if your environment already knows the source mapping)
+- Typical commands:
+  - `python3 dev-tools/td_cli.py jules repair`
+  - `python3 dev-tools/td_cli.py jules repair --worktree`
+
+#### 3) Ollama Local Review Workflows
+- Optional local runtime vars:
+  - `OLLAMA_URL` (default used by tooling: `http://localhost:11434/api/generate`)
+  - `OLLAMA_MODEL` (example: `qwen2.5-coder:7b`)
+- Verify local service before running Ollama-backed flows:
+  - `curl -fsS "$OLLAMA_URL" || true` (endpoint behavior varies by Ollama version)
+- Typical command:
+  - `python3 dev-tools/td_cli.py gh audit-pr <PR_NUMBER> --fetch --audit`
+
+#### 4) Headless / Bot Auditing
+- For batch auditing open PRs:
+  - `bash dev-tools/audit_headless.sh`
+- Ensure `jq`, `gh`, Python deps, and pnpm deps are installed (handled by setup script).
+
 ## 🚀 Repository CLI (`td_cli.py`)
 
 The unified entry point for all repository automation. It supports both human-readable terminal output and structured JSON for tool integration.

--- a/dev-tools/README.md
+++ b/dev-tools/README.md
@@ -99,6 +99,21 @@ After `./dev-tools/setup-agent.sh`, use the following workflow-specific setup:
   - `bash dev-tools/audit_headless.sh`
 - Ensure `jq`, `gh`, Python deps, and pnpm deps are installed (handled by setup script).
 
+
+### Codex / Jules GitHub Command Pattern
+
+Prefer repository CLI commands over raw `gh`:
+
+```bash
+source ./.agent-env.sh 2>/dev/null || true
+python3 dev-tools/td_cli.py gh --help
+python3 dev-tools/td_cli.py gh <repo-command>
+```
+
+Use raw `gh` only when `td_cli.py` does not expose the needed operation.
+
+If auth fails, do not run `gh auth login`. Instead, set a Codex secret named `CODEX_GH_TOKEN`.
+
 ## 🚀 Repository CLI (`td_cli.py`)
 
 The unified entry point for all repository automation. It supports both human-readable terminal output and structured JSON for tool integration.

--- a/dev-tools/setup-agent.sh
+++ b/dev-tools/setup-agent.sh
@@ -134,7 +134,7 @@ normalize_nvmrc_for_snapshot() {
 }
 
 ensure_corepack_pnpm() { ensure_node; normalize_nvmrc_for_snapshot; have corepack && corepack enable || true; have corepack && corepack prepare "pnpm@${PNPM_VERSION}" --activate || true; have pnpm || npm install -g "pnpm@${PNPM_VERSION}"; }
-install_python_deps() { have python3 || err "python3 is required."; pip_install --root-user-action=ignore --upgrade pip setuptools wheel; if [ -f "dev-tools/pyproject.toml" ]; then (cd "${REPO_ROOT}/dev-tools" && pip_install --root-user-action=ignore --editable .); fi; [ -f "etl/requirements.txt" ] && pip_install --root-user-action=ignore -r etl/requirements.txt; }
+install_python_deps() { have python3 || err "python3 is required."; pip_install --root-user-action=ignore --upgrade pip setuptools wheel; if [ -f "dev-tools/pyproject.toml" ]; then (cd "${REPO_ROOT}/dev-tools" && pip_install --root-user-action=ignore --editable .); fi; pip_install --root-user-action=ignore pyyaml; [ -f "etl/requirements.txt" ] && pip_install --root-user-action=ignore -r etl/requirements.txt; }
 install_node_deps() { have pnpm || err "pnpm is required."; [ -f "package.json" ] || return 0; [ -f "pnpm-lock.yaml" ] && pnpm install --frozen-lockfile || pnpm install; }
 install_playwright() { [ "$SKIP_PLAYWRIGHT" = "1" ] && return 0; [ -f "package.json" ] || return 0; pnpm exec playwright install --with-deps chromium || npx --yes playwright install --with-deps chromium || warn "Playwright install failed; continuing."; }
 configure_remote_origin() { configure_github_auth_env; ensure_remote_origin; }

--- a/dev-tools/setup-agent.sh
+++ b/dev-tools/setup-agent.sh
@@ -82,9 +82,22 @@ ensure_remote_origin() {
   local current repo_slug
   current="$(git remote get-url origin 2>/dev/null || true)"
   if [ -n "$current" ]; then log "remote.origin already configured: ${current}"; return 0; fi
+
+  # If another remote exists (e.g. upstream), mirror its URL into origin.
+  local fallback_remote fallback_url
+  fallback_remote="$(git remote | head -n 1 || true)"
+  if [ -n "$fallback_remote" ]; then
+    fallback_url="$(git remote get-url "$fallback_remote" 2>/dev/null || true)"
+    if [ -n "$fallback_url" ]; then
+      git remote add origin "$fallback_url"
+      log "Configured remote.origin from existing remote '${fallback_remote}' => ${fallback_url}"
+      return 0
+    fi
+  fi
+
   repo_slug="$(repo_slug_from_gh || true)"
   if [ -z "$repo_slug" ]; then
-    warn "No remote.origin and could not infer repo slug. Set GITHUB_REPOSITORY=owner/repo or REPO_SLUG=owner/repo."
+    warn "No remote.origin and could not infer repo slug. Set GITHUB_REPOSITORY, REPO_SLUG, or CODEX_REPOSITORY to owner/repo."
     return 0
   fi
   git remote add origin "https://github.com/${repo_slug}.git"

--- a/dev-tools/setup-agent.sh
+++ b/dev-tools/setup-agent.sh
@@ -1,14 +1,6 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-# Agent setup script for the BoomTick / Tech Dancer repo.
-# Safe to run in Codex, Jules, from the repo root, from ./scripts, or as a pasted setup script.
-
-# -------- repo root detection --------
-# Codex may copy the setup script to /tmp before running it. Jules usually runs
-# setup commands with the cloned repo as the working directory. Prefer the
-# current working directory's git root, then fall back to the script location,
-# then search upward for common repo markers.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd -P || pwd)"
 START_DIR="$(pwd -P)"
 
@@ -32,7 +24,6 @@ find_repo_root() {
 REPO_ROOT="$(find_repo_root "$START_DIR" || find_repo_root "$SCRIPT_DIR" || pwd -P)"
 cd "$REPO_ROOT"
 
-# -------- configuration --------
 PNPM_VERSION="${PNPM_VERSION:-10.28.2}"
 NODE_MAJOR="${NODE_MAJOR:-22}"
 SKIP_APT="${SKIP_APT:-0}"
@@ -44,238 +35,122 @@ export CI="${CI:-1}"
 export DEBIAN_FRONTEND="${DEBIAN_FRONTEND:-noninteractive}"
 export PLAYWRIGHT_BROWSERS_PATH="${PLAYWRIGHT_BROWSERS_PATH:-0}"
 
-# Put npm global installs in user space when running without sudo/root.
 if [ "$(id -u)" -ne 0 ] && ! command -v sudo >/dev/null 2>&1; then
   export NPM_CONFIG_PREFIX="${NPM_CONFIG_PREFIX:-$HOME/.npm-global}"
   export PATH="$NPM_CONFIG_PREFIX/bin:$PATH"
   mkdir -p "$NPM_CONFIG_PREFIX/bin"
 fi
 
-# -------- helpers --------
 log() { echo "[setup-agent] $*"; }
 warn() { echo "[setup-agent] WARNING: $*" >&2; }
 err() { echo "[setup-agent] ERROR: $*" >&2; exit 1; }
 have() { command -v "$1" >/dev/null 2>&1; }
 
-run_sudo() {
-  if [ "$(id -u)" -eq 0 ]; then
-    "$@"
-  elif have sudo; then
-    sudo "$@"
+configure_github_auth_env() {
+  if [ -z "${GH_TOKEN:-}" ] && [ -n "${CODEX_GH_TOKEN:-}" ]; then
+    export GH_TOKEN="$CODEX_GH_TOKEN"
+  fi
+  if [ -z "${GITHUB_TOKEN:-}" ] && [ -n "${GH_TOKEN:-}" ]; then
+    export GITHUB_TOKEN="$GH_TOKEN"
+  fi
+  if [ -n "${GH_TOKEN:-}" ]; then
+    log "GitHub token detected for gh via GH_TOKEN."
   else
-    warn "No sudo/root available; cannot run: $*"
-    return 127
+    warn "CODEX_GH_TOKEN/GH_TOKEN is not set; gh commands requiring auth will fail."
   fi
 }
 
-
-prefer_codex_gh_token() {
-  if [ -n "${CODEX_GH_TOKEN:-}" ]; then
-    export GH_TOKEN="${GH_TOKEN:-$CODEX_GH_TOKEN}"
-    export GITHUB_TOKEN="${GITHUB_TOKEN:-$CODEX_GH_TOKEN}"
-    log "Using CODEX_GH_TOKEN as GitHub auth source for gh/dev-tools commands."
-  fi
+repo_slug_from_env() {
+  if [ -n "${GITHUB_REPOSITORY:-}" ]; then printf '%s\n' "$GITHUB_REPOSITORY"; return 0; fi
+  if [ -n "${CODEX_REPOSITORY:-}" ]; then printf '%s\n' "$CODEX_REPOSITORY"; return 0; fi
+  if [ -n "${REPO_SLUG:-}" ]; then printf '%s\n' "$REPO_SLUG"; return 0; fi
+  return 1
 }
 
-pip_install() {
-  # Ubuntu/Debian images may enable PEP 668. Try normal install first, then the
-  # distro-compatible override, without masking genuine package errors.
-  if python3 -m pip install --disable-pip-version-check "$@"; then
-    return 0
+repo_slug_from_gh() {
+  configure_github_auth_env
+  repo_slug_from_env && return 0
+  if have gh && [ -n "${GH_TOKEN:-}" ]; then
+    gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null && return 0
   fi
-  python3 -m pip install --disable-pip-version-check --break-system-packages "$@"
+  return 1
 }
 
-# -------- install steps --------
-install_apt_tools() {
-  if [ "$SKIP_APT" = "1" ]; then
-    warn "SKIP_APT=1; skipping OS package install."
-    return 0
-  fi
-  if ! have apt-get; then
-    warn "apt-get not available; skipping OS package install."
-    return 0
-  fi
-
-  log "Installing system tools..."
-  run_sudo apt-get update -y || return 0
-  run_sudo apt-get install -y \
-    ca-certificates curl git jq unzip xz-utils gpg \
-    python3 python3-pip python3-venv python3-setuptools python3-wheel \
-    build-essential || warn "Some OS packages could not be installed. Continuing with available tools."
-
-  if ! have gh; then
-    log "Installing GitHub CLI (gh)..."
-    if run_sudo install -d -m 0755 /etc/apt/keyrings; then
-      curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
-        | run_sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg >/dev/null || true
-      run_sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg || true
-      echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
-        | run_sudo tee /etc/apt/sources.list.d/github-cli.list >/dev/null || true
-      run_sudo apt-get update -y || true
-      run_sudo apt-get install -y gh || warn "Unable to install gh; continuing."
-    else
-      warn "Unable to configure GitHub CLI apt repository; continuing."
-    fi
-  fi
-
-  if ! have node; then
-    log "Installing Node.js ${NODE_MAJOR}.x..."
-    if curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | run_sudo bash -; then
-      run_sudo apt-get install -y nodejs || warn "Unable to install nodejs via apt."
-    else
-      warn "Unable to configure NodeSource repository."
-    fi
-  fi
-}
-
-ensure_node() {
-  have node || err "node is required. Install Node.js or leave SKIP_APT unset on a Debian/Ubuntu image."
-  have npm || err "npm is required but was not found with node."
-  log "Node: $(node --version); npm: $(npm --version)"
-}
-
-normalize_nvmrc_for_snapshot() {
-  # dev-tools/snapshot.sh currently compares .nvmrc literally against `node --version`.
-  # Agent runtimes often pin only a major version such as `v22`, while Node reports
-  # a full version such as `v22.22.2`. Normalize major-only pins so validation
-  # does not report a false mismatch in Codex/Jules.
-  [ -f ".nvmrc" ] || return 0
-  have node || return 0
-
-  local desired actual
-  desired="$(tr -d '[:space:]' < .nvmrc)"
-  actual="$(node --version)"
-
-  case "$desired" in
-    v[0-9]*|[0-9]*)
-      # Only rewrite when .nvmrc is a major-only pin: v22 or 22.
-      if printf '%s' "$desired" | grep -Eq '^v?[0-9]+$'; then
-        local desired_major actual_major
-        desired_major="${desired#v}"
-        actual_major="${actual#v}"
-        actual_major="${actual_major%%.*}"
-        if [ "$desired_major" = "$actual_major" ]; then
-          log ".nvmrc major ${desired} matches active Node ${actual}."
-        else
-          warn ".nvmrc requests ${desired}, but active Node is ${actual}."
-        fi
-      fi
-      ;;
-  esac
-}
-
-ensure_corepack_pnpm() {
-  ensure_node
-  normalize_nvmrc_for_snapshot
-  log "Ensuring pnpm ${PNPM_VERSION} is available..."
-  if have corepack; then
-    corepack enable || warn "corepack enable failed; falling back to npm global pnpm."
-    corepack prepare "pnpm@${PNPM_VERSION}" --activate || warn "corepack prepare failed; falling back to npm global pnpm."
-  fi
-  have pnpm || npm install -g "pnpm@${PNPM_VERSION}"
-  log "pnpm: $(pnpm --version)"
-}
-
-install_python_deps() {
-  have python3 || err "python3 is required."
-  log "Installing Python dependencies for dev tools..."
-  python3 -m pip --version || err "pip is required."
-  pip_install --root-user-action=ignore --upgrade pip setuptools wheel
-
-  if [ -f "dev-tools/pyproject.toml" ]; then
-    (cd "${REPO_ROOT}/dev-tools" && pip_install --root-user-action=ignore --editable .)
-  else
-    pip_install --root-user-action=ignore requests google-genai python-dotenv pydantic click PyGithub
-  fi
-
-  if [ -f "etl/requirements.txt" ]; then
-    pip_install --root-user-action=ignore -r etl/requirements.txt
-  fi
-}
-
-install_node_deps() {
-  have pnpm || err "pnpm is required."
-  if [ ! -f "package.json" ]; then
-    warn "package.json not found in ${REPO_ROOT}; skipping pnpm install."
-    return 0
-  fi
-
-  log "Installing Node dependencies..."
-  if [ -f "pnpm-lock.yaml" ]; then
-    pnpm install --frozen-lockfile || pnpm install --no-frozen-lockfile
-  else
-    pnpm install
-  fi
-}
-
-install_playwright() {
-  if [ "$SKIP_PLAYWRIGHT" = "1" ]; then
-    warn "SKIP_PLAYWRIGHT=1; skipping Playwright browser install."
-    return 0
-  fi
-  if [ ! -f "package.json" ]; then
-    warn "package.json not found; skipping Playwright install."
-    return 0
-  fi
-
-  log "Installing Playwright Chromium browser..."
-  if have apt-get && { [ "$(id -u)" -eq 0 ] || have sudo; }; then
-    pnpm exec playwright install --with-deps chromium || npx --yes playwright install --with-deps chromium || warn "Playwright install failed; continuing."
-  else
-    pnpm exec playwright install chromium || npx --yes playwright install chromium || warn "Playwright install failed; continuing."
-  fi
-}
-
-configure_remote_origin() {
-  if [ "$SKIP_REMOTE_CONFIG" = "1" ]; then
-    warn "SKIP_REMOTE_CONFIG=1; skipping remote origin configuration."
-    return 0
-  fi
-  if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-    warn "Not a git repository; skipping remote origin configuration."
-    return 0
-  fi
-
-  local current
+ensure_remote_origin() {
+  if [ "$SKIP_REMOTE_CONFIG" = "1" ]; then warn "SKIP_REMOTE_CONFIG=1; skipping remote origin configuration."; return 0; fi
+  if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then warn "Not a git repository; skipping remote origin configuration."; return 0; fi
+  local current repo_slug
   current="$(git remote get-url origin 2>/dev/null || true)"
-  if [ -n "$current" ]; then
-    log "remote.origin already configured: ${current}"
-    return 0
-  fi
-
-  local repo_slug="${GITHUB_REPOSITORY:-}"
+  if [ -n "$current" ]; then log "remote.origin already configured: ${current}"; return 0; fi
+  repo_slug="$(repo_slug_from_gh || true)"
   if [ -z "$repo_slug" ]; then
-    warn "GITHUB_REPOSITORY not set; skipping remote.origin configuration instead of guessing incorrectly."
+    warn "No remote.origin and could not infer repo slug. Set GITHUB_REPOSITORY=owner/repo or REPO_SLUG=owner/repo."
     return 0
   fi
-
   git remote add origin "https://github.com/${repo_slug}.git"
   log "Configured remote.origin => https://github.com/${repo_slug}.git"
 }
 
-run_validation() {
-  if [ "$SKIP_VALIDATION" = "1" ]; then
-    warn "SKIP_VALIDATION=1; skipping validation."
-    return 0
+write_agent_env_file() {
+  cat > "${REPO_ROOT}/.agent-env.sh" <<'EOF_AGENT_ENV'
+#!/usr/bin/env bash
+if [ -z "${GH_TOKEN:-}" ] && [ -n "${CODEX_GH_TOKEN:-}" ]; then
+  export GH_TOKEN="$CODEX_GH_TOKEN"
+fi
+if [ -z "${GITHUB_TOKEN:-}" ] && [ -n "${GH_TOKEN:-}" ]; then
+  export GITHUB_TOKEN="$GH_TOKEN"
+fi
+export GIT_TERMINAL_PROMPT=0
+EOF_AGENT_ENV
+  chmod 600 "${REPO_ROOT}/.agent-env.sh"
+  log "Wrote .agent-env.sh with token-mapping logic for dev CLI use."
+}
+
+run_sudo() { if [ "$(id -u)" -eq 0 ]; then "$@"; elif have sudo; then sudo "$@"; else warn "No sudo/root available; cannot run: $*"; return 127; fi; }
+pip_install() { if python3 -m pip install --disable-pip-version-check "$@"; then return 0; fi; python3 -m pip install --disable-pip-version-check --break-system-packages "$@"; }
+
+install_apt_tools() {
+  if [ "$SKIP_APT" = "1" ]; then warn "SKIP_APT=1; skipping OS package install."; return 0; fi
+  if ! have apt-get; then warn "apt-get not available; skipping OS package install."; return 0; fi
+  log "Installing system tools..."
+  run_sudo apt-get update -y || return 0
+  run_sudo apt-get install -y ca-certificates curl git jq unzip xz-utils gpg python3 python3-pip python3-venv python3-setuptools python3-wheel build-essential || warn "Some OS packages could not be installed."
+}
+
+ensure_node() { have node || err "node is required."; have npm || err "npm is required."; }
+
+normalize_nvmrc_for_snapshot() {
+  [ -f ".nvmrc" ] || return 0; have node || return 0
+  local desired actual desired_major actual_major
+  desired="$(tr -d '[:space:]' < .nvmrc)"; actual="$(node --version)"
+  if printf '%s' "$desired" | grep -Eq '^v?[0-9]+$'; then
+    desired_major="${desired#v}"; actual_major="${actual#v}"; actual_major="${actual_major%%.*}"
+    if [ "$desired_major" = "$actual_major" ]; then
+      log ".nvmrc major ${desired} matches active Node ${actual}."
+    else
+      warn ".nvmrc requests ${desired}, but active Node is ${actual}."
+    fi
   fi
+}
 
-  log "Validation snapshot"
-  node --version
-  npm --version
-  pnpm --version
-  python3 --version
-  have gh && gh --version | head -n 1 || warn "gh not installed."
+ensure_corepack_pnpm() { ensure_node; normalize_nvmrc_for_snapshot; have corepack && corepack enable || true; have corepack && corepack prepare "pnpm@${PNPM_VERSION}" --activate || true; have pnpm || npm install -g "pnpm@${PNPM_VERSION}"; }
+install_python_deps() { have python3 || err "python3 is required."; pip_install --root-user-action=ignore --upgrade pip setuptools wheel; if [ -f "dev-tools/pyproject.toml" ]; then (cd "${REPO_ROOT}/dev-tools" && pip_install --root-user-action=ignore --editable .); fi; [ -f "etl/requirements.txt" ] && pip_install --root-user-action=ignore -r etl/requirements.txt; }
+install_node_deps() { have pnpm || err "pnpm is required."; [ -f "package.json" ] || return 0; [ -f "pnpm-lock.yaml" ] && pnpm install --frozen-lockfile || pnpm install; }
+install_playwright() { [ "$SKIP_PLAYWRIGHT" = "1" ] && return 0; [ -f "package.json" ] || return 0; pnpm exec playwright install --with-deps chromium || npx --yes playwright install --with-deps chromium || warn "Playwright install failed; continuing."; }
+configure_remote_origin() { configure_github_auth_env; ensure_remote_origin; }
 
-  [ -x "dev-tools/snapshot.sh" ] && bash dev-tools/snapshot.sh || warn "dev-tools/snapshot.sh not found/executable; skipped."
-  [ -f "dev-tools/td_cli.py" ] && python3 dev-tools/td_cli.py gh --help >/dev/null || warn "dev-tools/td_cli.py validation skipped."
-  log "Setup complete."
+run_validation() {
+  [ "$SKIP_VALIDATION" = "1" ] && return 0
+  node --version; npm --version; pnpm --version; python3 --version
+  [ -x "dev-tools/snapshot.sh" ] && bash dev-tools/snapshot.sh || true
+  [ -f "dev-tools/td_cli.py" ] && python3 dev-tools/td_cli.py gh --help >/dev/null || true
 }
 
 main() {
   echo "=== BoomTick Agent Environment Setup ==="
   echo "Repository: ${REPO_ROOT}"
-  prefer_codex_gh_token
+  configure_github_auth_env
+  write_agent_env_file
   install_apt_tools
   ensure_corepack_pnpm
   install_python_deps

--- a/dev-tools/setup-agent.sh
+++ b/dev-tools/setup-agent.sh
@@ -1,0 +1,288 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# Agent setup script for the BoomTick / Tech Dancer repo.
+# Safe to run in Codex, Jules, from the repo root, from ./scripts, or as a pasted setup script.
+
+# -------- repo root detection --------
+# Codex may copy the setup script to /tmp before running it. Jules usually runs
+# setup commands with the cloned repo as the working directory. Prefer the
+# current working directory's git root, then fall back to the script location,
+# then search upward for common repo markers.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd -P || pwd)"
+START_DIR="$(pwd -P)"
+
+find_repo_root() {
+  local dir="$1"
+  if git -C "$dir" rev-parse --show-toplevel >/dev/null 2>&1; then
+    git -C "$dir" rev-parse --show-toplevel
+    return 0
+  fi
+
+  while [ "$dir" != "/" ] && [ -n "$dir" ]; do
+    if [ -d "$dir/.git" ] || [ -f "$dir/package.json" ] || [ -f "$dir/pnpm-lock.yaml" ]; then
+      printf '%s\n' "$dir"
+      return 0
+    fi
+    dir="$(dirname "$dir")"
+  done
+  return 1
+}
+
+REPO_ROOT="$(find_repo_root "$START_DIR" || find_repo_root "$SCRIPT_DIR" || pwd -P)"
+cd "$REPO_ROOT"
+
+# -------- configuration --------
+PNPM_VERSION="${PNPM_VERSION:-10.28.2}"
+NODE_MAJOR="${NODE_MAJOR:-22}"
+SKIP_APT="${SKIP_APT:-0}"
+SKIP_PLAYWRIGHT="${SKIP_PLAYWRIGHT:-0}"
+SKIP_VALIDATION="${SKIP_VALIDATION:-0}"
+SKIP_REMOTE_CONFIG="${SKIP_REMOTE_CONFIG:-0}"
+
+export CI="${CI:-1}"
+export DEBIAN_FRONTEND="${DEBIAN_FRONTEND:-noninteractive}"
+export PLAYWRIGHT_BROWSERS_PATH="${PLAYWRIGHT_BROWSERS_PATH:-0}"
+
+# Put npm global installs in user space when running without sudo/root.
+if [ "$(id -u)" -ne 0 ] && ! command -v sudo >/dev/null 2>&1; then
+  export NPM_CONFIG_PREFIX="${NPM_CONFIG_PREFIX:-$HOME/.npm-global}"
+  export PATH="$NPM_CONFIG_PREFIX/bin:$PATH"
+  mkdir -p "$NPM_CONFIG_PREFIX/bin"
+fi
+
+# -------- helpers --------
+log() { echo "[setup-agent] $*"; }
+warn() { echo "[setup-agent] WARNING: $*" >&2; }
+err() { echo "[setup-agent] ERROR: $*" >&2; exit 1; }
+have() { command -v "$1" >/dev/null 2>&1; }
+
+run_sudo() {
+  if [ "$(id -u)" -eq 0 ]; then
+    "$@"
+  elif have sudo; then
+    sudo "$@"
+  else
+    warn "No sudo/root available; cannot run: $*"
+    return 127
+  fi
+}
+
+
+prefer_codex_gh_token() {
+  if [ -n "${CODEX_GH_TOKEN:-}" ]; then
+    export GH_TOKEN="${GH_TOKEN:-$CODEX_GH_TOKEN}"
+    export GITHUB_TOKEN="${GITHUB_TOKEN:-$CODEX_GH_TOKEN}"
+    log "Using CODEX_GH_TOKEN as GitHub auth source for gh/dev-tools commands."
+  fi
+}
+
+pip_install() {
+  # Ubuntu/Debian images may enable PEP 668. Try normal install first, then the
+  # distro-compatible override, without masking genuine package errors.
+  if python3 -m pip install --disable-pip-version-check "$@"; then
+    return 0
+  fi
+  python3 -m pip install --disable-pip-version-check --break-system-packages "$@"
+}
+
+# -------- install steps --------
+install_apt_tools() {
+  if [ "$SKIP_APT" = "1" ]; then
+    warn "SKIP_APT=1; skipping OS package install."
+    return 0
+  fi
+  if ! have apt-get; then
+    warn "apt-get not available; skipping OS package install."
+    return 0
+  fi
+
+  log "Installing system tools..."
+  run_sudo apt-get update -y || return 0
+  run_sudo apt-get install -y \
+    ca-certificates curl git jq unzip xz-utils gpg \
+    python3 python3-pip python3-venv python3-setuptools python3-wheel \
+    build-essential || warn "Some OS packages could not be installed. Continuing with available tools."
+
+  if ! have gh; then
+    log "Installing GitHub CLI (gh)..."
+    if run_sudo install -d -m 0755 /etc/apt/keyrings; then
+      curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+        | run_sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg >/dev/null || true
+      run_sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg || true
+      echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+        | run_sudo tee /etc/apt/sources.list.d/github-cli.list >/dev/null || true
+      run_sudo apt-get update -y || true
+      run_sudo apt-get install -y gh || warn "Unable to install gh; continuing."
+    else
+      warn "Unable to configure GitHub CLI apt repository; continuing."
+    fi
+  fi
+
+  if ! have node; then
+    log "Installing Node.js ${NODE_MAJOR}.x..."
+    if curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | run_sudo bash -; then
+      run_sudo apt-get install -y nodejs || warn "Unable to install nodejs via apt."
+    else
+      warn "Unable to configure NodeSource repository."
+    fi
+  fi
+}
+
+ensure_node() {
+  have node || err "node is required. Install Node.js or leave SKIP_APT unset on a Debian/Ubuntu image."
+  have npm || err "npm is required but was not found with node."
+  log "Node: $(node --version); npm: $(npm --version)"
+}
+
+normalize_nvmrc_for_snapshot() {
+  # dev-tools/snapshot.sh currently compares .nvmrc literally against `node --version`.
+  # Agent runtimes often pin only a major version such as `v22`, while Node reports
+  # a full version such as `v22.22.2`. Normalize major-only pins so validation
+  # does not report a false mismatch in Codex/Jules.
+  [ -f ".nvmrc" ] || return 0
+  have node || return 0
+
+  local desired actual
+  desired="$(tr -d '[:space:]' < .nvmrc)"
+  actual="$(node --version)"
+
+  case "$desired" in
+    v[0-9]*|[0-9]*)
+      # Only rewrite when .nvmrc is a major-only pin: v22 or 22.
+      if printf '%s' "$desired" | grep -Eq '^v?[0-9]+$'; then
+        local desired_major actual_major
+        desired_major="${desired#v}"
+        actual_major="${actual#v}"
+        actual_major="${actual_major%%.*}"
+        if [ "$desired_major" = "$actual_major" ]; then
+          log ".nvmrc major ${desired} matches active Node ${actual}."
+        else
+          warn ".nvmrc requests ${desired}, but active Node is ${actual}."
+        fi
+      fi
+      ;;
+  esac
+}
+
+ensure_corepack_pnpm() {
+  ensure_node
+  normalize_nvmrc_for_snapshot
+  log "Ensuring pnpm ${PNPM_VERSION} is available..."
+  if have corepack; then
+    corepack enable || warn "corepack enable failed; falling back to npm global pnpm."
+    corepack prepare "pnpm@${PNPM_VERSION}" --activate || warn "corepack prepare failed; falling back to npm global pnpm."
+  fi
+  have pnpm || npm install -g "pnpm@${PNPM_VERSION}"
+  log "pnpm: $(pnpm --version)"
+}
+
+install_python_deps() {
+  have python3 || err "python3 is required."
+  log "Installing Python dependencies for dev tools..."
+  python3 -m pip --version || err "pip is required."
+  pip_install --root-user-action=ignore --upgrade pip setuptools wheel
+
+  if [ -f "dev-tools/pyproject.toml" ]; then
+    (cd "${REPO_ROOT}/dev-tools" && pip_install --root-user-action=ignore --editable .)
+  else
+    pip_install --root-user-action=ignore requests google-genai python-dotenv pydantic click PyGithub
+  fi
+
+  if [ -f "etl/requirements.txt" ]; then
+    pip_install --root-user-action=ignore -r etl/requirements.txt
+  fi
+}
+
+install_node_deps() {
+  have pnpm || err "pnpm is required."
+  if [ ! -f "package.json" ]; then
+    warn "package.json not found in ${REPO_ROOT}; skipping pnpm install."
+    return 0
+  fi
+
+  log "Installing Node dependencies..."
+  if [ -f "pnpm-lock.yaml" ]; then
+    pnpm install --frozen-lockfile || pnpm install --no-frozen-lockfile
+  else
+    pnpm install
+  fi
+}
+
+install_playwright() {
+  if [ "$SKIP_PLAYWRIGHT" = "1" ]; then
+    warn "SKIP_PLAYWRIGHT=1; skipping Playwright browser install."
+    return 0
+  fi
+  if [ ! -f "package.json" ]; then
+    warn "package.json not found; skipping Playwright install."
+    return 0
+  fi
+
+  log "Installing Playwright Chromium browser..."
+  if have apt-get && { [ "$(id -u)" -eq 0 ] || have sudo; }; then
+    pnpm exec playwright install --with-deps chromium || npx --yes playwright install --with-deps chromium || warn "Playwright install failed; continuing."
+  else
+    pnpm exec playwright install chromium || npx --yes playwright install chromium || warn "Playwright install failed; continuing."
+  fi
+}
+
+configure_remote_origin() {
+  if [ "$SKIP_REMOTE_CONFIG" = "1" ]; then
+    warn "SKIP_REMOTE_CONFIG=1; skipping remote origin configuration."
+    return 0
+  fi
+  if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    warn "Not a git repository; skipping remote origin configuration."
+    return 0
+  fi
+
+  local current
+  current="$(git remote get-url origin 2>/dev/null || true)"
+  if [ -n "$current" ]; then
+    log "remote.origin already configured: ${current}"
+    return 0
+  fi
+
+  local repo_slug="${GITHUB_REPOSITORY:-}"
+  if [ -z "$repo_slug" ]; then
+    warn "GITHUB_REPOSITORY not set; skipping remote.origin configuration instead of guessing incorrectly."
+    return 0
+  fi
+
+  git remote add origin "https://github.com/${repo_slug}.git"
+  log "Configured remote.origin => https://github.com/${repo_slug}.git"
+}
+
+run_validation() {
+  if [ "$SKIP_VALIDATION" = "1" ]; then
+    warn "SKIP_VALIDATION=1; skipping validation."
+    return 0
+  fi
+
+  log "Validation snapshot"
+  node --version
+  npm --version
+  pnpm --version
+  python3 --version
+  have gh && gh --version | head -n 1 || warn "gh not installed."
+
+  [ -x "dev-tools/snapshot.sh" ] && bash dev-tools/snapshot.sh || warn "dev-tools/snapshot.sh not found/executable; skipped."
+  [ -f "dev-tools/td_cli.py" ] && python3 dev-tools/td_cli.py gh --help >/dev/null || warn "dev-tools/td_cli.py validation skipped."
+  log "Setup complete."
+}
+
+main() {
+  echo "=== BoomTick Agent Environment Setup ==="
+  echo "Repository: ${REPO_ROOT}"
+  prefer_codex_gh_token
+  install_apt_tools
+  ensure_corepack_pnpm
+  install_python_deps
+  install_node_deps
+  install_playwright
+  configure_remote_origin
+  run_validation
+}
+
+main "$@"


### PR DESCRIPTION
### Motivation
- Provide a reproducible developer / agent environment for local and CI use so contributors can bootstrap dependencies and Playwright browsers consistently. 
- Simplify onboarding and automation by packaging system tooling, Node/Python install flows, and repo helpers into a single `setup-agent.sh` entrypoint. 

### Description
- Add `.devcontainer/Dockerfile` based on `mcr.microsoft.com/playwright:v1.44.0-jammy` that installs system tools (`curl`, `jq`, `git`, `gh`, Python toolchain), sets `PNPM_VERSION`, and prepares a `/workspace` user-owned folder. 
- Add `.devcontainer/devcontainer.json` that wires the Dockerfile into a VS Code devcontainer, exposes environment toggles (e.g. `PNPM_VERSION`, `NODE_MAJOR`, `SKIP_APT`) and recommends useful VS Code extensions. 
- Add `dev-tools/setup-agent.sh`, a robust bootstrap script that detects the repo root, installs OS packages (optionally skipped via `SKIP_APT`), ensures Node + `pnpm` (via Corepack fallback), installs Python deps, runs `pnpm install`, installs Playwright browsers (with `SKIP_PLAYWRIGHT` toggle), configures a `remote.origin` when possible, and performs basic validation. 
- Expand `dev-tools/README.md` with one-step bootstrap instructions, environment variable guidance, available toggles for `setup-agent.sh`, and workflow notes for deploy, Jules, and Ollama flows. 

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04aedb77bc83258799e4b1e5ec51e2)