### PR TITLE
Follow-up to #1410: ensure SHARE failure exposes COPY LINK fallback

### DIFF
--- a/src/components/layout/ArticleActions.tsx
+++ b/src/components/layout/ArticleActions.tsx
@@ -36,6 +36,7 @@ function ActionChip({ label, icon, onClick, className }: ActionChipProps) {
 
 export function ArticleActions({ title, description }: ArticleActionsProps) {
   const [copied, setCopied] = useState(false);
+  const [showCopyFallback, setShowCopyFallback] = useState(false);
   const hasNativeShare = typeof navigator !== 'undefined' && !!navigator.share;
 
   const handleCopyLink = async () => {
@@ -54,6 +55,7 @@ export function ArticleActions({ title, description }: ArticleActionsProps) {
         await navigator.share({ title, text: description, url: window.location.href });
       } catch (error) {
         console.error('Share failed; falling back to copy link', error);
+        setShowCopyFallback(true);
         await handleCopyLink();
       }
       return;
@@ -70,7 +72,7 @@ export function ArticleActions({ title, description }: ArticleActionsProps) {
         className="text-accent hover:bg-accent/10 transition-all active:scale-95 cursor-pointer"
       />
 
-      {!hasNativeShare && (
+      {(!hasNativeShare || showCopyFallback) && (
         <ActionChip
           label={copied ? 'COPIED' : 'COPY LINK'}
           icon={copied ? <Check className="w-4 h-4" /> : <LinkIcon className="w-4 h-4" />}


### PR DESCRIPTION
### Motivation
- Ensure users are not left without a usable sharing action when the Web Share API exists but `navigator.share()` rejects at runtime. 

### Description
- In `src/components/layout/ArticleActions.tsx` add `showCopyFallback` state and set it to `true` when `navigator.share()` throws, and immediately invoke `handleCopyLink`. 
- Update the render condition so the `COPY LINK` chip is shown when native share is unavailable or when the share failed in this session. 

### Testing
- Ran `pnpm run audit` which completed successfully and reported no anti-patterns. 
- Ran `pnpm run build` (includes `tsc --noEmit` and `vite build`) which completed successfully. 
- Attempted `python3 dev-tools/td_cli.py conflicts` which failed because the `conflicts` subcommand is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d65b37e14832590f3e20743a948be)