### PR TITLE
Simplify Design Token Indirection

### DIFF
--- a/src/components/ui/HeroSection.tsx
+++ b/src/components/ui/HeroSection.tsx
@@ -60,27 +60,24 @@ export function HeroSection() {
         >
           <Text
             as="span"
+            variant="hero"
             color="white"
             size={{ base: "3xl", md: "5xl", lg: "6xl" }}
-            tracking="tight"
-            className="font-serif font-black leading-[1.2]"
           >
             Built for dancers.
           </Text>
           <Text
             as="span"
+            variant="hero"
             size={{ base: "4xl", md: "6xl", lg: "7xl" }}
-            tracking="tight"
-            className="font-serif font-black leading-[1.2]"
           >
             <span className="hero-accent-color">Train smarter.</span>
           </Text>
           <Text
             as="span"
+            variant="hero"
             color="white"
             size={{ base: "4xl", md: "6xl", lg: "7xl" }}
-            tracking="tight"
-            className="font-serif font-black leading-[1.2]"
           >
             Dance better.
           </Text>

--- a/src/components/ui/HeroSection.tsx
+++ b/src/components/ui/HeroSection.tsx
@@ -60,24 +60,27 @@ export function HeroSection() {
         >
           <Text
             as="span"
-            variant="hero"
             color="white"
             size={{ base: "3xl", md: "5xl", lg: "6xl" }}
+            tracking="tight"
+            className="font-serif font-black leading-[1.2]"
           >
             Built for dancers.
           </Text>
           <Text
             as="span"
-            variant="hero"
             size={{ base: "4xl", md: "6xl", lg: "7xl" }}
+            tracking="tight"
+            className="font-serif font-black leading-[1.2]"
           >
             <span className="hero-accent-color">Train smarter.</span>
           </Text>
           <Text
             as="span"
-            variant="hero"
             color="white"
             size={{ base: "4xl", md: "6xl", lg: "7xl" }}
+            tracking="tight"
+            className="font-serif font-black leading-[1.2]"
           >
             Dance better.
           </Text>

--- a/src/components/ui/Wordmark.tsx
+++ b/src/components/ui/Wordmark.tsx
@@ -35,9 +35,10 @@ export function Wordmark({
   return (
     <Text
       variant={VARIANT_MAP[variant]}
+      color="white"
       size={size || (isHero ? undefined : (isNav ? "sm" : "base"))}
       weight={weight || "font-extrabold"}
-      className={cn(VARIANT_CLASSES[variant], className)}
+      className={cn("leading-none", VARIANT_CLASSES[variant], className)}
       style={style}
       tracking="wordmark"
       {...props}

--- a/src/components/ui/Wordmark.tsx
+++ b/src/components/ui/Wordmark.tsx
@@ -8,10 +8,10 @@ export interface WordmarkProps extends Omit<TextProps, 'variant'> {
 }
 
 const VARIANT_MAP: Record<WordmarkVariant, TextProps["variant"]> = {
-  default: "wordmark",
-  hero: "wordmarkHero",
-  navigation: "wordmark",
-  nav: "wordmark", // Legacy alias for navigation
+  default: "sans",
+  hero: "display",
+  navigation: "sans",
+  nav: "sans", // Legacy alias for navigation
 };
 
 const VARIANT_CLASSES: Record<WordmarkVariant, string> = {

--- a/src/styles/design-tokens.ts
+++ b/src/styles/design-tokens.ts
@@ -8,14 +8,8 @@
 
 
 export const spacing = {
-  container: "p-container-sm md:p-container-md",
   card: "p-card",
   compact: "p-compact",
-  nav: "p-nav",
-  emailBar: "py-email-bar-y px-email-bar-x-sm md:px-email-bar-x-md",
-  hero: "py-hero",
-  comfort: "py-comfort",
-  endPad: "pb-end-pad",
 };
 
 export const animation = {
@@ -35,11 +29,6 @@ export const layout = {
   navRail: "nav-rail hidden lg:flex flex-col justify-between min-h-screen sticky top-0",
   mobileHeader: "lg:hidden fixed top-0 left-0 right-0 h-16 bg-surface z-[110] flex items-center justify-between px-8 border-b border-line w-full",
   panel: "panel h-full overflow-y-auto w-full",
-  card: "bg-surface border border-line rounded-none transition-all duration-300 w-full",
-  interactive: "cursor-pointer",
-  grid: "grid grid-cols-1 md:grid-cols-12 gap-4 md:gap-8 w-full",
-  section: "mt-24 space-y-8",
-  divider: "border-b border-line pb-4 flex items-end justify-between",
 };
 
 export const inputs = {
@@ -104,19 +93,10 @@ export const typography = {
   h2: "font-display font-bold tracking-tight leading-tight",
   h3: "font-display font-semibold tracking-tight leading-snug",
   headline: "font-display font-bold tracking-tighter leading-[0.9]",
-  hero: "font-serif font-black tracking-tight leading-[1.2]",
   display: "font-display font-bold tracking-tight leading-none",
   body: "font-sans leading-relaxed text-text-body max-w-[65ch]",
   mono: "font-mono tracking-widest uppercase",
-  utility: `font-mono ${tracking.utility} uppercase`,
-  label: `font-mono font-bold uppercase ${tracking.label}`,
-  micro: "font-mono uppercase tracking-widest",
-  tight: "tracking-[0.15em] uppercase",
-  content: "font-sans leading-relaxed text-text-body max-w-[70ch]",
-  headerAccent: `font-mono font-bold ${tracking["wide-editorial"]} uppercase text-accent`,
   sans: "font-sans",
-  wordmark: `font-sans leading-none text-white ${tracking.wordmark}`,
-  wordmarkHero: `font-display leading-none text-white ${tracking.wordmark}`,
 };
 
 export const typeSizes = {

--- a/src/styles/design-tokens.ts
+++ b/src/styles/design-tokens.ts
@@ -94,6 +94,7 @@ export const typography = {
   h3: "font-display font-semibold tracking-tight leading-snug",
   headline: "font-display font-bold tracking-tighter leading-[0.9]",
   display: "font-display font-bold tracking-tight leading-none",
+  hero: "font-serif font-black tracking-tight leading-[1.2]",
   body: "font-sans leading-relaxed text-text-body max-w-[65ch]",
   mono: "font-mono tracking-widest uppercase",
   sans: "font-sans",


### PR DESCRIPTION
Simplified the design token system in `src/styles/design-tokens.ts` by removing redundant and unused tokens. Tokens that were only used in a single location or were not found in the codebase were either inlined or deleted. Foundational tokens and those reused across many files (like `headline`, `display`, and core layout primitives) were preserved to maintain systemic consistency and avoid breaking the UI. `Wordmark.tsx` was refactored to use standard typography tokens, and the `hero` headline in `HeroSection.tsx` was inlined with raw Tailwind classes. verified the changes with a successful build and passed relevant tests.

Fixes #1516

---
*PR created automatically by Jules for task [8289276856885659307](https://jules.google.com/task/8289276856885659307) started by @arii*