### PR TITLE
Follow-up: detail-page back labels, share copy-link fallback, and mobile prose hardening

### DIFF
--- a/src/components/layout/ArticleActions.tsx
+++ b/src/components/layout/ArticleActions.tsx
@@ -1,10 +1,37 @@
 import { Share2, Link as LinkIcon, Check } from 'lucide-react';
 import { useState } from 'react';
+import { ReactNode } from 'react';
 import { Stack, Text } from '@/layouts/Primitives';
 
 interface ArticleActionsProps {
   title: string;
   description: string;
+}
+
+interface ActionChipProps {
+  label: string;
+  icon: ReactNode;
+  onClick: () => void;
+  className: string;
+}
+
+function ActionChip({ label, icon, onClick, className }: ActionChipProps) {
+  return (
+    <Stack
+      as="button"
+      direction="row"
+      onClick={onClick}
+      align="center"
+      gap={2}
+      paddingX={3}
+      paddingY={1.5}
+      radius="sm"
+      className={className}
+    >
+      {icon}
+      <Text variant="mono" size="xs" weight="font-bold">{label}</Text>
+    </Stack>
+  );
 }
 
 export function ArticleActions({ title, description }: ArticleActionsProps) {
@@ -33,36 +60,20 @@ export function ArticleActions({ title, description }: ArticleActionsProps) {
 
   return (
     <Stack direction="row" gap={2} wrap>
-      <Stack
-        as="button"
-        direction="row"
+      <ActionChip
+        label="SHARE"
+        icon={<Share2 className="w-4 h-4" />}
         onClick={handleShare}
-        align="center"
-        gap={2}
-        paddingX={3}
-        paddingY={1.5}
-        radius="sm"
         className="text-accent hover:bg-accent/10 transition-all active:scale-95 cursor-pointer"
-      >
-        <Share2 className="w-4 h-4" />
-        <Text variant="mono" size="xs" weight="font-bold">SHARE</Text>
-      </Stack>
+      />
 
       {!hasNativeShare && (
-        <Stack
-          as="button"
-          direction="row"
+        <ActionChip
+          label={copied ? 'COPIED' : 'COPY LINK'}
+          icon={copied ? <Check className="w-4 h-4" /> : <LinkIcon className="w-4 h-4" />}
           onClick={() => void handleCopyLink()}
-          align="center"
-          gap={2}
-          paddingX={3}
-          paddingY={1.5}
-          radius="sm"
           className="text-text-dim hover:text-accent hover:bg-accent/10 transition-all active:scale-95 cursor-pointer"
-        >
-          {copied ? <Check className="w-4 h-4" /> : <LinkIcon className="w-4 h-4" />}
-          <Text variant="mono" size="xs" weight="font-bold">{copied ? 'COPIED' : 'COPY LINK'}</Text>
-        </Stack>
+        />
       )}
     </Stack>
   );

--- a/src/components/layout/ArticleActions.tsx
+++ b/src/components/layout/ArticleActions.tsx
@@ -1,5 +1,5 @@
 import { Share2, Link as LinkIcon, Check } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import { Stack, Text } from '@/layouts/Primitives';
 
 interface ArticleActionsProps {
@@ -9,8 +9,7 @@ interface ArticleActionsProps {
 
 export function ArticleActions({ title, description }: ArticleActionsProps) {
   const [copied, setCopied] = useState(false);
-
-  const hasNativeShare = useMemo(() => typeof navigator !== 'undefined' && !!navigator.share, []);
+  const hasNativeShare = typeof navigator !== 'undefined' && !!navigator.share;
 
   const handleCopyLink = async () => {
     try {

--- a/src/components/layout/ArticleActions.tsx
+++ b/src/components/layout/ArticleActions.tsx
@@ -1,0 +1,70 @@
+import { Share2, Link as LinkIcon, Check } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { Stack, Text } from '@/layouts/Primitives';
+
+interface ArticleActionsProps {
+  title: string;
+  description: string;
+}
+
+export function ArticleActions({ title, description }: ArticleActionsProps) {
+  const [copied, setCopied] = useState(false);
+
+  const hasNativeShare = useMemo(() => typeof navigator !== 'undefined' && !!navigator.share, []);
+
+  const handleCopyLink = async () => {
+    try {
+      await navigator.clipboard.writeText(window.location.href);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1800);
+    } catch (error) {
+      console.error('Failed to copy article URL', error);
+    }
+  };
+
+  const handleShare = () => {
+    if (hasNativeShare) {
+      navigator
+        .share({ title, text: description, url: window.location.href })
+        .catch((error) => console.error('Share failed', error));
+      return;
+    }
+    void handleCopyLink();
+  };
+
+  return (
+    <Stack direction="row" gap={2} wrap>
+      <Stack
+        as="button"
+        direction="row"
+        onClick={handleShare}
+        align="center"
+        gap={2}
+        paddingX={3}
+        paddingY={1.5}
+        radius="sm"
+        className="text-accent hover:bg-accent/10 transition-all active:scale-95 cursor-pointer"
+      >
+        <Share2 className="w-4 h-4" />
+        <Text variant="mono" size="xs" weight="font-bold">SHARE</Text>
+      </Stack>
+
+      {!hasNativeShare && (
+        <Stack
+          as="button"
+          direction="row"
+          onClick={() => void handleCopyLink()}
+          align="center"
+          gap={2}
+          paddingX={3}
+          paddingY={1.5}
+          radius="sm"
+          className="text-text-dim hover:text-accent hover:bg-accent/10 transition-all active:scale-95 cursor-pointer"
+        >
+          {copied ? <Check className="w-4 h-4" /> : <LinkIcon className="w-4 h-4" />}
+          <Text variant="mono" size="xs" weight="font-bold">{copied ? 'COPIED' : 'COPY LINK'}</Text>
+        </Stack>
+      )}
+    </Stack>
+  );
+}

--- a/src/components/layout/DetailLayout.tsx
+++ b/src/components/layout/DetailLayout.tsx
@@ -107,7 +107,7 @@ export function DetailLayout({
                 width="full"
                 marginX="auto"
                 maxWidth="prose"
-                className="prose prose-slate prose-headings:font-display prose-p:font-sans prose-p:text-text-dim prose-strong:text-text-main"
+                className="prose prose-slate detail-prose prose-headings:font-display prose-p:font-sans prose-p:text-text-dim prose-strong:text-text-main"
               >
                 <MarkdownRenderer content={content} />
               </Box>

--- a/src/features/journal/BlogPost.tsx
+++ b/src/features/journal/BlogPost.tsx
@@ -71,7 +71,7 @@ export default function BlogPost() {
       <BlogPostDetail
         post={post}
         onBack={() => navigate('/blog')}
-        backLabel="Back to Folio"
+        backLabel="Back to Blog"
       />
     </>
   );

--- a/src/features/journal/components/BlogPostDetail.tsx
+++ b/src/features/journal/components/BlogPostDetail.tsx
@@ -1,7 +1,7 @@
-import { Share2 } from 'lucide-react';
 import { Box, Stack, Text } from '@/layouts/Primitives';
 
 import { DetailLayout } from '@/components/layout/DetailLayout';
+import { ArticleActions } from '@/components/layout/ArticleActions';
 import { Post } from '@/lib/content';
 
 interface BlogPostDetailProps {
@@ -11,16 +11,6 @@ interface BlogPostDetailProps {
 }
 
 export function BlogPostDetail({ post, onBack, backLabel }: BlogPostDetailProps) {
-  const share = () => {
-    if (navigator.share) {
-      navigator.share({
-        title: post.title,
-        text: post.excerpt,
-        url: window.location.href,
-      }).catch(console.error);
-    }
-  };
-
   return (
     <DetailLayout
       title={post.title}
@@ -37,15 +27,12 @@ export function BlogPostDetail({ post, onBack, backLabel }: BlogPostDetailProps)
              <Text variant="mono" size="xs">{post.author}</Text>
           </Stack>
           <Box flex />
-          <Stack as="button" direction="row" onClick={share} align="center" gap={2} paddingX={3} paddingY={1.5} radius="sm" className="text-accent hover:bg-accent/10 hover:shadow-glow transition-all active:scale-95 cursor-pointer">
-            <Share2 className="w-4 h-4" />
-            <Text variant="mono" size="xs" weight="font-bold">SHARE</Text>
-          </Stack>
+          <ArticleActions title={post.title} description={post.excerpt} />
         </Stack>
       }
     >
       {post.tags && post.tags.length > 0 && (
-        <Box border="t" paddingTop={12} marginTop={12} className="border-line/30">
+        <Box border="t" paddingTop={8} marginTop={10} className="border-line/30">
           <Stack gap={4}>
             <Text variant="mono" size="tiny" color="dim" uppercase tracking="widest">Discovery Tags</Text>
             <Stack direction="row" wrap gap={2}>

--- a/src/features/lab/GearPost.tsx
+++ b/src/features/lab/GearPost.tsx
@@ -76,7 +76,7 @@ export default function GearPost() {
       <GearPostDetail
         post={resource}
         onBack={() => navigate('/gear')}
-        backLabel="Back to Toolbox"
+        backLabel="Back to Gear"
       />
     </>
   );

--- a/src/features/lab/components/GearPostDetail.tsx
+++ b/src/features/lab/components/GearPostDetail.tsx
@@ -1,6 +1,8 @@
 import { Resource } from '@/lib/content';
 import { DetailLayout } from '@/components/layout/DetailLayout';
 import { VerdictCallout } from '@/components/layout/DetailElements';
+import { ArticleActions } from '@/components/layout/ArticleActions';
+import { Stack } from '@/layouts/Primitives';
 import { ResourceSidebar } from './sidebar/ResourceSidebar';
 import { ResourceScoreGrid } from './ResourceScoreGrid';
 
@@ -12,14 +14,17 @@ interface GearPostDetailProps {
 
 export function GearPostDetail({ post, onBack, backLabel }: GearPostDetailProps) {
   const headerExtras = (
-    <ResourceScoreGrid
-      rating={post.rating || 0}
-      durability={post.durability}
-      value={post.value}
-      priceCategory={post.priceCategory}
-      updatedDate={post.updatedDate}
-      date={post.date}
-    />
+    <Stack gap={6}>
+      <ResourceScoreGrid
+        rating={post.rating || 0}
+        durability={post.durability}
+        value={post.value}
+        priceCategory={post.priceCategory}
+        updatedDate={post.updatedDate}
+        date={post.date}
+      />
+      <ArticleActions title={post.title} description={post.excerpt} />
+    </Stack>
   );
 
   return (

--- a/src/index.css
+++ b/src/index.css
@@ -237,6 +237,58 @@
   .prose a {
     @apply text-accent decoration-accent/30 underline decoration-1 underline-offset-4 transition-all hover:decoration-accent hover:text-accent/80;
   }
+
+  .detail-prose {
+    line-height: 1.85;
+  }
+
+  .detail-prose :is(h2, h3, h4) {
+    scroll-margin-top: 5rem;
+  }
+
+  .detail-prose p {
+    margin-top: 1.1rem;
+    margin-bottom: 1.1rem;
+    max-width: 62ch;
+  }
+
+  .detail-prose :is(pre, code, table, img) {
+    max-width: 100%;
+  }
+
+  .detail-prose pre,
+  .detail-prose table {
+    overflow-x: auto;
+    display: block;
+  }
+
+  .detail-prose a {
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+
+  .detail-prose img {
+    margin-top: 1.5rem;
+    margin-bottom: 1.5rem;
+    border-radius: var(--raw-radius-standard);
+  }
+
+  @media (max-width: 640px) {
+    .detail-prose {
+      font-size: 0.98rem;
+      line-height: 1.9;
+    }
+
+    .detail-prose :is(h2, h3) {
+      margin-top: 1.7rem;
+      margin-bottom: 0.85rem;
+    }
+
+    .detail-prose p {
+      margin-top: 1rem;
+      margin-bottom: 1rem;
+    }
+  }
 }
 
 .panel { @apply bg-bg p-4 sm:p-6 md:p-12 relative overflow-hidden w-full; }


### PR DESCRIPTION
### Motivation
- Improve mobile reading ergonomics and action controls for long-form detail pages across `/blog/:slug` and `/gear/:slug` pages. 
- Provide a robust share experience by adding a copy-link fallback when the Web Share API is not available. 
- Prevent horizontal overflow and improve tag wrapping and paragraph rhythm on narrow viewports.

### Description
- Added a new shared `ArticleActions` component that uses `navigator.share` when available and falls back to copying `window.location.href` to the clipboard with a transient copied-state indicator. 
- Replaced the single-share button in the blog detail header with `ArticleActions` and slightly tightened the blog tag section spacing to better fit mobile bottom navigation. 
- Updated back labels to be section-specific by setting `backLabel` to `Back to Blog` for posts and `Back to Gear` for gear reviews. 
- Hardened article typography and overflow handling by adding a `detail-prose` class in `DetailLayout` and corresponding CSS rules to tune line-height, heading spacing, paragraph rhythm, long-link wrapping, and horizontal overflow guards for `pre`, `table`, `img`, and code blocks.

### Testing
- Ran `pnpm run audit` which completed successfully and reported no UI anti-patterns. 
- Ran `pnpm run build` which invoked `tsc --noEmit` and completed a production build successfully. 
- Note: repo docs reference `python3 dev-tools/td_cli.py conflicts` and `python3 dev-tools/td_cli.py pre-submit` but those commands are not available in the current `td_cli.py` command set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d4f2e4c4c83258465c3af2d5149cc)