### PR TITLE
Fix 404 fetching gh job logs by falling back to check_run_id and add allow_redirects

### DIFF
--- a/dev-tools/tdw_services/services/github.py
+++ b/dev-tools/tdw_services/services/github.py
@@ -37,7 +37,7 @@ class GitHubClient:
             raise Exception(f"GH command failed: {proc.stderr}")
         return proc.stdout
 
-    def _request(self, method: str, path: str, json_data: Optional[Dict] = None, is_text: bool = False, accept: Optional[str] = None) -> Any:
+    def _request(self, method: str, path: str, json_data: Optional[Dict] = None, is_text: bool = False, accept: Optional[str] = None, allow_redirects: bool = True) -> Any:
         url = f"{self.base_url}{path}"
         headers = {
             "Authorization": f"Bearer {self.token}",
@@ -50,7 +50,8 @@ class GitHubClient:
                 url,
                 headers=headers,
                 json=json_data,
-                timeout=30
+                timeout=30,
+                allow_redirects=allow_redirects
             )
             response.raise_for_status()
             if is_text:
@@ -94,8 +95,13 @@ class GitHubClient:
         try:
             # GitHub API returns a 302 redirect to a URL that expires after a few minutes
             # We explicitly set Accept to None or a generic type to avoid the .diff default in _request
-            return self._request('GET', f'/repos/{self.repo}/actions/jobs/{job_id}/logs', is_text=True, accept="application/vnd.github.v3+json")
+            return self._request('GET', f'/repos/{self.repo}/actions/jobs/{job_id}/logs', is_text=True, accept="application/vnd.github.v3+json", allow_redirects=True)
         except Exception as e:
+            if "404" in str(e) and external_id is not None:
+                try:
+                    return self._request('GET', f'/repos/{self.repo}/actions/jobs/{check_run_id}/logs', is_text=True, accept="application/vnd.github.v3+json", allow_redirects=True)
+                except Exception as e2:
+                    return f"Failed to fetch logs for job {check_run_id} (fallback): {str(e2)}"
             return f"Failed to fetch logs for job {job_id}: {str(e)}"
 
     def create_issue_comment(self, number: int, body: str) -> Dict[str, Any]:

--- a/tests/dev-tools/test_td_cli.py
+++ b/tests/dev-tools/test_td_cli.py
@@ -12,12 +12,15 @@ from submit_review import submit_review
 
 class TestTDCLI(unittest.TestCase):
 
+    @patch('tdw_services.orchestrator.get_github_client')
+    @patch('tdw_services.orchestrator.get_repo_name')
     @patch('td_cli.get_github_token')
     @patch('td_cli.get_github_client')
     @patch('td_cli.get_repo_name')
-    def test_validate_issue_dry_run_default(self, mock_repo, mock_get_client, mock_token):
+    def test_validate_issue_dry_run_default(self, mock_repo, mock_get_client, mock_token, mock_orch_repo, mock_orch_client):
         """Test that validate-issue defaults to dry-run True"""
         mock_repo.return_value = "owner/repo"
+        mock_orch_repo.return_value = "owner/repo"
 
         mock_issue = MagicMock()
         mock_issue.number = 123
@@ -25,6 +28,7 @@ class TestTDCLI(unittest.TestCase):
         mock_issue.body = "Test Body"
 
         mock_get_client.return_value.get_repo.return_value.get_issue.return_value = mock_issue
+        mock_orch_client.return_value.get_repo.return_value.get_issue.return_value = mock_issue
 
         args = MagicMock()
         args.issue_number = 123


### PR DESCRIPTION
Fixes the issue where fetching job logs would fail because GitHub occasionally uses external_id in a different form from the one required by the endpoint. It now catches a 404 to explicitly fall back to check_run_id and enables allow_redirects for S3. Also mocks the correct client in the tests to allow proper running offline.

---
*PR created automatically by Jules for task [15109623328175107743](https://jules.google.com/task/15109623328175107743) started by @arii*