### PR TITLE
Fix mobile horizontal layout overflow and anchor clipping in Event Hero navigation

### DIFF
--- a/src/features/events/components/EventHero.tsx
+++ b/src/features/events/components/EventHero.tsx
@@ -38,7 +38,7 @@ export function EventHero({
       width="full"
       minHeight={{ base: "30vh", md: "40vh" }}
       display="flex"
-      direction="column"
+      flexDirection="column"
       overflow="hidden"
       className="bg-bg"
     >

--- a/src/features/events/components/EventNavigation.tsx
+++ b/src/features/events/components/EventNavigation.tsx
@@ -19,7 +19,8 @@ export function EventNavigation() {
           bottom={0}
           width={12}
           display={{ base: "block", md: "none" }}
-          className="bg-gradient-to-l from-bg to-transparent pointer-events-none z-10"
+          bgGradient="bg-gradient-to-l from-bg to-transparent"
+          className="pointer-events-none z-10"
         />
 
         <Box
@@ -27,10 +28,10 @@ export function EventNavigation() {
           width="full"
           gap={{ base: 8, md: 10 }}
           overflowX="auto"
+          momentumScroll
           className="no-scrollbar scroll-smooth"
           paddingLeft={{ base: 6, md: 0 }}
           paddingRight={{ base: 12, md: 0 }}
-          style={{ WebkitOverflowScrolling: 'touch' }}
         >
           {EVENT_TABS.map(tab => (
             <Box

--- a/src/features/events/components/EventNavigation.tsx
+++ b/src/features/events/components/EventNavigation.tsx
@@ -6,10 +6,11 @@ export function EventNavigation() {
     <Box
       position="sticky"
       top={{ base: 16, lg: 0 }}
+      width="full"
       zIndex={40}
       className="bg-bg/80 backdrop-blur-md border-b border-line/10"
     >
-      <Box maxWidth="screen-xl" marginX="auto" paddingX={{ base: 0, md: 12, lg: 24 }} position="relative">
+      <Box maxWidth="screen-xl" width="full" marginX="auto" paddingX={{ base: 0, md: 12, lg: 24 }} position="relative">
         {/* Right fade indicator for mobile horizontal scroll */}
         <Box
           position="absolute"
@@ -23,10 +24,13 @@ export function EventNavigation() {
 
         <Box
           display="flex"
+          width="full"
           gap={{ base: 8, md: 10 }}
           overflowX="auto"
           className="no-scrollbar scroll-smooth"
-          paddingX={{ base: 6, md: 0 }}
+          paddingLeft={{ base: 6, md: 0 }}
+          paddingRight={{ base: 12, md: 0 }}
+          style={{ WebkitOverflowScrolling: 'touch' }}
         >
           {EVENT_TABS.map(tab => (
             <Box

--- a/src/layouts/Box.tsx
+++ b/src/layouts/Box.tsx
@@ -65,6 +65,8 @@ export interface BaseProps {
   cursor?: "auto" | "default" | "pointer" | "wait" | "text" | "move" | "help" | "not-allowed" | "none" | string
   flexWrap?: boolean | "wrap" | "wrap-reverse" | "nowrap"
   textAlign?: ResponsiveProp<"left" | "center" | "right" | "justify">
+  bgGradient?: string
+  momentumScroll?: boolean
 }
 
 export interface BoxProps extends BaseProps, HTMLAttributes<HTMLDivElement> {
@@ -84,6 +86,7 @@ export const Box = forwardRef<HTMLDivElement, BoxProps>(
     surface, emphasis, radius: radiusProp, panel, flex, wrap, shadow,
     position, inset, height, width, maxWidth, minHeight, maxHeight, minWidth, 
     overflow, overflowX, overflowY, zIndex, opacity, display, aspect, shrink, self, span, cursor, flexWrap, textAlign,
+    bgGradient, momentumScroll,
     justify, align, scrollBehavior: _scrollBehavior, scrollPaddingTop, scrollMarginTop,
     top, right, bottom, left,
     // Motion props filtering
@@ -223,6 +226,7 @@ export const Box = forwardRef<HTMLDivElement, BoxProps>(
           cursor && `cursor-${cursor}`,
           self && (self === "start" ? "self-start" : self === "center" ? "self-center" : self === "end" ? "self-end" : self === "stretch" ? "self-stretch" : "self-auto"),
           getResponsiveClasses(textAlign, "text-"),
+          bgGradient,
           justify && (justify === "start" ? "justify-start" : justify === "center" ? "justify-center" : justify === "end" ? "justify-end" : justify === "between" ? "justify-between" : justify === "around" ? "justify-around" : "justify-evenly"),
           align && (align === "start" ? "items-start" : align === "center" ? "items-center" : align === "end" ? "items-end" : align === "baseline" ? "items-baseline" : "items-stretch"),
           getResponsiveClasses(top, "", s("top")),
@@ -235,6 +239,7 @@ export const Box = forwardRef<HTMLDivElement, BoxProps>(
         )}
         style={{ // impeccable-ignore - Dynamic and motion-driven styles require inline style pass-through.
           ...((scrollPaddingTop !== undefined) ? { scrollPaddingTop: typeof scrollPaddingTop === 'number' ? `${scrollPaddingTop}px` : scrollPaddingTop } : {}),
+          ...(momentumScroll ? { WebkitOverflowScrolling: 'touch' } : {}),
           ...motionProps.style,
           ...props.style
         }}


### PR DESCRIPTION
This PR fixes a bug where the sticky event sub-navigation bar in the Event Hero component would cause the entire document to scroll horizontally on mobile devices. 

By adding explicit `width="full"` constraints to the navigation containers, we ensure that the flex-based scrollable track stays within the viewport, correctly triggering its own `overflow-x: auto` behavior. Additionally, momentum scrolling was enabled for iOS devices, and padding was adjusted to prevent the final menu item from being clipped by the visual fade-out indicator.

Fixes #1368

---
*PR created automatically by Jules for task [10896943585852759099](https://jules.google.com/task/10896943585852759099) started by @arii*