### PR TITLE
Fix product image URL handling, include event theme gear, and simplify contact button text styling

### DIFF
--- a/src/components/products/ProductCard.tsx
+++ b/src/components/products/ProductCard.tsx
@@ -18,6 +18,12 @@ interface ProductCardProps {
 
 export function ProductCard({ product, variant = 'full' }: ProductCardProps) {
   const isCompact = variant === 'compact' || variant === 'resource-preview';
+  const isExternalImage = product.imageUrl.startsWith('http');
+  const isRootRelativeImage = product.imageUrl.startsWith('/');
+  const isPrefixedImage = ASSET_PREFIX !== '' && product.imageUrl.startsWith(`${ASSET_PREFIX}/`);
+  const productImageUrl = isExternalImage || !isRootRelativeImage || isPrefixedImage
+    ? product.imageUrl
+    : `${ASSET_PREFIX}${product.imageUrl}`;
 
   return (
     <Stack
@@ -53,7 +59,7 @@ export function ProductCard({ product, variant = 'full' }: ProductCardProps) {
       >
         <Box
           as="img"
-          src={product.imageUrl.startsWith('http') ? product.imageUrl : `${ASSET_PREFIX}${product.imageUrl}`}
+          src={productImageUrl}
           alt={product.title}
           width="full"
           height="full"

--- a/src/features/contact/components/ContactFormView.tsx
+++ b/src/features/contact/components/ContactFormView.tsx
@@ -112,12 +112,12 @@ export function ContactFormView({ register, errors, isSubmitting, onSubmit }: Co
                 {isSubmitting ? (
                   <Stack direction="row" align="center" gap={3}>
                     <Box width={4} height={4} border={2} className="border-current border-t-transparent animate-spin" />
-                    <Text color="inherit" size="sm" weight="font-bold">Sending...</Text>
+                    <Text size="sm" weight="font-bold">Sending...</Text>
                   </Stack>
                 ) : (
                   <Stack direction="row" align="center" gap={2}>
                     <Send className="w-4 h-4" />
-                    <Text size="sm" weight="font-bold" color="inherit">Send Message</Text>
+                    <Text size="sm" weight="font-bold">Send Message</Text>
                   </Stack>
                 )}
               </ActionButton>

--- a/src/features/lab/Toolbox.tsx
+++ b/src/features/lab/Toolbox.tsx
@@ -18,6 +18,7 @@ import { ProductDisclosure } from '@/components/products/ProductDisclosure';
 
 export default function Toolbox() {
   const { filteredCategories, searchTerm, setSearchTerm, view, setView, selectedPill, setSelectedPill } = useToolbox();
+  const baseUrl = (import.meta.env.BASE_URL || '/').replace(/\/$/, '');
 
   const allFilteredItems = useMemo(() =>
     filteredCategories.flatMap(cat => cat.items),
@@ -74,7 +75,7 @@ export default function Toolbox() {
               product={affiliateToCatalogItem({
                 id: item.affiliateIds?.[0] || item.slug,
                 name: item.title,
-                url: `/gear/${item.slug}`,
+                url: `${baseUrl}/gear/${item.slug}`,
                 category: item.category,
                 description: item.excerpt,
                 image: item.image,

--- a/src/lib/productCatalog.ts
+++ b/src/lib/productCatalog.ts
@@ -44,6 +44,8 @@ export function getProductsForEvent(event: Event): ProductCatalogItem[] {
   const shoeIds = event.gear?.shoeIds || [];
   const essentialIds = event.gear?.essentialIds || [];
   const travelIds = event.gear?.travelIds || [];
+  const themeOutfitIds = event.theme?.outfitIds || [];
+  const themeAccessoryIds = event.theme?.accessoryIds || [];
 
   const allIds = [
     ...outfitIds,
@@ -51,6 +53,8 @@ export function getProductsForEvent(event: Event): ProductCatalogItem[] {
     ...shoeIds,
     ...essentialIds,
     ...travelIds,
+    ...themeOutfitIds,
+    ...themeAccessoryIds,
   ];
 
   // In this system, we check both sources for the IDs.


### PR DESCRIPTION
### Motivation

- Ensure product images resolve correctly when an `ASSET_PREFIX` is present or when image URLs are external or root-relative.
- Make generated gear links robust to base path differences by using the app `BASE_URL` at runtime.
- Include gear referenced by an event's `theme` in the assembled product list so themed outfits/accessories are shown. 
- Avoid forcing text color on contact form button labels so the inherited color system works consistently.

### Description

- Updated `ProductCard` to compute `productImageUrl` that respects external URLs, root-relative paths, and the `ASSET_PREFIX` before passing it to the `img` `src` attribute. 
- Added `baseUrl` in `Toolbox` to normalize `import.meta.env.BASE_URL` and prefixed gear detail URLs with it when creating catalog items. 
- Extended `getProductsForEvent` in `src/lib/productCatalog.ts` to pull `outfitIds` and `accessoryIds` from `event.theme` and include them in the resolved product set, then deduplicate the combined affiliate and merch results. 
- Removed explicit `color="inherit"` props from the `Text` nodes in `ContactFormView` to rely on inherited text color for the sending/submit button labels.

### Testing

- Ran TypeScript type checking and a production build with `pnpm build`, which completed successfully. 
- Executed the unit test suite with `pnpm test`, and all tests passed. 
- Ran the local dev server and spot-checked the Toolbox and ProductCard UIs, confirming images and gear links render as expected (local verification passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13b77a8fc08325aadb3c6c0fbf0a49)