### PR TITLE
Replace raw icon className styling in ReminderSignups

### DIFF
--- a/src/features/events/components/ReminderSignups.tsx
+++ b/src/features/events/components/ReminderSignups.tsx
@@ -28,7 +28,9 @@ export function ReminderSignups({ event, id }: ReminderSignupsProps) {
           <Stack direction={{ base: 'col', md: 'row' }} gap={8} align="center" justify="between">
             <Stack gap={2} flex={1}>
               <Box display="flex" align="center" gap={3}>
-                <Bell className="w-5 h-5 text-accent" />
+                <Text color="accent" as="span">
+                  <Bell size={20} aria-hidden="true" />
+                </Text>
                 <Text variant="headline" size="lg" weight="font-bold">Never Miss a Deadline</Text>
               </Box>
               <Text size="sm" color="dim" maxWidth="xl">


### PR DESCRIPTION
### Motivation
- Codex review flagged direct Tailwind styling on the `Bell` icon in `src/features/events/components/ReminderSignups.tsx`, which violates the repository UI rules (`No Raw Tailwind in App/Feature Layers` and `No System Bypass via className`).

### Description
- Replaced `<Bell className="w-5 h-5 text-accent" />` with a design-system-aligned pattern by wrapping the icon in `<Text color="accent" as="span">` and using `Bell size={20}` so color and sizing are applied via tokens/primitives in `ReminderSignups.tsx`.

### Testing
- Ran `pnpm run audit` (which executes `node scripts/detect-antipatterns.mjs`) and it reported `No anti-patterns detected`, indicating the change passes the UI anti-pattern audit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d65ee293c8325a0efcbcae55cfa01)