### PR TITLE
Add remark-gfm and enable GFM parsing; update JJO merch content and table formatting

### DIFF
--- a/content/events/jack-and-jill-orama.md
+++ b/content/events/jack-and-jill-orama.md
@@ -89,26 +89,25 @@ Every year Team NorCal BestCal runs a Rainbow Pride Month theme, so we're leanin
 
 ## Shop the Rainbow
 
-Use the outfit, accessory, shoes, essentials, and travel sections above as your planning checklist so no card renders empty when you're building your weekend loadout. For official Team NorCal BestCal merch, shop https://boomtick.printful.me/.
+Use the outfit, accessory, shoes, essentials, and travel sections above as your planning checklist so no card renders empty when you're building your weekend loadout. For official Team NorCal BestCal merch, shop [boomtick.printful.me](https://boomtick.printful.me/).
 
+## NorCal BestCal Merch Picks
 
-## NorCal BestCal Merch Picks (With Photos)
-
-Browse the full collection at https://boomtick.printful.me/, or start with these 11 featured grid items and price points. Bonus: use the Printful referral link for $5 off your order: https://www.printful.com/give-5-get-5/GZB6C4.
+Browse our featured collection or use the [Printful referral link](https://www.printful.com/give-5-get-5/GZB6C4) to get **$5 off your order**.
 
 | Item | Preview | Price | Link |
-| :--- | :---: | :--- | :--- |
-| LOVE neon tshirt - ask me to follow | ![LOVE neon tshirt - ask me to follow](https://cdn.printful.me/t/quick-stores/products/w168/18182963-679-6a0bf5f177de8__360) | From $24.50 | https://boomtick.printful.me/product/love-neon-tshirt-ask-me-to-follow |
-| Love neon tshirt - ask me to lead | ![Love neon tshirt - ask me to lead](https://cdn.printful.me/t/quick-stores/products/w168/18182963-679-6a0bf58bde26a__360) | From $24.00 | https://boomtick.printful.me/product/love-neon-tshirt-ask-me-to-lead |
-| War Eagle oversized high neck t-shirt | ![War Eagle oversized high neck t-shirt](https://cdn.printful.me/t/quick-stores/products/w168/18182963-823-6a0ba0a711254__360) | From $22.00 | https://boomtick.printful.me/product/war-eagle-oversized-high-neck-t-shirt |
-| Lead follow or switch LOVE shirt in Neon | ![Lead follow or switch LOVE shirt in Neon](https://cdn.printful.me/t/quick-stores/products/w168/87343-679-6a0b93c3dcf19__360) | From $24.00 | https://boomtick.printful.me/product/lead-follow-or-switch-love-shirt-in-neon |
-| Men's Bear Tank Nor Cal Best Cal | ![Men's Bear Tank Nor Cal Best Cal](https://cdn.printful.me/t/quick-stores/products/w168/18182963-537-6a0b755a9a348__360) | From $18.50 | https://boomtick.printful.me/product/mens-bear-tank-nor-cal-best-cal |
-| NorCal Best Cal Cropped top | ![NorCal Best Cal Cropped top](https://cdn.printful.me/t/quick-stores/products/w168/18182963-636-6a0b71ea8fae2__360) | From $20.50 | https://boomtick.printful.me/product/norcal-best-cal-cropped-top |
-| NorCal BestCal Golden Gate Crop Hoodie | ![NorCal BestCal Golden Gate Crop Hoodie](https://cdn.printful.me/t/quick-stores/products/w168/18182963-317-6a0b6eab9f0f4__360) | From $34.00 | https://boomtick.printful.me/product/norcal-bestcal-golden-gate-crop-hoodie |
-| NorCal BestCal Golden Gate Rainbow Pride Shirt | ![NorCal BestCal Golden Gate Rainbow Pride Shirt](https://cdn.printful.me/t/quick-stores/products/w168/18182963-823-6a0b6ad05e8a7__360) | From $23.00 | https://boomtick.printful.me/product/norcal-bestcal-golden-gate-rainbow-pride-shirt |
-| NorCal Best Cal Pride California Bear Apparel | ![NorCal Best Cal Pride California Bear Apparel](https://cdn.printful.me/t/quick-stores/products/w168/18182963-71-6a0b6a31c4326__360) | From $15.50 | https://boomtick.printful.me/product/norcal-best-cal-pride-california-bear-apparel |
-| LOVE Lead Follow or Switch Unisex shirt | ![LOVE Lead Follow or Switch Unisex shirt](https://cdn.printful.me/t/quick-stores/products/w168/87343-71-6a0b962244279__360) | From $18.64 | https://boomtick.printful.me/product/unisex-t-shirt |
-| NorCal BestCal | ![NorCal BestCal](https://cdn.printful.me/t/quick-stores/products/w168/18182963-71-6a07b116ea5ce__360) | From $12.00 | https://boomtick.printful.me/product/norcal-bestcal |
+| :--- | :---: | :---: | :--- |
+| **LOVE Neon Shirt**<br>_Ask me to follow_ | ![Ask me to follow](https://cdn.printful.me/t/quick-stores/products/w168/18182963-679-6a0bf5f177de8__360) | From $24.50 | [Buy Now](https://boomtick.printful.me/product/love-neon-tshirt-ask-me-to-follow) |
+| **LOVE Neon Shirt**<br>_Ask me to lead_ | ![Ask me to lead](https://cdn.printful.me/t/quick-stores/products/w168/18182963-679-6a0bf58bde26a__360) | From $24.00 | [Buy Now](https://boomtick.printful.me/product/love-neon-tshirt-ask-me-to-lead) |
+| **War Eagle Oversized Shirt**<br>_High-neck t-shirt_ | ![War Eagle High Neck](https://cdn.printful.me/t/quick-stores/products/w168/18182963-823-6a0ba0a711254__360) | From $22.00 | [Buy Now](https://boomtick.printful.me/product/war-eagle-oversized-high-neck-t-shirt) |
+| **Lead Follow or Switch**<br>_LOVE shirt in Neon_ | ![Lead Follow or Switch Neon](https://cdn.printful.me/t/quick-stores/products/w168/87343-679-6a0b93c3dcf19__360) | From $24.00 | [Buy Now](https://boomtick.printful.me/product/lead-follow-or-switch-love-shirt-in-neon) |
+| **Men's Bear Tank**<br>_NorCal BestCal Edition_ | ![Mens Bear Tank](https://cdn.printful.me/t/quick-stores/products/w168/18182963-537-6a0b755a9a348__360) | From $18.50 | [Buy Now](https://boomtick.printful.me/product/mens-bear-tank-nor-cal-best-cal) |
+| **NorCal BestCal Cropped Top** | ![NorCal BestCal Cropped Top](https://cdn.printful.me/t/quick-stores/products/w168/18182963-636-6a0b71ea8fae2__360) | From $20.50 | [Buy Now](https://boomtick.printful.me/product/norcal-best-cal-cropped-top) |
+| **Golden Gate Crop Hoodie**<br>_NorCal BestCal_ | ![Golden Gate Crop Hoodie](https://cdn.printful.me/t/quick-stores/products/w168/18182963-317-6a0b6eab9f0f4__360) | From $34.00 | [Buy Now](https://boomtick.printful.me/product/norcal-bestcal-golden-gate-crop-hoodie) |
+| **Golden Gate Rainbow Shirt**<br>_NorCal BestCal_ | ![Golden Gate Rainbow Shirt](https://cdn.printful.me/t/quick-stores/products/w168/18182963-823-6a0b6ad05e8a7__360) | From $23.00 | [Buy Now](https://boomtick.printful.me/product/norcal-bestcal-golden-gate-rainbow-pride-shirt) |
+| **Pride California Bear Apparel**<br>_NorCal BestCal_ | ![Pride California Bear Apparel](https://cdn.printful.me/t/quick-stores/products/w168/18182963-71-6a0b6a31c4326__360) | From $15.50 | [Buy Now](https://boomtick.printful.me/product/norcal-best-cal-pride-california-bear-apparel) |
+| **LOVE Lead Follow or Switch**<br>_Unisex shirt_ | ![LOVE Lead Follow or Switch](https://cdn.printful.me/t/quick-stores/products/w168/87343-71-6a0b962244279__360) | From $18.64 | [Buy Now](https://boomtick.printful.me/product/unisex-t-shirt) |
+| **NorCal BestCal Tee** | ![NorCal BestCal Tee](https://cdn.printful.me/t/quick-stores/products/w168/18182963-71-6a07b116ea5ce__360) | From $12.00 | [Buy Now](https://boomtick.printful.me/product/norcal-bestcal) |
 
 > Prices and product availability are captured from your provided grid snapshot and can change over time at checkout.
 

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "react-markdown": "^10.1.0",
     "react-router-dom": "^7.14.1",
     "recharts": "2.15.0",
+    "remark-gfm": "^4.0.1",
     "remark-parse": "^11.0.0",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       recharts:
         specifier: 2.15.0
         version: 2.15.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
       remark-parse:
         specifier: ^11.0.0
         version: 11.0.0
@@ -3411,6 +3414,10 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
+
   escodegen@2.1.0:
     resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
     engines: {node: '>=6.0'}
@@ -4339,6 +4346,9 @@ packages:
     resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
     engines: {node: '>=8'}
 
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
   marky@1.3.0:
     resolution: {integrity: sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==}
 
@@ -4346,8 +4356,29 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
   mdast-util-from-markdown@2.0.3:
     resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
 
   mdast-util-mdx-expression@2.0.1:
     resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
@@ -4400,6 +4431,27 @@ packages:
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
 
   micromark-factory-destination@2.0.1:
     resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
@@ -5015,11 +5067,17 @@ packages:
     resolution: {integrity: sha512-dLsljMd9sqwRkby8zhO1gSg3PnJIBFid8f4CQj/sXx+7cKx+E7u0PKhZ+U4wmhx7EfmtvnA318oVaIkAB1lRJw==}
     hasBin: true
 
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
   remark-parse@11.0.0:
     resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
 
   remark-rehype@11.1.2:
     resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -9274,6 +9332,8 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
+  escape-string-regexp@5.0.0: {}
+
   escodegen@2.1.0:
     dependencies:
       esprima: 4.0.1
@@ -10347,9 +10407,18 @@ snapshots:
     dependencies:
       semver: 6.3.1
 
+  markdown-table@3.0.4: {}
+
   marky@1.3.0: {}
 
   math-intrinsics@1.1.0: {}
+
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
 
   mdast-util-from-markdown@2.0.3:
     dependencies:
@@ -10365,6 +10434,63 @@ snapshots:
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
       unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
@@ -10473,6 +10599,64 @@ snapshots:
       micromark-util-resolve-all: 2.0.1
       micromark-util-subtokenize: 2.1.0
       micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
       micromark-util-types: 2.0.2
 
   micromark-factory-destination@2.0.1:
@@ -11226,6 +11410,17 @@ snapshots:
     dependencies:
       jsesc: 3.1.0
 
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
   remark-parse@11.0.0:
     dependencies:
       '@types/mdast': 4.0.4
@@ -11242,6 +11437,12 @@ snapshots:
       mdast-util-to-hast: 13.2.1
       unified: 11.0.5
       vfile: 6.0.3
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
 
   require-directory@2.1.1: {}
 

--- a/src/components/ui/MarkdownRenderer.tsx
+++ b/src/components/ui/MarkdownRenderer.tsx
@@ -1,5 +1,6 @@
 // impeccable-ignore-file
 import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 import { Box, Text } from '@/layouts/Primitives';
 import { Link } from 'react-router-dom';
 
@@ -11,6 +12,7 @@ export function MarkdownRenderer({ content }: MarkdownRendererProps) {
   return (
     <Box className="prose-counters">
       <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
         components={{
           a: ({node: _node, href, ...props}) => {
             const isInternal = href?.startsWith('/');


### PR DESCRIPTION
### Motivation

- Enable GitHub-flavored Markdown features (tables, strikethrough, task lists, autolinks) in the app's Markdown renderer so authored content renders correctly.
- Improve the Jack & Jill O'Rama merch section for clearer links and table layout and update copy for referral information.

### Description

- Added `remark-gfm` to `package.json` and updated `pnpm-lock.yaml` to include GFM and related remark/micromark/mdast packages.
- Updated `src/components/ui/MarkdownRenderer.tsx` to import `remark-gfm` and pass it to `ReactMarkdown` via `remarkPlugins={[remarkGfm]}` so GFM features are parsed.
- Modified `content/events/jack-and-jill-orama.md` to convert plain URLs into Markdown links, rework the "NorCal BestCal Merch Picks" section and table rows for clearer product titles and "Buy Now" links, and adjusted the gallery/copy accordingly.

### Testing

- Ran `pnpm install` to update dependencies and lockfile, which completed successfully.
- Built the project with `pnpm build` to verify compilation after dependency changes, and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d3053a1048325ba37e5bba1934c71)