### PR TITLE
[PR #1490 Follow-up] Fix theme catalog coverage, image prefixing, and toolbox base-path links

### DIFF
--- a/src/components/products/ProductCard.tsx
+++ b/src/components/products/ProductCard.tsx
@@ -18,6 +18,12 @@ interface ProductCardProps {
 
 export function ProductCard({ product, variant = 'full' }: ProductCardProps) {
   const isCompact = variant === 'compact' || variant === 'resource-preview';
+  const isExternalImage = product.imageUrl.startsWith('http');
+  const isRootRelativeImage = product.imageUrl.startsWith('/');
+  const isPrefixedImage = ASSET_PREFIX !== '' && product.imageUrl.startsWith(`${ASSET_PREFIX}/`);
+  const productImageUrl = isExternalImage || !isRootRelativeImage || isPrefixedImage
+    ? product.imageUrl
+    : `${ASSET_PREFIX}${product.imageUrl}`;
 
   return (
     <Stack
@@ -53,7 +59,7 @@ export function ProductCard({ product, variant = 'full' }: ProductCardProps) {
       >
         <Box
           as="img"
-          src={product.imageUrl.startsWith('http') ? product.imageUrl : `${ASSET_PREFIX}${product.imageUrl}`}
+          src={productImageUrl}
           alt={product.title}
           width="full"
           height="full"

--- a/src/features/lab/Toolbox.tsx
+++ b/src/features/lab/Toolbox.tsx
@@ -18,6 +18,7 @@ import { ProductDisclosure } from '@/components/products/ProductDisclosure';
 
 export default function Toolbox() {
   const { filteredCategories, searchTerm, setSearchTerm, view, setView, selectedPill, setSelectedPill } = useToolbox();
+  const baseUrl = (import.meta.env.BASE_URL || '/').replace(/\/$/, '');
 
   const allFilteredItems = useMemo(() =>
     filteredCategories.flatMap(cat => cat.items),
@@ -74,7 +75,7 @@ export default function Toolbox() {
               product={affiliateToCatalogItem({
                 id: item.affiliateIds?.[0] || item.slug,
                 name: item.title,
-                url: `/gear/${item.slug}`,
+                url: `${baseUrl}/gear/${item.slug}`,
                 category: item.category,
                 description: item.excerpt,
                 image: item.image,

--- a/src/lib/productCatalog.ts
+++ b/src/lib/productCatalog.ts
@@ -44,6 +44,8 @@ export function getProductsForEvent(event: Event): ProductCatalogItem[] {
   const shoeIds = event.gear?.shoeIds || [];
   const essentialIds = event.gear?.essentialIds || [];
   const travelIds = event.gear?.travelIds || [];
+  const themeOutfitIds = event.theme?.outfitIds || [];
+  const themeAccessoryIds = event.theme?.accessoryIds || [];
 
   const allIds = [
     ...outfitIds,
@@ -51,6 +53,8 @@ export function getProductsForEvent(event: Event): ProductCatalogItem[] {
     ...shoeIds,
     ...essentialIds,
     ...travelIds,
+    ...themeOutfitIds,
+    ...themeAccessoryIds,
   ];
 
   // In this system, we check both sources for the IDs.


### PR DESCRIPTION
### Motivation
- Fix three high-priority regressions introduced while centralizing product/catalog logic so event Theme Spotlight, product images, and toolbox navigation work correctly under subpath deployments.
- Ensure event product resolution includes theme-defined products that were previously dropped when not duplicated in `event.gear`.
- Prevent image URL double-prefixing and ensure toolbox product links respect the app basename to avoid broken assets and navigation.

### Description
- Include theme IDs when resolving event products by adding `event.theme.outfitIds` and `event.theme.accessoryIds` to `getProductsForEvent` in `src/lib/productCatalog.ts` so theme recommendations aren't lost.
- Normalize product image URLs in `src/components/products/ProductCard.tsx` with guards for external (`http`), root-relative (`/`), and already-prefixed (`ASSET_PREFIX`) paths to avoid double-prefixing and broken URLs.
- Make toolbox product card URLs basename-aware in `src/features/lab/Toolbox.tsx` by deriving a `baseUrl` from `import.meta.env.BASE_URL` and prepending it when constructing the card `url`.

### Testing
- Ran `pnpm run audit` and it passed with no anti-patterns detected.
- Ran a full production build with `pnpm run build`, which includes `tsc --noEmit` type-checking and the Vite build; the build completed successfully.
- Attempted repository automation commands `python3 dev-tools/td_cli.py conflicts` and `python3 dev-tools/td_cli.py pre-submit`, but those commands are not available in this environment and returned errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13b77a8fc08325aadb3c6c0fbf0a49)