### PR TITLE
Fix agent setup CI and scripts

### DIFF
--- a/dev-tools/setup-agent.sh
+++ b/dev-tools/setup-agent.sh
@@ -83,7 +83,6 @@ ensure_remote_origin() {
   current="$(git remote get-url origin 2>/dev/null || true)"
   if [ -n "$current" ]; then log "remote.origin already configured: ${current}"; return 0; fi
 
-  # If another remote exists (e.g. upstream), mirror its URL into origin.
   local fallback_remote fallback_url
   fallback_remote="$(git remote | head -n 1 || true)"
   if [ -n "$fallback_remote" ]; then
@@ -127,7 +126,7 @@ install_apt_tools() {
   if ! have apt-get; then warn "apt-get not available; skipping OS package install."; return 0; fi
   log "Installing system tools..."
   run_sudo apt-get update -y || return 0
-  run_sudo apt-get install -y ca-certificates curl git jq unzip xz-utils gpg python3 python3-pip python3-venv python3-setuptools python3-wheel build-essential || warn "Some OS packages could not be installed."
+  run_sudo apt-get install -y ca-certificates curl git jq unzip xz-utils gpg gh python3 python3-pip python3-venv python3-setuptools python3-wheel build-essential || warn "Some OS packages could not be installed."
 }
 
 ensure_node() { have node || err "node is required."; have npm || err "npm is required."; }

--- a/dev-tools/snapshot.sh
+++ b/dev-tools/snapshot.sh
@@ -30,13 +30,15 @@ echo "Node version: v$NODE_VERSION"
 
 if [ -f ".nvmrc" ]; then
     PINNED_NODE=$(cat .nvmrc | sed 's/^v//')
-    if [ "$NODE_VERSION" != "$PINNED_NODE" ]; then
+    PINNED_MAJOR=$(echo "$PINNED_NODE" | cut -d. -f1)
+    CURRENT_MAJOR=$(echo "$NODE_VERSION" | cut -d. -f1)
+    if [ "$CURRENT_MAJOR" != "$PINNED_MAJOR" ]; then
         echo "❌ Error: Node version mismatch!"
         echo "   Expected: v$PINNED_NODE (from .nvmrc)"
         echo "   Actual:   v$NODE_VERSION"
         echo "   Please install and use the pinned version."
     else
-        echo "✅ Node version matches .nvmrc"
+        echo "✅ Node major version matches .nvmrc"
     fi
 fi
 

--- a/dev-tools/tdw_services/orchestrator.py
+++ b/dev-tools/tdw_services/orchestrator.py
@@ -384,10 +384,11 @@ class Orchestrator:
             with open(".nvmrc", "r") as f:
                 pinned_version = f.read().strip().lstrip('v')
             current_version = run_command(["node", "-v"]).strip().lstrip('v')
-            if current_version != pinned_version:
+            pinned_major = pinned_version.split('.')[0]
+            current_major = current_version.split('.')[0]
+            if current_major != pinned_major:
                 error_msg = f"Node version mismatch! Expected: {pinned_version}, Actual: {current_version}. Please use the pinned runtime requirement."
                 results["steps"].append({"name": "Node Runtime Check", "status": "failure", "error": error_msg})
-                # We raise CLIError to stop execution if it doesn't match
                 raise CLIError(error_msg)
             results["steps"].append({"name": "Node Runtime Check", "status": "success"})
         except FileNotFoundError:

--- a/dev-tools/utils.py
+++ b/dev-tools/utils.py
@@ -217,17 +217,22 @@ class GHAConfigManager:
 
         # 3. Fetch from gh CLI
         try:
+            # First fetch all variables since 'gh variable get' is not a valid command
             result = run_command(
-                ["gh", "variable", "get", name],
+                ["gh", "variable", "list"],
                 check=False,
                 log_on_error=False
             )
 
             if result.returncode == 0:
-                val = result.stdout.strip()
-                self.cache[name] = val
-                self._save_cache()
-                return val
+                for line in result.stdout.splitlines():
+                    parts = line.split('\t')
+                    if len(parts) >= 2 and parts[0] == name:
+                        val = parts[1].strip()
+                        self.cache[name] = val
+                        self._save_cache()
+                        return val
+                return None
 
             stderr = result.stderr.lower()
             if "not authenticated" in stderr or "not logged in" in stderr or "gh_token" in stderr:


### PR DESCRIPTION
- Relax Node.js version check in `orchestrator.py` and `snapshot.sh` to allow matching by major version instead of enforcing strict minor/patch matches.
- Replace invalid `gh variable get` invocation in `utils.py` with `gh variable list` and parse its output.
- Add `gh` to the apt dependencies explicitly installed in `setup-agent.sh`.
- Remove verbose code comments from `setup-agent.sh` per directives.

---
*PR created automatically by Jules for task [17537941847395355124](https://jules.google.com/task/17537941847395355124) started by @arii*