### PR TITLE
Relax Node engine constraint to ">=22" to avoid pnpm engine errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "zustand": "^5.0.12"
   },
   "engines": {
-    "node": "22",
+    "node": ">=22",
     "pnpm": ">=10.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
### Motivation
- The repo pinned `engines.node` to the exact value `"22"`, which caused `pnpm` to fail with `ERR_PNPM_UNSUPPORTED_ENGINE` on newer Node runtimes (for example `v24.14.1`), so a minimum-compatible range is needed.

### Description
- Updated `package.json` to change `engines.node` from `"22"` to `">=22"` so environments running Node 22 or newer are accepted while keeping the `pnpm` constraint.

### Testing
- Ran `pnpm run audit`, which completed successfully and reported no anti-patterns.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a138ea86b0883259bb9ef192a73d785)