### PR TITLE
fix: Synchronize GitHub Pages concurrency queue to prevent deployment cancellations

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ permissions:
   issues: write
 
 concurrency:
-  group: "gh-pages-publish"
+  group: "pages"
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/prune-stale-previews.yml
+++ b/.github/workflows/prune-stale-previews.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch: # Allows manual triggering
 
 concurrency:
-  group: "gh-pages-publish"
+  group: "pages"
   cancel-in-progress: false
 
 


### PR DESCRIPTION
This PR fixes the issue where multiple consecutive workflow runs causing rapid sequential pushes to the `gh-pages` branch trigger the internal GitHub `pages build and deployment` workflow to repeatedly cancel itself mid-flight. 

By changing the `concurrency` group to `"pages"` (which is the default, unchangeable concurrency group assigned to the built-in Pages deployment jobs), these manual actions workflows will queue correctly alongside the actual GitHub Pages publish runs, allowing the entire deploy sequence to complete predictably without overlap-based cancellation.

---
*PR created automatically by Jules for task [11066150117236451663](https://jules.google.com/task/11066150117236451663) started by @arii*