### PR TITLE
Follow-up: enforce CI failure triage and approval gating in PR review workflow

### DIFF
--- a/.agent/workflows/REVIEW_INSTRUCTIONS.md
+++ b/.agent/workflows/REVIEW_INSTRUCTIONS.md
@@ -46,3 +46,13 @@ All review submissions MUST follow this JSON schema exactly.
 ## 3. Tooling Guidelines
 
 Agents must not directly use git or gh commands but reuse existing tooling. Agents should not use Copilot, but may use Ollama.
+
+## 4. CI Failure Gating (Blocking Rule)
+
+CI status in `pr-context-<PR_NUMBER>.md` is a hard gate for approval:
+
+- If any required CI check has `failure`, `timed_out`, or `cancelled`, the final recommendation must be `Not Approved`.
+- The review body must include: (a) failing check name, (b) failing suite/test or build step, and (c) at least one concrete remediation step.
+- If CI is still in progress, do not approve; use `Approved with Minor Changes` only when code quality is otherwise clean and the note explicitly states CI is pending verification.
+- Approval is only allowed when required checks are successful (or explicitly documented as non-blocking in repository policy).
+

--- a/.agent/workflows/review-pr.md
+++ b/.agent/workflows/review-pr.md
@@ -48,6 +48,7 @@ PYTHONPATH=$(pwd)/dev-tools python3 dev-tools/tdw_services/cli.py gh audit-pr PR
 2. **Read the Context & Instructions**:
    - Read `.agent/workflows/REVIEW_INSTRUCTIONS.md` to understand the audit criteria. The audit scope includes `src/features`, `src/pages`, `src/components`, and `src/layouts`.
    - Read `dev-tools/logs/reviews/pr-context-PR_NUMBER.md` to analyze the code diffs, stats, and **Last Commit Time**.
+   - If any CI check in the context has a failing conclusion, perform dedicated log triage before drafting recommendations: identify the failing suite, isolate the primary error, and include concrete remediation steps in the review body.
 
 3. **Draft the Feedback (Output)**:
    - Open the generated `dev-tools/logs/reviews/pr-review-PR_NUMBER.md` file.


### PR DESCRIPTION
### Motivation

- Ensure the PR audit workflow acts on CI signal captured by the auditor by making failing checks a hard gate for approvals.  
- Close the gap between `audit_pr` capturing check-run data and reviewer behavior by requiring explicit failure triage and remediation guidance.  

### Description

- Add a new **CI Failure Gating** section to `.agent/workflows/REVIEW_INSTRUCTIONS.md` that blocks approval when required checks are `failure`, `timed_out`, or `cancelled` and mandates specific review artifacts for failures.  
- Update `.agent/workflows/review-pr.md` to require dedicated log triage when any CI check in the PR context has a failing conclusion and to surface failing-suite/error and remediation steps in the review body.  
- These changes are documentation/workflow-only and do not modify runtime code paths.  

### Testing

- Located relevant orchestrator and workflow references using `rg -n "audit_pr|fetch_check_runs|REVIEW_INSTRUCTIONS|review-pr"` to ensure consistency with `dev-tools/tdw_services/orchestrator.py`.  
- Applied the text patches via a small Python edit script and confirmed the expected CI gating text appears in both workflow files by inspecting the updated file contents.  
- Attempted `python3 dev-tools/td_cli.py conflicts` which failed because the `conflicts` subcommand is not present in this repository's CLI.  
- Created a follow-up PR entry using the repository helper tooling to record the change and rationale.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d377bcdb0832580ad41b9bcf94b09)