### PR TITLE
fix: increase Playwright crawler timeout to prevent CI failures

### DIFF
--- a/tests/crawl.spec.ts
+++ b/tests/crawl.spec.ts
@@ -37,6 +37,7 @@ function isInternal(url: string, baseUrl: string): boolean {
 }
 
 test.describe('Automated UX/Console Error Crawler', () => {
+  test.setTimeout(120000);
   test('crawls routes and verifies no errors', async ({ page, baseURL, pageErrors }) => {
     if (!baseURL) throw new Error('baseURL is required for crawling');
 


### PR DESCRIPTION
The `tests/crawl.spec.ts` automated crawler test was timing out in CI because it involves crawling up to 50 URLs and checking for errors, which can exceed the default 30-second Playwright limit. This commit increases the timeout for this specific test block to 120 seconds (`test.setTimeout(120000)`). All e2e and unit tests have been run locally and successfully passed.

---
*PR created automatically by Jules for task [5711595571219027867](https://jules.google.com/task/5711595571219027867) started by @arii*