### PR TITLE
ArticleActions: fall back to copy when native share rejects

### DIFF
--- a/src/components/layout/ArticleActions.tsx
+++ b/src/components/layout/ArticleActions.tsx
@@ -48,14 +48,17 @@ export function ArticleActions({ title, description }: ArticleActionsProps) {
     }
   };
 
-  const handleShare = () => {
+  const handleShare = async () => {
     if (hasNativeShare) {
-      navigator
-        .share({ title, text: description, url: window.location.href })
-        .catch((error) => console.error('Share failed', error));
+      try {
+        await navigator.share({ title, text: description, url: window.location.href });
+      } catch (error) {
+        console.error('Share failed; falling back to copy link', error);
+        await handleCopyLink();
+      }
       return;
     }
-    void handleCopyLink();
+    await handleCopyLink();
   };
 
   return (
@@ -63,7 +66,7 @@ export function ArticleActions({ title, description }: ArticleActionsProps) {
       <ActionChip
         label="SHARE"
         icon={<Share2 className="w-4 h-4" />}
-        onClick={handleShare}
+        onClick={() => void handleShare()}
         className="text-accent hover:bg-accent/10 transition-all active:scale-95 cursor-pointer"
       />
 


### PR DESCRIPTION
### Motivation
- Ensure users still have a working share path when the Web Share API is present but rejects at runtime by falling back to a copy-link action.

### Description
- Updated `src/components/layout/ArticleActions.tsx` so `handleShare` is `async`, catches `navigator.share()` failures, logs context, and invokes `handleCopyLink()` as a fallback, and updated the `SHARE` button click to call the async handler via `void handleShare()` to keep UI non-blocking.

### Testing
- Ran `pnpm run audit`, which completed successfully with no anti-patterns detected, and ran `pnpm run build` (which includes `tsc --noEmit`) and the production build completed successfully; the repo's `td_cli.py` does not provide `conflicts` or `pre-submit` commands so those checks were not run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d5ca5fb788325b7354ffdad07da12)