### PR TITLE
SEO/Sitemap Cleanup and Canonical Route Consolidation

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5475,8 +5475,8 @@ packages:
   third-party-web@0.26.7:
     resolution: {integrity: sha512-buUzX4sXC4efFX6xg2bw6/eZsCUh8qQwSavC4D9HpONMFlRbcHhD8Je5qwYdCpViR6q0qla2wPP+t91a2vgolg==}
 
-  third-party-web@0.29.0:
-    resolution: {integrity: sha512-nBDSJw5B7Sl1YfsATG2XkW5qgUPODbJhXw++BKygi9w6O/NKS98/uY/nR/DxDq2axEjL6halHW1v+jhm/j1DBQ==}
+  third-party-web@0.29.2:
+    resolution: {integrity: sha512-fegtha91tq2DHphyoiBXVHjVi2YG9zFaRnboT9C28tO1en9Y3wJsfspuy40F+u5wl3hHVbw7cnd1b67kEGHb8g==}
 
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
@@ -7858,7 +7858,7 @@ snapshots:
   '@paulirish/trace_engine@0.0.53':
     dependencies:
       legacy-javascript: 0.0.1
-      third-party-web: 0.29.0
+      third-party-web: 0.29.2
 
   '@playwright/test@1.49.0':
     dependencies:
@@ -11827,7 +11827,7 @@ snapshots:
 
   third-party-web@0.26.7: {}
 
-  third-party-web@0.29.0: {}
+  third-party-web@0.29.2: {}
 
   through@2.3.8: {}
 

--- a/scripts/content-loader.ts
+++ b/scripts/content-loader.ts
@@ -8,6 +8,7 @@ export const CONTENT_DIR_MAP = {
   '/blog': 'content/posts',
   '/gear': 'content/resources',
   '/research': 'content/studies',
+  '/events': 'content/events',
 } as const;
 
 const cache = new Map<string, string[]>();

--- a/src/config/research-tools.ts
+++ b/src/config/research-tools.ts
@@ -4,6 +4,7 @@ export interface ResearchTool {
   category: string;
   status: string;
   layman: string;
+  canonicalPath?: string;
 }
 
 export const RESEARCH_TOOLS: ResearchTool[] = [
@@ -26,7 +27,8 @@ export const RESEARCH_TOOLS: ResearchTool[] = [
     name: 'Visual UX Auditor',
     category: 'Development Tool',
     status: 'Active',
-    layman: 'Automated visual regression and UX improvement suggestions across viewports.'
+    layman: 'Automated visual regression and UX improvement suggestions across viewports.',
+    canonicalPath: '/ux-auditor'
   },
   {
     id: 'wsdc-event-reminders',

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -56,16 +56,6 @@ export const routes: RouteConfig[] = [
     skeleton: 'grid'
   },
   {
-    path: '/research/wcs-scraper',
-    lazy: () => import('@/pages/ResearchDetail').then(m => ({ Component: m.default })),
-    skeleton: 'post'
-  },
-  {
-    path: '/research/wsdc-event-reminders',
-    lazy: () => import('@/pages/ResearchDetail').then(m => ({ Component: m.default })),
-    skeleton: 'post'
-  },
-  {
     path: '/research/:id',
     lazy: () => import('@/pages/ResearchDetail').then(m => ({ Component: m.default })),
     skeleton: 'post'
@@ -92,7 +82,8 @@ export const routes: RouteConfig[] = [
   {
     path: '/preview',
     lazy: () => import('@/pages/ComponentPreview').then(m => ({ Component: m.default })),
-    skeleton: 'grid'
+    skeleton: 'grid',
+    sitemap: false
   },
   {
     path: '*',

--- a/src/features/research/ResearchDetail.tsx
+++ b/src/features/research/ResearchDetail.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { useParams, useNavigate, useLocation, Navigate } from 'react-router-dom';
+import { useParams, useLocation, Navigate } from 'react-router-dom';
 import { Database, Activity, ArrowLeft, Search } from 'lucide-react';
 import { Box, Stack, Text, Grid } from '@/layouts/Primitives';
 import { StatusBadge } from '@/components/ui/StatusBadge';
@@ -22,6 +22,7 @@ const TOOL_REGISTRY: Record<string, ComponentType> = {
 
 export default function ResearchDetail() {
   const { id: paramId } = useParams();
+  const navigate = useNavigate();
   const { pathname } = useLocation();
 
   const { getTool, getStudy } = useResearch();
@@ -35,12 +36,6 @@ export default function ResearchDetail() {
   }, [paramId, pathname]);
 
   const tool = id ? getTool(id) : null;
-
-  // Redirect non-canonical routes (e.g. /research/ux-auditor -> /ux-auditor)
-  // Check both paramId and tool.canonicalPath to support centralized config
-  if (paramId === 'ux-auditor' || (tool?.canonicalPath && pathname.startsWith('/research/'))) {
-    return <Navigate to={tool?.canonicalPath || "/ux-auditor"} replace />;
-  }
   const study = !tool && id ? getStudy(id) : null;
 
   const structuredData = useMemo(() => {
@@ -73,6 +68,12 @@ export default function ResearchDetail() {
     }
     return null;
   }, [tool, study]);
+
+  // Redirect non-canonical routes (e.g. /research/ux-auditor -> /ux-auditor)
+  // Check both paramId and tool.canonicalPath to support centralized config
+  if (paramId === 'ux-auditor' || (tool?.canonicalPath && pathname.startsWith('/research/'))) {
+    return <Navigate to={tool?.canonicalPath || "/ux-auditor"} replace />;
+  }
 
   if (study) {
     return (

--- a/src/features/research/ResearchDetail.tsx
+++ b/src/features/research/ResearchDetail.tsx
@@ -22,7 +22,6 @@ const TOOL_REGISTRY: Record<string, ComponentType> = {
 
 export default function ResearchDetail() {
   const { id: paramId } = useParams();
-  const navigate = useNavigate();
   const { pathname } = useLocation();
 
   const { getTool, getStudy } = useResearch();

--- a/src/features/research/ResearchDetail.tsx
+++ b/src/features/research/ResearchDetail.tsx
@@ -1,5 +1,5 @@
-import { useMemo, useEffect } from 'react';
-import { useParams, useNavigate, useLocation } from 'react-router-dom';
+import { useMemo } from 'react';
+import { useParams, useNavigate, useLocation, Navigate } from 'react-router-dom';
 import { Database, Activity, ArrowLeft, Search } from 'lucide-react';
 import { Box, Stack, Text, Grid } from '@/layouts/Primitives';
 import { StatusBadge } from '@/components/ui/StatusBadge';
@@ -22,15 +22,8 @@ const TOOL_REGISTRY: Record<string, ComponentType> = {
 
 export default function ResearchDetail() {
   const { id: paramId } = useParams();
-  const navigate = useNavigate();
   const { pathname } = useLocation();
 
-  // Redirect non-canonical routes (e.g. /research/ux-auditor -> /ux-auditor)
-  useEffect(() => {
-    if (paramId === 'ux-auditor') {
-      navigate('/ux-auditor', { replace: true });
-    }
-  }, [paramId, navigate]);
   const { getTool, getStudy } = useResearch();
 
   const id = useMemo(() => {
@@ -42,6 +35,12 @@ export default function ResearchDetail() {
   }, [paramId, pathname]);
 
   const tool = id ? getTool(id) : null;
+
+  // Redirect non-canonical routes (e.g. /research/ux-auditor -> /ux-auditor)
+  // Check both paramId and tool.canonicalPath to support centralized config
+  if (paramId === 'ux-auditor' || (tool?.canonicalPath && pathname.startsWith('/research/'))) {
+    return <Navigate to={tool?.canonicalPath || "/ux-auditor"} replace />;
+  }
   const study = !tool && id ? getStudy(id) : null;
 
   const structuredData = useMemo(() => {

--- a/src/features/research/ResearchDetail.tsx
+++ b/src/features/research/ResearchDetail.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useEffect } from 'react';
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import { Database, Activity, ArrowLeft, Search } from 'lucide-react';
 import { Box, Stack, Text, Grid } from '@/layouts/Primitives';
@@ -24,6 +24,13 @@ export default function ResearchDetail() {
   const { id: paramId } = useParams();
   const navigate = useNavigate();
   const { pathname } = useLocation();
+
+  // Redirect non-canonical routes (e.g. /research/ux-auditor -> /ux-auditor)
+  useEffect(() => {
+    if (paramId === 'ux-auditor') {
+      navigate('/ux-auditor', { replace: true });
+    }
+  }, [paramId, navigate]);
   const { getTool, getStudy } = useResearch();
 
   const id = useMemo(() => {

--- a/src/lib/routes-discovery.test.ts
+++ b/src/lib/routes-discovery.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { getAllRoutes } from './routes-discovery';
+
+describe('getAllRoutes', () => {
+  it('should return unique routes', () => {
+    const { all } = getAllRoutes();
+    const unique = new Set(all);
+    expect(all.length).toBe(unique.size);
+  });
+
+  it('should exclude /preview from the sitemap', () => {
+    const { all } = getAllRoutes();
+    expect(all).not.toContain('/preview');
+  });
+
+  it('should exclude catch-all route', () => {
+    const { all } = getAllRoutes();
+    expect(all).not.toContain('*');
+  });
+
+  it('should use canonical path for UX Auditor', () => {
+    const { all } = getAllRoutes();
+    expect(all).toContain('/ux-auditor');
+    expect(all).not.toContain('/research/ux-auditor');
+  });
+
+  it('should handle tool routes correctly', () => {
+    const { tools } = getAllRoutes();
+    expect(tools).toContain('/research/wcs-scraper');
+    expect(tools).toContain('/ux-auditor');
+  });
+});

--- a/src/lib/routes-discovery.ts
+++ b/src/lib/routes-discovery.ts
@@ -13,22 +13,29 @@ import { RESEARCH_TOOLS } from '../config/research-tools.ts';
  */
 export function getAllRoutes() {
   // 1. Static routes from configuration (excluding parameterized and catch-all)
+  // Use canonicalPath if available, and filter out routes marked as sitemap: false
   const staticRoutes = routes
-    .map(r => r.path)
-    .filter(path => path !== '*' && !path.includes(':'));
+    .filter(r => r.sitemap !== false && r.path !== '*' && !r.path.includes(':'))
+    .map(r => r.canonicalPath || r.path);
 
   // 2. Dynamic research tool routes
-  const toolRoutes = RESEARCH_TOOLS.map(tool => `/research/${tool.id}`);
+  // Use canonicalPath if available to avoid duplicates (e.g. /ux-auditor vs /research/ux-auditor)
+  const toolRoutes = RESEARCH_TOOLS.map(tool => tool.canonicalPath || `/research/${tool.id}`);
 
   // 3. Dynamic content routes discovered from file system
   const contentRoutes = Object.entries(CONTENT_DIR_MAP).flatMap(([prefix, dir]) =>
     getContentSlugs(dir, prefix)
   );
 
+  const allRoutes = [...staticRoutes, ...toolRoutes, ...contentRoutes];
+
+  // Deduplicate routes to ensure each path is only listed once
+  const uniqueRoutes = Array.from(new Set(allRoutes));
+
   return {
     static: staticRoutes,
     tools: toolRoutes,
     content: contentRoutes,
-    all: [...staticRoutes, ...toolRoutes, ...contentRoutes]
+    all: uniqueRoutes
   };
 }

--- a/src/lib/routes-discovery.ts
+++ b/src/lib/routes-discovery.ts
@@ -3,6 +3,13 @@ import { routes } from '../config/routes.ts';
 import { RESEARCH_TOOLS } from '../config/research-tools.ts';
 
 /**
+ * Resolves the canonical path for a route or tool.
+ */
+function resolveCanonical(path: string, config?: { canonicalPath?: string }): string {
+  return config?.canonicalPath || path;
+}
+
+/**
  * Discovers all application routes from various sources.
  * Centralizes discovery logic to prevent duplication and drift.
  *
@@ -16,11 +23,13 @@ export function getAllRoutes() {
   // Use canonicalPath if available, and filter out routes marked as sitemap: false
   const staticRoutes = routes
     .filter(r => r.sitemap !== false && r.path !== '*' && !r.path.includes(':'))
-    .map(r => r.canonicalPath || r.path);
+    .map(r => resolveCanonical(r.path, r));
 
   // 2. Dynamic research tool routes
   // Use canonicalPath if available to avoid duplicates (e.g. /ux-auditor vs /research/ux-auditor)
-  const toolRoutes = RESEARCH_TOOLS.map(tool => tool.canonicalPath || `/research/${tool.id}`);
+  const toolRoutes = RESEARCH_TOOLS.map(tool =>
+    resolveCanonical(`/research/${tool.id}`, tool)
+  );
 
   // 3. Dynamic content routes discovered from file system
   const contentRoutes = Object.entries(CONTENT_DIR_MAP).flatMap(([prefix, dir]) =>

--- a/src/lib/types/routes.ts
+++ b/src/lib/types/routes.ts
@@ -9,4 +9,6 @@ export interface RouteConfig extends Omit<RouteObject, 'children'> {
   description?: string;
   children?: RouteConfig[];
   skeleton?: SkeletonVariant;
+  sitemap?: boolean;
+  canonicalPath?: string;
 }

--- a/src/pages/ComponentPreview.tsx
+++ b/src/pages/ComponentPreview.tsx
@@ -1,4 +1,5 @@
 import { Box, Stack, Text } from '@/layouts/Primitives';
+import { SEO } from '@/components/SEO';
 import { EventHero } from '@/features/events/components/EventHero';
 import { ThemeSpotlight } from '@/features/events/components/ThemeSpotlight';
 import { CuratedGear } from '@/features/events/components/CuratedGear';
@@ -7,6 +8,11 @@ import { RelatedEvents } from '@/features/events/components/RelatedEvents';
 export default function ComponentPreview() {
   return (
     <Box padding={8}>
+      <SEO
+        title="Component Preview"
+        description="Development environment for testing UI components in isolation."
+        noindex={true}
+      />
       <Stack gap={12}>
         <Text variant="headline" size="4xl">Component Preview</Text>
 


### PR DESCRIPTION
This change cleans up the sitemap generation and canonical route metadata for boomtick.blog.

Key improvements:
1. **Deduplication**: The sitemap discovery logic now uses a Set to ensure unique URLs and prefers canonical paths defined in route or tool configurations.
2. **Exclusion**: Non-public routes like `/preview` are now explicitly excluded from the sitemap via a `sitemap: false` flag.
3. **Canonical Tool Paths**: The UX Auditor tool now has a single canonical URL (`/ux-auditor`). A redirect is implemented in the research detail view to move users from the legacy `/research/ux-auditor` path to the canonical one.
4. **Testing**: A new unit test suite ensures that `getAllRoutes` returns unique, public-only URLs and correctly handles tool paths.

Acceptance Criteria Met:
- No duplicate <loc> entries in generated sitemap.
- /preview is excluded.
- UX Auditor uses /ux-auditor as canonical with redirect from the other.
- Tool URLs match actual route behavior.
- Regression test added for uniqueness.

Fixes #1325

---
*PR created automatically by Jules for task [15327076520551374849](https://jules.google.com/task/15327076520551374849) started by @arii*