### PR TITLE
Fix build versioning and hardcoded commit links in production deployment

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -51,8 +51,12 @@ export default defineConfig(({mode}) => {
     define: {
       'process.env.APP_URL': JSON.stringify(fullAppUrl),
       'import.meta.env.VITE_APP_URL': JSON.stringify(fullAppUrl),
-      'import.meta.env.VITE_APP_VERSION': JSON.stringify(process.env.npm_package_version),
-      'import.meta.env.VITE_COMMIT_SHA': JSON.stringify(process.env.GITHUB_SHA || 'dev'),
+      'import.meta.env.VITE_APP_VERSION': JSON.stringify(process.env.npm_package_version || '0.0.0'),
+      'import.meta.env.VITE_COMMIT_SHA': JSON.stringify(
+        process.env.VERCEL_GIT_COMMIT_SHA ||
+        process.env.GITHUB_SHA ||
+        'dev'
+      ),
     },
     plugins: [
       react(),


### PR DESCRIPTION
This change ensures that the production deployment correctly identifies and displays the build version and Git commit SHA by mapping Vercel-provided environment variables to the application's build-time constants in the Vite configuration.

Fixes #1377

---
*PR created automatically by Jules for task [7925309819331651254](https://jules.google.com/task/7925309819331651254) started by @arii*