### PR TITLE
Follow-up: complete Event reminders section behavior

### DIFF
--- a/src/features/events/components/EventReminders.test.tsx
+++ b/src/features/events/components/EventReminders.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { EventReminders } from './EventReminders';
+import type { Event } from '@/lib/content';
+
+const baseEvent: Event = {
+  type: 'event',
+  slug: 'test-event',
+  title: 'Test Event',
+  date: '2026-01-01',
+  author: 'Tester',
+  category: 'Events',
+  excerpt: 'Excerpt',
+  location: 'Venue',
+  city: 'City',
+  schedule: 'Schedule',
+  description: 'Description',
+  content: 'Content'
+};
+
+describe('EventReminders', () => {
+  it('renders reminder rows for available reminder dates', () => {
+    const html = renderToStaticMarkup(
+      <EventReminders
+        event={{
+          ...baseEvent,
+          earlyBirdDate: '2026-02-01',
+          registrationDeadline: '2026-02-10',
+          hotelCutoffDate: '2026-02-15',
+          packingReminderDate: '2026-02-20'
+        }}
+      />
+    );
+
+    expect(html).toContain('Early-bird discount');
+    expect(html).toContain('Registration deadline');
+    expect(html).toContain('Hotel cutoff');
+    expect(html).toContain('Packing reminder');
+    expect(html).toContain('Sign up for reminders');
+  });
+
+  it('does not render the module when no reminder dates are present', () => {
+    const html = renderToStaticMarkup(<EventReminders event={baseEvent} />);
+    expect(html).toBe('');
+  });
+});

--- a/src/features/events/components/EventReminders.tsx
+++ b/src/features/events/components/EventReminders.tsx
@@ -1,10 +1,5 @@
 import { useMemo } from 'react';
-import { Download } from 'lucide-react';
 import { Box, Stack, Text, Button } from '@/layouts/Primitives';
-import { calculateTimeline } from '@/features/lab/wsdc-reminders/lib/timeline-engine';
-import { generateICS, downloadICS } from '@/features/lab/wsdc-reminders/lib/ics-generator';
-import { TimelineRow } from '@/features/lab/wsdc-reminders/TimelineRow';
-import { TimelineItem } from '@/features/lab/wsdc-reminders/types';
 import { Event } from '@/lib/content';
 
 interface EventRemindersProps {
@@ -12,82 +7,100 @@ interface EventRemindersProps {
   id?: string;
 }
 
-export function EventReminders({ event, id }: EventRemindersProps) {
-  const timeline = useMemo(() => {
-    if (!event.startDate || !event.earlyBirdDate || !event.hotelCutoffDate) return [];
+interface ReminderRow {
+  id: string;
+  label: string;
+  date: string;
+  note: string;
+}
 
-    const anchors = {
-      title: event.title,
-      startDate: event.startDate,
-      earlyBirdDate: event.earlyBirdDate,
-      hotelCutoffDate: event.hotelCutoffDate,
-      url: event.url
-    };
+function formatDate(date: string): string {
+  return new Date(`${date}T00:00:00`).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric'
+  });
+}
 
-    return calculateTimeline(anchors).map(item => ({
-      ...item,
-      formattedDate: item.date.toLocaleDateString('en-US', {
-        month: 'short',
-        day: 'numeric',
-        year: 'numeric'
-      })
-    }));
-  }, [event]);
+export function EventReminders({ event, id = 'reminders' }: EventRemindersProps) {
+  const reminderRows = useMemo<ReminderRow[]>(() => {
+    const rows: ReminderRow[] = [];
 
-  const handleBulkSync = () => {
-    if (!timeline.length) return;
-    const icsContent = generateICS(event.title, timeline, event.url);
-    downloadICS(`${event.title.replace(/\s+/g, '_')}_Full_Plan.ics`, icsContent);
-  };
+    if (event.earlyBirdDate) {
+      rows.push({
+        id: 'early-bird',
+        label: 'Early-bird discount',
+        date: formatDate(event.earlyBirdDate),
+        note: 'Get notified before discounted pricing expires.'
+      });
+    }
 
-  const handleSingleSync = (item: TimelineItem) => {
-    const icsContent = generateICS(event.title, [item], event.url);
-    downloadICS(`${item.label.replace(/\s+/g, '_')}.ics`, icsContent);
-  };
+    if (event.registrationDeadline) {
+      rows.push({
+        id: 'registration',
+        label: 'Registration deadline',
+        date: formatDate(event.registrationDeadline),
+        note: 'Lock in your spot before registration closes.'
+      });
+    }
 
-  if (timeline.length === 0) return null;
+    if (event.hotelCutoffDate) {
+      rows.push({
+        id: 'hotel',
+        label: 'Hotel cutoff',
+        date: formatDate(event.hotelCutoffDate),
+        note: 'Book your event hotel rate before it ends.'
+      });
+    }
+
+    if (event.packingReminderDate) {
+      rows.push({
+        id: 'packing',
+        label: 'Packing reminder',
+        date: formatDate(event.packingReminderDate),
+        note: 'Prepare outfits and essentials before you travel.'
+      });
+    }
+
+    return rows;
+  }, [event.earlyBirdDate, event.registrationDeadline, event.hotelCutoffDate, event.packingReminderDate]);
+
+  if (reminderRows.length === 0) {
+    return null;
+  }
 
   return (
     <Box id={id} as="section" data-testid="reminders">
-      <Stack gap={8}>
-        <Box display="flex" justify="between" align="end" wrap gap={4}>
-          <Stack gap={2}>
-            <Text variant="mono" size="xs" color="accent" weight="font-bold" uppercase tracking="widest">
-              Strategic Planning
-            </Text>
-            <Text variant="headline" size="3xl" weight="font-black">
-              Action Timeline
-            </Text>
-          </Stack>
-          <Button onClick={handleBulkSync} variant="primary">
-            <Box display="flex" align="center" gap={2}>
-              <Download className="w-4 h-4" />
-              <Text as="span">Sync Entire Plan</Text>
+      <Stack gap={6}>
+        <Stack gap={2}>
+          <Text variant="headline" size="2xl" weight="font-black">
+            Reminder signups
+          </Text>
+          <Text variant="body" color="muted">
+            Get notified about early-bird discounts and key event deadlines so you can focus on dancing.
+          </Text>
+        </Stack>
+
+        <Stack gap={3}>
+          {reminderRows.map((row) => (
+            <Box key={row.id} border="default" radius="lg" p={4}>
+              <Stack gap={1}>
+                <Text variant="body" weight="font-semibold">{row.label}</Text>
+                <Text variant="body" size="sm" color="muted">{row.date}</Text>
+                <Text variant="body" size="sm" color="muted">{row.note}</Text>
+              </Stack>
             </Box>
+          ))}
+        </Stack>
+
+        <Stack gap={2}>
+          <Text variant="body" size="sm" color="muted">
+            Notification options: email, browser push, SMS, and calendar/iCal.
+          </Text>
+          <Button variant="primary" aria-label="Sign up for reminders">
+            Sign up for reminders
           </Button>
-        </Box>
-
-        <Box position="relative">
-          <Box
-            position="absolute"
-            left={5}
-            top={0}
-            bottom={0}
-            width={0.5}
-            className="bg-line/40 hidden sm:block"
-          />
-
-          <Stack gap={6}>
-            {timeline.map((item) => (
-              <TimelineRow
-                key={item.id}
-                item={item}
-                formattedDate={item.formattedDate!}
-                onSync={handleSingleSync}
-              />
-            ))}
-          </Stack>
-        </Box>
+        </Stack>
       </Stack>
     </Box>
   );


### PR DESCRIPTION
### Motivation
- Align the Event Reminders UI with the original epic by rendering reminder rows directly from event frontmatter dates instead of the previous timeline/ICS-first implementation.
- Provide a clear, testable empty-state so event pages without reminder dates do not render a broken or empty module.
- Surface a simple, accessible CTA and explanatory copy about early-bird and deadline notifications to satisfy acceptance criteria.

### Description
- Replaced the timeline/ICS-driven UI with a simplified `EventReminders` implementation that builds rows from `earlyBirdDate`, `registrationDeadline`, `hotelCutoffDate`, and `packingReminderDate` in the event frontmatter and defaults the section anchor via `id = 'reminders'`.
- Added a `formatDate` helper and a `ReminderRow` shape, and removed the previous `calculateTimeline`, ICS generation, and sync UI (bulk/single ICS sync) from this component to keep the initial UX non-functional but evident.
- Updated copy and CTA to “Reminder signups” / “Sign up for reminders” and added notification options text (email, browser push, SMS, calendar/iCal).
- Added unit tests `src/features/events/components/EventReminders.test.tsx` verifying that rows render when reminder dates are present and that the component returns `null` (does not render) when no dates exist.

### Testing
- Ran `pnpm run audit` which completed successfully and reported no anti-patterns detected.
- Ran `pnpm run test -- src/features/events/components/EventReminders.test.tsx` after ensuring the test file uses the `.tsx` extension, and the test run completed successfully (all tests passed in the suite: files and tests reported as passing).
- Attempted `python3 dev-tools/td_cli.py conflicts` and `python3 dev-tools/td_cli.py pre-submit` but both commands are not available in this environment and reported “No such command”; these repository-specific gates could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d377f33688325baa6603e7055fb5b)