### PR TITLE
Make SVG logos theme-aware with CSS variables and dark mode

### DIFF
--- a/public/boomtick_logo.svg
+++ b/public/boomtick_logo.svg
@@ -1,19 +1,33 @@
 <svg viewBox="0 0 325 100" fill="none" xmlns="http://www.w3.org/2000/svg" class="h-full w-auto max-w-none overflow-visible" aria-hidden="true" preserveAspectRatio="xMidYMid meet">
   <style>
-    .brand-stop-accent { stop-color: #22d3ee; }
-    .brand-stop-purple { stop-color: #8b5cf6; }
-    .brand-text-accent { fill: #22d3ee; }
-    .brand-text-muted { fill: rgba(241, 245, 249, 0.6); }
+    :root {
+      color-scheme: light dark;
+      --bt-text-base: #0f172a;
+      --bt-text-accent: #0891b2;
+      --bt-text-muted: rgba(15, 23, 42, 0.62);
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bt-text-base: #f8fafc;
+        --bt-text-accent: #67e8f9;
+        --bt-text-muted: rgba(241, 245, 249, 0.72);
+      }
+    }
+
+    .text-base { fill: var(--bt-text-base); }
+    .text-accent { fill: var(--bt-text-accent); }
+    .text-muted { fill: var(--bt-text-muted); }
+
     .brand-wordmark {
       font-family: 'Bricolage Grotesque', sans-serif;
       font-weight: 800;
     }
   </style>
 
-  <!-- Wordmark -->
   <text x="0" y="75" font-size="52" letter-spacing="-1.5" class="brand-wordmark">
-    <tspan fill="white">boom</tspan>
-    <tspan class="brand-text-accent" fill="#22d3ee">tick</tspan>
-    <tspan class="brand-text-muted" fill="rgba(241,245,249,0.6)" font-weight="300">.blog</tspan>
+    <tspan class="text-base">boom</tspan>
+    <tspan class="text-accent">tick</tspan>
+    <tspan class="text-muted" font-weight="300">.blog</tspan>
   </text>
 </svg>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,18 +1,27 @@
 <svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
   <style>
-    .brand-stop-accent { stop-color: #22d3ee; }
-    .brand-stop-purple { stop-color: #8b5cf6; }
-    .brand-text-accent { fill: #22d3ee; }
-    .brand-text-muted { fill: rgba(241, 245, 249, 0.6); }
-    .brand-wordmark {
-      font-family: 'Bricolage Grotesque', sans-serif;
-      font-weight: 800;
+    :root {
+      color-scheme: light dark;
+      --bt-text-base: #0f172a;
+      --bt-text-accent: #0891b2;
+      --bt-surface: #f8fafc;
     }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bt-text-base: #f8fafc;
+        --bt-text-accent: #67e8f9;
+        --bt-surface: #020617;
+      }
+    }
+
+    .surface { fill: var(--bt-surface); }
+    .text-base { fill: var(--bt-text-base); }
+    .text-accent { fill: var(--bt-text-accent); }
   </style>
-  <rect width="64" height="64" rx="14" fill="#020617"/>
-  
-  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="12" class="brand-wordmark">
-    <tspan fill="white">boom</tspan>
-    <tspan class="brand-text-accent" fill="#22d3ee">tick</tspan>
+
+  <rect class="surface" width="64" height="64" rx="14" />
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="12" font-family="'Bricolage Grotesque', sans-serif" font-weight="800">
+    <tspan class="text-base">boom</tspan><tspan class="text-accent">tick</tspan>
   </text>
 </svg>


### PR DESCRIPTION
### Motivation
- Update the brand SVG assets to be theme-aware so the logo adapts to light and dark color schemes. 
- Replace hardcoded colors with variables to make branding easier to maintain and align with site theming. 

### Description
- Replaced hardcoded color classes in `public/boomtick_logo.svg` and `public/favicon.svg` with a `:root` CSS variable palette and `@media (prefers-color-scheme: dark)` overrides. 
- Swapped old class names and inline fills for variable-driven classes such as `text-base`, `text-accent`, `text-muted`, and `surface`, and consolidated font attributes into the `text` elements. 
- Adjusted the favicon to use a `.surface` rect and ensured the wordmark uses the correct font family and weight inline for consistency. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d4f2162648325849826c03cf3b403)