### PR TITLE
Hide sample event guide template from UI and search

### DIFF
--- a/content/events/sample-event.md
+++ b/content/events/sample-event.md
@@ -1,5 +1,6 @@
 ---
 type: event
+draft: true
 title: "Sample Event Guide"
 date: "2026-10-01"
 startDate: "2026-10-01"

--- a/scripts/content-loader.ts
+++ b/scripts/content-loader.ts
@@ -48,6 +48,13 @@ export function getContentSlugs(dir: string, prefix: string): ContentItem[] {
         // Attempt to get date from frontmatter for more stable lastmod
         try {
           const content = fs.readFileSync(filePath, 'utf-8');
+
+          // Skip draft items
+          const draftMatch = content.match(/^draft:\s*(true|false)/m);
+          if (draftMatch?.[1] === 'true') {
+            return null;
+          }
+
           const dateMatch = content.match(/^date:\s*["']?([^"'\n]+)["']?/m);
           if (dateMatch?.[1]) {
             const date = new Date(dateMatch[1]);
@@ -63,7 +70,8 @@ export function getContentSlugs(dir: string, prefix: string): ContentItem[] {
           slug: `${prefix}/${f.replace(/\.md$/, '')}`,
           lastmod
         };
-      });
+      })
+      .filter((item): item is ContentItem => item !== null);
 
     cache.set(cacheKey, items);
     return items;

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -140,6 +140,7 @@ function transform<T extends { date?: string }>(
 
       return result as unknown as T;
     })
+    .filter((item) => !(item as any).draft)
     .sort((a, b) => {
       const timeA = a.date ? new Date(a.date).getTime() : 0;
       const timeB = b.date ? new Date(b.date).getTime() : 0;

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -48,7 +48,7 @@ const contentModules = {
 
 const slugFrom = (path: string) => path.split('/').pop()?.replace('.md', '') || '';
 
-function transform<T extends { date?: string }>(
+function transform<T extends { date?: string; draft?: boolean }>(
   modules: Record<string, string | ContentModule>,
 ): T[] {
   const asArray = (val: unknown) => (Array.isArray(val) ? (val as string[]) : []);
@@ -140,7 +140,7 @@ function transform<T extends { date?: string }>(
 
       return result as unknown as T;
     })
-    .filter((item) => !(item as any).draft)
+    .filter((item) => !item.draft)
     .sort((a, b) => {
       const timeA = a.date ? new Date(a.date).getTime() : 0;
       const timeB = b.date ? new Date(b.date).getTime() : 0;

--- a/src/lib/types/content.ts
+++ b/src/lib/types/content.ts
@@ -5,6 +5,7 @@
 
 export interface Post {
   type: 'post';
+  draft?: boolean;
   slug: string;
   title: string;
   date: string;
@@ -20,6 +21,7 @@ export interface Post {
 
 export interface Resource {
   type: 'resource';
+  draft?: boolean;
   slug: string;
   title: string;
   date: string;
@@ -41,6 +43,7 @@ export interface Resource {
 
 export interface Study {
   type: 'study';
+  draft?: boolean;
   slug: string;
   title: string;
   date: string;
@@ -70,6 +73,7 @@ export interface EventGear {
 
 export interface Event {
   type: "event";
+  draft?: boolean;
   slug: string;
   title: string;
   date: string;


### PR DESCRIPTION
This PR implements a "draft" mechanism to hide template content from the live site. 

Specifically, it:
1. Marks `content/events/sample-event.md` as a draft.
2. Updates the content loading pipeline (`src/lib/content.ts`) to filter out any items with the `draft: true` flag.
3. Updates the build-time route discovery (`scripts/content-loader.ts`) to exclude draft items from SPA stubs and sitemaps.
4. Adds the `draft` property to the relevant TypeScript interfaces in `src/lib/types/content.ts`.

Verification:
- Run `pnpm test` confirms `getEvents()` no longer returns the sample event.
- Visual verification with Playwright confirms the sample event is gone from the events list and search results.
- Build inspection confirms `dist/events/sample-event/index.html` is no longer generated.

Fixes #1452

---
*PR created automatically by Jules for task [9869360196149500219](https://jules.google.com/task/9869360196149500219) started by @arii*