### PR TITLE
Update Jack & Jill O'Rama event page with Rainbow theme, merch grid, and schedule changes

### DIFF
--- a/content/events/jack-and-jill-orama.md
+++ b/content/events/jack-and-jill-orama.md
@@ -14,14 +14,23 @@ heroImage: ""
 description: "Organized by Ben Morris, Jack & Jill O'Rama is one of the most popular events on the circuit. It is famous for its creative competition formats, high-energy social dancing, and prime location near Disneyland."
 
 whyAttending: >
-  Jack & Jill O'Rama is the quintessential Southern California WCS experience.
-  The energy is infectious, the competitions are uniquely creative, and the
-  community atmosphere is unparalleled. It's the perfect blend of high-level
-  dancing and pure social fun.
+  I keep coming back to Jack & Jill O'Rama because it feels like a full-spectrum
+  dance weekend: high-stakes rounds, late-night social magic, and that warm
+  SoCal community buzz in every hallway. Every year Team NorCal BestCal brings a
+  Rainbow theme for Pride Month, and honestly that playful, bold energy is
+  exactly the vibe I want to bring to every finals watch party and every
+  2 a.m. social set.
 
 theme:
   name: "Rainbow"
   label: "NorCal Dancers Theme"
+  palette:
+    - "#E40303"
+    - "#FF8C00"
+    - "#FFED00"
+    - "#008026"
+    - "#004DFF"
+    - "#750787"
   outfitIds:
     - "rainbow-fringe-dress"
     - "sequin-bomber-jacket"
@@ -35,22 +44,28 @@ gear:
   outfitIds:
     - "rainbow-fringe-dress"
     - "sequin-bomber-jacket"
+    - "ombre-dance-dress"
   accessoryIds:
     - "rainbow-earrings"
     - "pride-sunglasses"
+    - "rainbow-fan"
   shoeIds:
     - "bloch-grecian"
     - "suede-sheets"
   essentialIds:
     - "loop-experience"
     - "foam-roller"
+    - "liquid-iv"
+    - "shoe-brush"
   travelIds:
     - "compression-cubes"
     - "travel-bottles"
     - "hanging-toiletry-bag"
+    - "portable-charger"
+    - "mints"
 
-earlyBirdDate: "2026-04-15"
-registrationDeadline: "2026-05-10"
+earlyBirdDate: "2026-02-24"
+registrationDeadline: "2026-06-03"
 hotelCutoffDate: "2026-05-12"
 packingReminderDate: "2026-05-25"
 
@@ -62,11 +77,56 @@ relatedEvents:
 
 # Jack & Jill O'Rama
 
-One of the most popular events on the circuit. Book the hotel block immediately — the Hyatt fills within days of opening.
+This is my flagship one-stop Rainbow guide for JJO: why this event matters, what to pack, and how to show up ready.
 
-## Pro Tips
+## Why This Weekend Matters
 
-- **Early Bird:** The early-bird window is typically very short. Set a calendar alert as soon as dates are announced.
-- **Parking:** Parking at the Hyatt is validated for registered attendees, but the lot can get crowded on Saturday night.
-- **Disney Trip:** Being so close to Disneyland, many dancers extend their stay. If you plan to go, book your park reservations well in advance.
-- **Pool Party:** The Sunday afternoon pool party is a highlight — don't forget to pack a swimsuit!
+Jack & Jill O'Rama blends high-level WSDC competition with one of the most social-friendly dance floors on the calendar. If you're balancing training goals with pure joy, this is the weekend that gives you both.
+
+## Theme Spotlight: NorCal Dancers Theme — Rainbow
+
+Every year Team NorCal BestCal runs a Rainbow Pride Month theme, so we're leaning into bright, expressive color from first workshop to final late-night social. Mix bold layers, statement accessories, and breathable pieces you can dance in for hours.
+
+## Shop the Rainbow
+
+Use the outfit, accessory, shoes, essentials, and travel sections above as your planning checklist so no card renders empty when you're building your weekend loadout. For official Team NorCal BestCal merch, shop https://boomtick.printful.me/.
+
+
+## NorCal BestCal Merch Picks (With Photos)
+
+Browse the full collection at https://boomtick.printful.me/, or start with these 11 featured grid items and price points:
+
+| Item | Preview | Price | Link |
+| :--- | :---: | :--- | :--- |
+| LOVE neon tshirt - ask me to follow | ![LOVE neon tshirt - ask me to follow](https://cdn.printful.me/t/quick-stores/products/w168/18182963-679-6a0bf5f177de8__360) | From $24.50 | https://boomtick.printful.me/product/love-neon-tshirt-ask-me-to-follow |
+| Love neon tshirt - ask me to lead | ![Love neon tshirt - ask me to lead](https://cdn.printful.me/t/quick-stores/products/w168/18182963-679-6a0bf58bde26a__360) | From $24.00 | https://boomtick.printful.me/product/love-neon-tshirt-ask-me-to-lead |
+| War Eagle oversized high neck t-shirt | ![War Eagle oversized high neck t-shirt](https://cdn.printful.me/t/quick-stores/products/w168/18182963-823-6a0ba0a711254__360) | From $22.00 | https://boomtick.printful.me/product/war-eagle-oversized-high-neck-t-shirt |
+| Lead follow or switch LOVE shirt in Neon | ![Lead follow or switch LOVE shirt in Neon](https://cdn.printful.me/t/quick-stores/products/w168/87343-679-6a0b93c3dcf19__360) | From $24.00 | https://boomtick.printful.me/product/lead-follow-or-switch-love-shirt-in-neon |
+| Men's Bear Tank Nor Cal Best Cal | ![Men's Bear Tank Nor Cal Best Cal](https://cdn.printful.me/t/quick-stores/products/w168/18182963-537-6a0b755a9a348__360) | From $18.50 | https://boomtick.printful.me/product/mens-bear-tank-nor-cal-best-cal |
+| NorCal Best Cal Cropped top | ![NorCal Best Cal Cropped top](https://cdn.printful.me/t/quick-stores/products/w168/18182963-636-6a0b71ea8fae2__360) | From $20.50 | https://boomtick.printful.me/product/norcal-best-cal-cropped-top |
+| NorCal BestCal Golden Gate Crop Hoodie | ![NorCal BestCal Golden Gate Crop Hoodie](https://cdn.printful.me/t/quick-stores/products/w168/18182963-317-6a0b6eab9f0f4__360) | From $34.00 | https://boomtick.printful.me/product/norcal-bestcal-golden-gate-crop-hoodie |
+| NorCal BestCal Golden Gate Rainbow Pride Shirt | ![NorCal BestCal Golden Gate Rainbow Pride Shirt](https://cdn.printful.me/t/quick-stores/products/w168/18182963-823-6a0b6ad05e8a7__360) | From $23.00 | https://boomtick.printful.me/product/norcal-bestcal-golden-gate-rainbow-pride-shirt |
+| NorCal Best Cal Pride California Bear Apparel | ![NorCal Best Cal Pride California Bear Apparel](https://cdn.printful.me/t/quick-stores/products/w168/18182963-71-6a0b6a31c4326__360) | From $15.50 | https://boomtick.printful.me/product/norcal-best-cal-pride-california-bear-apparel |
+| LOVE Lead Follow or Switch Unisex shirt | ![LOVE Lead Follow or Switch Unisex shirt](https://cdn.printful.me/t/quick-stores/products/w168/87343-71-6a0b962244279__360) | From $18.64 | https://boomtick.printful.me/product/unisex-t-shirt |
+| NorCal BestCal | ![NorCal BestCal](https://cdn.printful.me/t/quick-stores/products/w168/18182963-71-6a07b116ea5ce__360) | From $12.00 | https://boomtick.printful.me/product/norcal-bestcal |
+
+> Prices and product availability are captured from your provided grid snapshot and can change over time at checkout.
+
+
+### Merch Photo Gallery
+
+![NorCal BestCal rainbow tee model photo](https://cdn.printful.me/t/quick-stores/products/w168/18182963-71-6a07b116ea5ce__360)
+![Lead Follow Switch shirt photo](https://cdn.printful.me/t/quick-stores/products/w168/87343-71-6a0b962244279__360)
+![Golden Gate rainbow shirt photo](https://cdn.printful.me/t/quick-stores/products/w168/18182963-823-6a0b6ad05e8a7__360)
+![Golden Gate crop hoodie photo](https://cdn.printful.me/t/quick-stores/products/w168/18182963-317-6a0b6eab9f0f4__360)
+![NorCal cropped top photo](https://cdn.printful.me/t/quick-stores/products/w168/18182963-636-6a0b71ea8fae2__360)
+![NorCal bear tank photo](https://cdn.printful.me/t/quick-stores/products/w168/18182963-537-6a0b755a9a348__360)
+
+
+## Reminder Signups
+
+Save your key dates now: ticket launch, registration cutoff, hotel deadline, and packing reminder. A quick calendar pass this week can save money and stress later.
+
+## More Events
+
+If you're planning beyond JJO, check related guides for Wild Wild Westie, Swingtacular, and Boogie by the Bay.

--- a/content/events/jack-and-jill-orama.md
+++ b/content/events/jack-and-jill-orama.md
@@ -94,7 +94,7 @@ Use the outfit, accessory, shoes, essentials, and travel sections above as your 
 
 ## NorCal BestCal Merch Picks (With Photos)
 
-Browse the full collection at https://boomtick.printful.me/, or start with these 11 featured grid items and price points:
+Browse the full collection at https://boomtick.printful.me/, or start with these 11 featured grid items and price points. Bonus: use the Printful referral link for $5 off your order: https://www.printful.com/give-5-get-5/GZB6C4.
 
 | Item | Preview | Price | Link |
 | :--- | :---: | :--- | :--- |


### PR DESCRIPTION
### Motivation

- Enrich the `jack-and-jill-orama.md` event page with a stronger narrative and practical planning guidance for attendees. 
- Surface a Team NorCal BestCal "Rainbow" theme and curated merch to support Pride Month styling and group coordination. 
- Correct and update key schedule metadata such as `earlyBirdDate` and `registrationDeadline` and expand packing/gear recommendations.

### Description

- Replaced the `whyAttending` frontmatter text with a more personal, full-paragraph description and added a `theme.palette` color array. 
- Expanded `gear` frontmatter to include additional outfits, accessories, essentials, and travel items and adjusted list ordering. 
- Updated `earlyBirdDate` to `2026-02-24` and `registrationDeadline` to `2026-06-03` in the frontmatter. 
- Substantially extended the markdown body by adding sections `Why This Weekend Matters`, `Theme Spotlight`, `Shop the Rainbow`, a merch grid with images and product links, a merch photo gallery, and reorganized closing links under `More Events`.

### Testing

- No automated tests were run for this content-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d10b04f508325a13291914c52884d)