### PR TITLE
Enhance Playwright Snapshot failure comment with run link

### DIFF
--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -102,6 +102,6 @@ jobs:
           comment-id: ${{ steps.initial-comment.outputs.comment-id }}
           body: |
             ❌ Failed to update Playwright snapshots.
-            Please check the workflow logs for more details.
+            Please check the [workflow logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for more details.
           edit-mode: replace
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The Playwright snapshot update workflow now provides an active diagnostic hyperlink back to the actual GitHub Actions run context in its failure comment. This eliminates the need for maintainers to manually navigate between the pull request and the actions tab to debug failures.

Fixes #1366

---
*PR created automatically by Jules for task [11769568318337075002](https://jules.google.com/task/11769568318337075002) started by @arii*