### PR TITLE
Add initial /merch storefront route and referral CTA

### DIFF
--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -1,4 +1,4 @@
-import { Home, BookOpen, ShoppingBag, Database, User, Send, Calendar } from 'lucide-react';
+import { Home, BookOpen, ShoppingBag, Database, User, Send, Calendar, Shirt } from 'lucide-react';
 import { RouteConfig } from '@/lib/types/routes';
 
 import { LucideIcon } from 'lucide-react';
@@ -48,6 +48,14 @@ export const routes: RouteConfig[] = [
     lazy: () => import('@/features/events/EventGuide').then(m => ({ Component: m.default })),
     skeleton: 'post'
   },
+
+  {
+    path: '/merch',
+    lazy: () => import('@/pages/Merch').then(m => ({ Component: m.default })),
+    label: 'Merch',
+    icon: Shirt,
+    skeleton: 'grid'
+  },
   {
     path: '/research',
     lazy: () => import('@/pages/Research').then(m => ({ Component: m.default })),
@@ -93,5 +101,5 @@ export const routes: RouteConfig[] = [
 ];
 
 export const MOBILE_NAV_ROUTES = routes.filter((r): r is RouteConfig & { label: string, icon: LucideIcon } =>
-  !!(r.label && r.icon && ['/', '/blog', '/gear', '/events', '/research'].includes(r.path))
+  !!(r.label && r.icon && ['/', '/blog', '/gear', '/events', '/research', '/merch'].includes(r.path))
 );

--- a/src/data/merch.ts
+++ b/src/data/merch.ts
@@ -1,0 +1,31 @@
+export type MerchCollection = 'lead-follow-switch' | 'norcal-bestcal' | 'rainbow-pride';
+
+export interface MerchProduct {
+  slug: string;
+  title: string;
+  description: string;
+  priceFrom: string;
+  tags: string[];
+  collection: MerchCollection;
+  image: string;
+  alt: string;
+  storeUrl: string;
+  roles?: Array<'lead' | 'follow' | 'switch'>;
+}
+
+export const PRINTFUL_REFERRAL_URL = 'https://www.printful.com/give-5-get-5/GZB6C4';
+
+export const merchProducts: MerchProduct[] = [
+  {
+    slug: 'lead-follow-switch-unisex-tee',
+    title: 'Lead Follow Switch Unisex Tee',
+    description: 'Soft everyday tee built for social dancing nights and weekend workshops.',
+    priceFrom: '24.99',
+    tags: ['West Coast Swing', 'social dance apparel'],
+    collection: 'lead-follow-switch',
+    image: '/assets/merch/lead-follow-switch-tee.webp',
+    alt: 'Lead Follow Switch shirt with role typography for social dance nights',
+    storeUrl: 'https://boomtick.printful.me/product/lead-follow-switch-unisex-tee',
+    roles: ['lead', 'follow', 'switch'],
+  },
+];

--- a/src/pages/Merch.tsx
+++ b/src/pages/Merch.tsx
@@ -1,0 +1,42 @@
+import { Gift } from 'lucide-react';
+import { SEO } from '@/components/SEO';
+import { Button, Grid, Stack, Text, Box } from '@/layouts/Primitives';
+import { merchProducts, PRINTFUL_REFERRAL_URL } from '@/data/merch';
+
+export default function Merch() {
+  return (
+    <Stack gap={8} padding={6}>
+      <SEO
+        title="West Coast Swing Dance Merch & NorCal Apparel | BoomTick"
+        description="Shop official BoomTick apparel for West Coast Swing dancers, social dancers, and NorCal locals."
+      />
+
+      <Stack gap={3}>
+        <Text as="h1" variant="display" size="4xl">West Coast Swing Dance Merch</Text>
+        <Text color="body">Editorial picks from our Printful store for dancers and NorCal locals.</Text>
+      </Stack>
+
+      <Box border="all" radius="lg" padding={4} className="bg-surface-alt border-line">
+        <Stack direction="row" justify="between" align="center" gap={3}>
+          <Stack gap={1}>
+            <Stack direction="row" align="center" gap={2}><Gift className="h-5 w-5" /><Text as="h2" variant="sans" size="xl">Get $5 Off Your First Order</Text></Stack>
+            <Text color="body">New to Printful? Use our referral link to save $5 on your first purchase.</Text>
+          </Stack>
+          <Button as="a" href={PRINTFUL_REFERRAL_URL} target="_blank" rel="sponsored noopener noreferrer">Claim $5 Discount</Button>
+        </Stack>
+      </Box>
+
+      <Grid cols={{ base: 1, md: 2 }} gap={4}>
+        {merchProducts.map((product) => (
+          <Stack key={product.slug} border="all" radius="lg" padding={4} gap={3} className="border-line bg-surface">
+            <Box as="img" src={product.image} alt={product.alt} width="full" radius="md" className="aspect-square object-cover" />
+            <Text as="h3" variant="sans" size="xl">{product.title}</Text>
+            <Text color="body">{product.description}</Text>
+            <Text size="sm" color="dim">From ${product.priceFrom}</Text>
+            <Button as="a" href={product.storeUrl} target="_blank" rel="sponsored noopener noreferrer">See Colors & Sizes</Button>
+          </Stack>
+        ))}
+      </Grid>
+    </Stack>
+  );
+}


### PR DESCRIPTION
### Motivation
- Provide an editorial merch landing page that showcases BoomTick products and funnels purchases to Printful.  
- Surface a $5 Printful referral discount prominently to drive first-time conversions.  
- Integrate the merch experience into site routing and navigation while keeping to existing primitives and lazy-loaded routes.

### Description
- Added a new lazy route entry for `/merch` and included it in mobile navigation by updating `src/config/routes.ts`.  
- Introduced a small data layer at `src/data/merch.ts` with `MerchProduct`/`MerchCollection` types, `PRINTFUL_REFERRAL_URL`, and an initial product scaffold.  
- Implemented the storefront page at `src/pages/Merch.tsx` using design primitives (`Stack`, `Box`, `Grid`, `Text`, `Button`), with SEO metadata, a hero, a referral banner (with `Gift` icon), and product cards linking to Printful.  
- Ensured outbound Printful links use `target="_blank"` and `rel="sponsored noopener noreferrer"`, and replaced an initial raw Tailwind spacing class with primitives to satisfy the audit.

### Testing
- Ran `pnpm run audit`, which initially reported one anti-pattern and then passed after replacing inline spacing with primitives.  
- Built the site with `pnpm run build`, which completed successfully and generated SPA stubs including `/merch`.  
- Attempted `python3 dev-tools/td_cli.py conflicts` as a workflow check but the command is not available in this repo, so it was treated as a manual check attempt.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d30bdfa648325b164bc130113f80d)