### PR TITLE
Refine dancer-first homepage copy and mobile menu IA

### DIFF
--- a/src/components/navigation/MobileMenuOverlay.tsx
+++ b/src/components/navigation/MobileMenuOverlay.tsx
@@ -13,6 +13,15 @@ interface MobileMenuOverlayProps {
   onSearchClick: () => void;
 }
 
+const MOBILE_MENU_COPY: Record<string, { label?: string; subtitle: string }> = {
+  '/': { label: 'Start Here', subtitle: 'Quick orientation for new visitors' },
+  '/blog': { label: 'Guides', subtitle: 'Training, travel, and WCS prep' },
+  '/gear': { subtitle: 'Useful products for dance weekends' },
+  '/events': { label: 'Events', subtitle: 'What to expect and what to pack' },
+  '/merch': { subtitle: 'BoomTick shirts, hats, and designs' },
+  '/about': { subtitle: 'Who writes BoomTick and why' },
+};
+
 export function MobileMenuOverlay({ isOpen, onClose, onSearchClick }: MobileMenuOverlayProps) {
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -97,11 +106,12 @@ export function MobileMenuOverlay({ isOpen, onClose, onSearchClick }: MobileMenu
             </Text>
           </Box>
         </Box>
-        {routes.filter((r): r is typeof r & { label: string } => !!(r.path !== '/' && r.label)).map((item) => (
+        {routes.filter((r): r is typeof r & { label: string } => !!r.label).map((item) => (
           <NavItem
             key={item.path}
             to={item.path}
-            label={item.label}
+            label={MOBILE_MENU_COPY[item.path]?.label ?? item.label}
+            subtitle={MOBILE_MENU_COPY[item.path]?.subtitle}
             icon={item.icon}
             onClick={onClose}
             isMobile

--- a/src/components/navigation/NavItem.tsx
+++ b/src/components/navigation/NavItem.tsx
@@ -8,12 +8,13 @@ import { cn } from '@/lib/utils';
 export interface NavItemProps {
   to: string;
   label: string;
+  subtitle?: string;
   icon?: LucideIcon;
   onClick?: () => void;
   isMobile?: boolean;
 }
 
-export function NavItem({ to, label, icon, onClick, isMobile }: NavItemProps) {
+export function NavItem({ to, label, subtitle, icon, onClick, isMobile }: NavItemProps) {
   if (!icon) {
     console.warn(`Navigation icon missing for route: ${label}. Falling back to Terminal icon.`);
   }
@@ -47,9 +48,16 @@ export function NavItem({ to, label, icon, onClick, isMobile }: NavItemProps) {
             <Box shrink={false}>
               <Icon className={cn(`${stroke.thick}`, isMobile ? "w-5 h-5" : "w-4 h-4")} />
             </Box>
-            <Text variant="sans" size={isMobile ? "lg" : "sm"} weight={isMobile ? "font-bold" : "font-medium"} className="leading-none">
-              {label}
-            </Text>
+            <Box>
+              <Text variant="sans" size={isMobile ? "lg" : "sm"} weight={isMobile ? "font-bold" : "font-medium"} className="leading-none">
+                {label}
+              </Text>
+              {isMobile && subtitle ? (
+                <Text variant="sans" size="sm" color="dim" marginTop={1} className="leading-tight">
+                  {subtitle}
+                </Text>
+              ) : null}
+            </Box>
           </Box>
         )}
       </NavLink>

--- a/src/components/navigation/NavItem.tsx
+++ b/src/components/navigation/NavItem.tsx
@@ -34,7 +34,7 @@ export function NavItem({ to, label, subtitle, icon, onClick, isMobile }: NavIte
         {({ isActive }) => (
           <Box
             display="flex"
-            align="center"
+            align={isMobile ? "start" : "center"}
             gap={3}
             paddingY={3}
             paddingX={isMobile ? 4 : 6}
@@ -48,12 +48,12 @@ export function NavItem({ to, label, subtitle, icon, onClick, isMobile }: NavIte
             <Box shrink={false}>
               <Icon className={cn(`${stroke.thick}`, isMobile ? "w-5 h-5" : "w-4 h-4")} />
             </Box>
-            <Box>
-              <Text variant="sans" size={isMobile ? "lg" : "sm"} weight={isMobile ? "font-bold" : "font-medium"} className="leading-none">
+            <Box flex={1}>
+              <Text as="p" variant="sans" size={isMobile ? "lg" : "sm"} weight={isMobile ? "font-bold" : "font-medium"} className="leading-none">
                 {label}
               </Text>
               {isMobile && subtitle ? (
-                <Text variant="sans" size="sm" color="dim" marginTop={1} className="leading-tight">
+                <Text as="p" variant="sans" size="sm" color="dim" marginTop={1} className="leading-tight">
                   {subtitle}
                 </Text>
               ) : null}

--- a/src/components/ui/HeroSection.tsx
+++ b/src/components/ui/HeroSection.tsx
@@ -114,8 +114,8 @@ export function HeroSection() {
             size={{ base: "base", md: "lg", lg: "xl" }}
             className="hero-tagline-text"
           >
-            Training tips, travel guides, and gear reviews for competitive West Coast Swing dancers,
-            plus technical deep dives into building the platform with DevAI.
+            Field guides, gear notes, and event prep for West Coast Swing dancers who want to
+            train smarter, travel better, and show up ready.
           </Text>
         </Stack>
 

--- a/src/components/ui/HeroSection.tsx
+++ b/src/components/ui/HeroSection.tsx
@@ -120,35 +120,6 @@ export function HeroSection() {
           </Text>
         </Stack>
 
-        <Stack
-          direction={{ base: "column", sm: "row" }}
-          align="start"
-          gap={3}
-          marginTop={6}
-          className="opacity-0 hero-tagline-anim"
-        >
-          <Box
-            as={NavLink}
-            to="/events"
-            paddingX={5}
-            paddingY={2.5}
-            radius="full"
-            className="bg-accent text-bg font-semibold hover:opacity-90 transition-opacity"
-          >
-            Explore Guides
-          </Box>
-          <Box
-            as={NavLink}
-            to="/gear"
-            paddingX={5}
-            paddingY={2.5}
-            radius="full"
-            className="border border-line text-text-main font-semibold hover:bg-surface-alt transition-colors"
-          >
-            Browse Gear
-          </Box>
-        </Stack>
-
         {/* Waveform - Height fixed and overflow-hidden for layout stability. Margin adjusted for breathing room. */}
         <Stack
           direction="row"
@@ -185,7 +156,28 @@ export function HeroSection() {
         zIndex={10}
         className="opacity-0 hero-cta-anim"
       >
-
+        <Stack direction={{ base: "column", sm: "row" }} align="center" gap={3}>
+          <Box
+            as={NavLink}
+            to="/events"
+            paddingX={5}
+            paddingY={2.5}
+            radius="full"
+            className="bg-accent text-bg font-semibold hover:opacity-90 transition-opacity"
+          >
+            Explore Guides
+          </Box>
+          <Box
+            as={NavLink}
+            to="/gear"
+            paddingX={5}
+            paddingY={2.5}
+            radius="full"
+            className="border border-line text-text-main font-semibold hover:bg-surface-alt transition-colors"
+          >
+            Browse Gear
+          </Box>
+        </Stack>
       </Stack>
     </Stack>
   );

--- a/src/components/ui/HeroSection.tsx
+++ b/src/components/ui/HeroSection.tsx
@@ -4,6 +4,7 @@ import { HeroParticleCanvas } from './HeroParticleCanvas';
 import { Stack, Text, Box } from '@/layouts/Primitives';
 import { Wordmark } from './Wordmark';
 import { HERO_CONFIG } from '@/config/hero';
+import { NavLink } from 'react-router-dom';
 
 // Generate deterministic bar data based on index to prevent visual regression flakiness
 const BARS = Array.from({ length: HERO_CONFIG.BAR_COUNT }, (_, i) => ({
@@ -62,14 +63,14 @@ export function HeroSection() {
             as="span"
             variant="hero"
             color="white"
-            size={{ base: "3xl", md: "5xl", lg: "6xl" }}
+            size={{ base: "4xl", md: "6xl", lg: "7xl" }}
           >
             Built for dancers.
           </Text>
           <Text
             as="span"
             variant="hero"
-            size={{ base: "4xl", md: "6xl", lg: "7xl" }}
+            size={{ base: "5xl", md: "7xl", lg: "8xl" }}
           >
             <span className="hero-accent-color">Train smarter.</span>
           </Text>
@@ -77,7 +78,7 @@ export function HeroSection() {
             as="span"
             variant="hero"
             color="white"
-            size={{ base: "4xl", md: "6xl", lg: "7xl" }}
+            size={{ base: "5xl", md: "7xl", lg: "8xl" }}
           >
             Dance better.
           </Text>
@@ -98,7 +99,7 @@ export function HeroSection() {
           align="stretch"
           gap={5}
           marginTop={{ base: 6, lg: 8 }}
-          maxWidth="2xl"
+          maxWidth="xl"
           className="opacity-0 hero-tagline-anim"
         >
           <Box
@@ -117,6 +118,35 @@ export function HeroSection() {
             Field guides, gear notes, and event prep for West Coast Swing dancers who want to
             train smarter, travel better, and show up ready.
           </Text>
+        </Stack>
+
+        <Stack
+          direction={{ base: "column", sm: "row" }}
+          align="start"
+          gap={3}
+          marginTop={6}
+          className="opacity-0 hero-tagline-anim"
+        >
+          <Box
+            as={NavLink}
+            to="/events"
+            paddingX={5}
+            paddingY={2.5}
+            radius="full"
+            className="bg-accent text-bg font-semibold hover:opacity-90 transition-opacity"
+          >
+            Explore Guides
+          </Box>
+          <Box
+            as={NavLink}
+            to="/gear"
+            paddingX={5}
+            paddingY={2.5}
+            radius="full"
+            className="border border-line text-text-main font-semibold hover:bg-surface-alt transition-colors"
+          >
+            Browse Gear
+          </Box>
         </Stack>
 
         {/* Waveform - Height fixed and overflow-hidden for layout stability. Margin adjusted for breathing room. */}

--- a/src/components/ui/HeroSection.tsx
+++ b/src/components/ui/HeroSection.tsx
@@ -4,7 +4,6 @@ import { HeroParticleCanvas } from './HeroParticleCanvas';
 import { Stack, Text, Box } from '@/layouts/Primitives';
 import { Wordmark } from './Wordmark';
 import { HERO_CONFIG } from '@/config/hero';
-import { NavLink } from 'react-router-dom';
 
 // Generate deterministic bar data based on index to prevent visual regression flakiness
 const BARS = Array.from({ length: HERO_CONFIG.BAR_COUNT }, (_, i) => ({
@@ -146,7 +145,6 @@ export function HeroSection() {
         </Stack>
       </Stack>
 
-      {/* Scroll Down Indicator - Enhanced Mobile CTA */}
       <Stack
         position="absolute"
         inset="bottom"
@@ -155,30 +153,7 @@ export function HeroSection() {
         paddingBottom={8}
         zIndex={10}
         className="opacity-0 hero-cta-anim"
-      >
-        <Stack direction={{ base: "column", sm: "row" }} align="center" gap={3}>
-          <Box
-            as={NavLink}
-            to="/events"
-            paddingX={5}
-            paddingY={2.5}
-            radius="full"
-            className="bg-accent text-bg font-semibold hover:opacity-90 transition-opacity"
-          >
-            Explore Guides
-          </Box>
-          <Box
-            as={NavLink}
-            to="/gear"
-            paddingX={5}
-            paddingY={2.5}
-            radius="full"
-            className="border border-line text-text-main font-semibold hover:bg-surface-alt transition-colors"
-          >
-            Browse Gear
-          </Box>
-        </Stack>
-      </Stack>
+      />
     </Stack>
   );
 }

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -20,7 +20,7 @@ export const PRINTFUL_REFERRAL = {
   FOOTER_DESCRIPTION: 'Supporting BoomTick helps us keep the servers running and the content flowing. Save $5 on your first Printful order and support the blog at the same time.'
 } as const;
 
-const DEFAULT_DESCRIPTION = "The West Coast Swing Lifestyle Blog by Tech Dancer. Training tips, travel guides, and gear reviews for competitive West Coast Swing dancers, plus technical deep dives into building the platform with DevAI.";
+const DEFAULT_DESCRIPTION = "BoomTick is built for West Coast Swing dancers who want to train smarter, travel better, and show up ready with practical guides, event prep, and gear notes.";
 
 export const STATIC_SCHEMAS = {
   HOME: {

--- a/src/features/dashboard/Dashboard.tsx
+++ b/src/features/dashboard/Dashboard.tsx
@@ -34,7 +34,7 @@ export default function Home() {
                   paddingBottom={0}
                   border="none"
                   as="h2"
-                  titleSize="fluid-6"
+                  titleSize="fluid-5"
                 />
                 <Box
                   as={NavLink}

--- a/src/features/dashboard/Dashboard.tsx
+++ b/src/features/dashboard/Dashboard.tsx
@@ -5,7 +5,6 @@ import { Box, Stack, Text, Grid } from '@/layouts/Primitives';
 import { useHome } from './useHome';
 import { SEO } from '@/components/SEO';
 import { STATIC_SCHEMAS } from '@/config/constants';
-import { PageHeader } from '@/components/ui/PageHeader';
 import { SectionHeader } from '@/components/ui/SectionHeader';
 import { HeroSection } from '@/components/ui/HeroSection';
 import { EventCard } from '@/components/ui/EventCard';
@@ -28,14 +27,14 @@ export default function Home() {
           <Stack gap={6}>
             <Stack gap={1}>
               <Box width="full" display="flex" justify="between" align="end" direction={{ base: "col", sm: "row" }} gap={{ base: 3, sm: 0 }}>
-                <PageHeader
-                  label="Latest Updates"
-                  title="Recent Posts"
-                  paddingBottom={0}
-                  border="none"
-                  as="h2"
-                  titleSize="fluid-5"
-                />
+                <Stack gap={1}>
+                  <Text variant="mono" size="xs" color="brand" weight="font-black" tracking="wide-editorial" uppercase>
+                    Latest Updates
+                  </Text>
+                  <Text as="h2" variant="headline" size="4xl" weight="font-black" leading="tight" tracking="tight">
+                    Recent Posts
+                  </Text>
+                </Stack>
                 <Box
                   as={NavLink}
                   to="/blog"

--- a/src/index.css
+++ b/src/index.css
@@ -257,7 +257,7 @@
 @layer utilities {
   .hero-section {
     background: var(--hero-bg);
-    min-height: 42vh;
+    min-height: 47vh;
   }
   .hero-bottom-gradient {
     background-image: linear-gradient(to top, var(--raw-color-bg), transparent);

--- a/src/index.css
+++ b/src/index.css
@@ -257,7 +257,7 @@
 @layer utilities {
   .hero-section {
     background: var(--hero-bg);
-    min-height: 34vh;
+    min-height: 42vh;
   }
   .hero-bottom-gradient {
     background-image: linear-gradient(to top, var(--raw-color-bg), transparent);

--- a/src/index.css
+++ b/src/index.css
@@ -257,7 +257,7 @@
 @layer utilities {
   .hero-section {
     background: var(--hero-bg);
-    min-height: 47vh;
+    min-height: 54vh;
   }
   .hero-bottom-gradient {
     background-image: linear-gradient(to top, var(--raw-color-bg), transparent);


### PR DESCRIPTION
### Motivation
- Make the homepage messaging feel like a West Coast Swing field guide instead of a technical/platform blog. 
- Improve mobile navigation clarity so new visitors can find key paths (Guides, Gear, Events, Merch) quickly. 
- Provide short explanatory subtitles in the mobile menu to reduce cognitive load and guide clicks.

### Description
- Update the hero tagline in `src/components/ui/HeroSection.tsx` to a dancer-first line: “Field guides, gear notes, and event prep for West Coast Swing dancers who want to train smarter, travel better, and show up ready.”
- Replace the default site description in `src/config/constants.ts` with a concise dancer-focused `DEFAULT_DESCRIPTION` used for schema/SEO.
- Add an optional `subtitle` prop to the navigation item component in `src/components/navigation/NavItem.tsx` and render the subtitle for mobile items using layout primitives (no raw spacing classes).
- Add `MOBILE_MENU_COPY` to `src/components/navigation/MobileMenuOverlay.tsx` and wire friendly labels and explanatory subtitles (including a `Start Here` entry) into the mobile menu while adjusting the route filtering to include Home.

### Testing
- Ran the UI anti-pattern auditor with `pnpm run audit`, which reported no anti-patterns after the changes and passed successfully. 
- Attempted `python3 dev-tools/td_cli.py conflicts` and `python3 dev-tools/td_cli.py pre-submit`, but those commands are not available in this repo build and returned "No such command" errors. 
- No additional unit or integration test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a139281b7a48325989ca264172a9c24)