### PR TITLE
Fix product image cropping on gear review pages

### DIFF
--- a/src/components/layout/DetailLayout.tsx
+++ b/src/components/layout/DetailLayout.tsx
@@ -6,6 +6,7 @@ import { Box, Stack, Text, Grid } from '@/layouts/Primitives';
 import { PageHeader } from '@/components/ui/PageHeader';
 import { Icon } from '@/components/ui/Icon';
 import { MarkdownRenderer } from '@/components/ui/MarkdownRenderer';
+import { ProductImageFrame } from '@/components/ui/ProductImageFrame';
 import { readingTime } from '@/lib/content';
 
 interface DetailLayoutProps {
@@ -22,6 +23,7 @@ interface DetailLayoutProps {
   headerExtras?: ReactNode;
   relatedContent?: ReactNode;
   showImagePair?: boolean;
+  imageFit?: 'cover' | 'contain';
 }
 
 export function DetailLayout({
@@ -37,7 +39,8 @@ export function DetailLayout({
   children,
   headerExtras,
   relatedContent,
-  showImagePair = false
+  showImagePair = false,
+  imageFit = 'cover'
 }: DetailLayoutProps) {
   const rt = readingTime(content);
   const [showBack, setShowBack] = useState(false);
@@ -93,31 +96,23 @@ export function DetailLayout({
                     <Text variant="mono" size="xs" weight="font-bold" tracking="widest" uppercase color="dim">
                       Front
                     </Text>
-                    <Box aspect="video" overflow="hidden" border radius="md">
-                      <img
-                        src={image}
-                        alt={`${title} – front view`}
-                        width={1280}
-                        height={720}
-                        loading="lazy"
-                        className="w-full h-full object-cover"
-                      />
-                    </Box>
+                    <ProductImageFrame
+                      src={image}
+                      alt={`${title} – front view`}
+                      objectFit={imageFit}
+                      border
+                    />
                   </Stack>
                   <Stack gap={2}>
                     <Text variant="mono" size="xs" weight="font-bold" tracking="widest" uppercase color="dim">
                       Back
                     </Text>
-                    <Box aspect="video" overflow="hidden" border radius="md">
-                      <img
-                        src={imageBack}
-                        alt={`${title} – back view`}
-                        width={1280}
-                        height={720}
-                        loading="lazy"
-                        className="w-full h-full object-cover"
-                      />
-                    </Box>
+                    <ProductImageFrame
+                      src={imageBack}
+                      alt={`${title} – back view`}
+                      objectFit={imageFit}
+                      border
+                    />
                   </Stack>
                 </Grid>
               ) : (
@@ -155,17 +150,14 @@ export function DetailLayout({
                       </Box>
                     </Box>
                   )}
-                  <Box aspect="video" overflow="hidden">
-                    <img
-                      key={displayImage}
-                      src={displayImage}
-                      alt={`${title}${showBack ? ' – back view' : ''}`}
-                      width={1280}
-                      height={720}
-                      loading="lazy"
-                      className="w-full h-full object-cover transition-opacity duration-300"
-                    />
-                  </Box>
+                  <ProductImageFrame
+                    key={displayImage}
+                    src={displayImage || ""}
+                    alt={`${title}${showBack ? ' – back view' : ''}`}
+                    objectFit={imageFit}
+                    border={false}
+                    radius="none"
+                  />
                 </>
               )}
             </Box>

--- a/src/components/ui/ProductImageFrame.tsx
+++ b/src/components/ui/ProductImageFrame.tsx
@@ -1,0 +1,44 @@
+import { Box } from '@/layouts/Primitives';
+import { cn } from '@/lib/utils';
+
+interface ProductImageFrameProps {
+  src: string;
+  alt: string;
+  objectFit?: 'cover' | 'contain';
+  aspect?: 'video' | 'square' | 'auto' | string;
+  className?: string;
+  border?: boolean | "t" | "b" | "l" | "r" | "x" | "y";
+  radius?: 'none' | 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl' | 'full';
+}
+
+export function ProductImageFrame({
+  src,
+  alt,
+  objectFit = 'cover',
+  aspect = 'video',
+  className,
+  border = true,
+  radius = 'md'
+}: ProductImageFrameProps) {
+  return (
+    <Box
+      aspect={aspect}
+      overflow="hidden"
+      border={border}
+      radius={radius}
+      className={cn("bg-surface-alt", className)}
+    >
+      <img
+        src={src}
+        alt={alt}
+        width={1280}
+        height={720}
+        loading="lazy"
+        className={cn(
+          "w-full h-full transition-opacity duration-300",
+          objectFit === 'contain' ? "object-contain p-4" : "object-cover"
+        )}
+      />
+    </Box>
+  );
+}

--- a/src/features/lab/components/FullPreview.tsx
+++ b/src/features/lab/components/FullPreview.tsx
@@ -106,6 +106,7 @@ export function FullPreview(props: FullPreviewProps & DraftData) {
         backLabel="Back to Editor"
         headerExtras={headerExtras}
         sidebar={sidebar}
+        imageFit={props.type === 'resource' ? 'contain' : 'cover'}
       >
          {props.excerpt && (
            <Box marginY={8} border="l" paddingLeft={6} className="border-accent">

--- a/src/features/lab/components/GearPostDetail.tsx
+++ b/src/features/lab/components/GearPostDetail.tsx
@@ -35,6 +35,7 @@ export function GearPostDetail({ post, onBack, backLabel }: GearPostDetailProps)
       headerExtras={headerExtras}
       imageBack={post.imageBack}
       showImagePair
+      imageFit="contain"
     >
       {post.verdict && <VerdictCallout verdict={post.verdict} />}
     </DetailLayout>


### PR DESCRIPTION
Improved gear review pages by preventing product image cropping.

Key changes:
- Created a reusable `ProductImageFrame` component that uses `object-contain` and a neutral background.
- Added an `imageFit` prop to `DetailLayout` to toggle between `cover` and `contain` for hero images.
- Applied the `contain` fit to individual gear review pages (`GearPostDetail`) and the Lab previewer (`FullPreview`).
- Verified the fix via Playwright screenshots, ensuring gear images show the full item with padding while blog posts retain their original layout.
- Refined component props and layout based on code review feedback to ensure visual consistency with the existing design system.

Fixes #1554

---
*PR created automatically by Jules for task [7163855370497249415](https://jules.google.com/task/7163855370497249415) started by @arii*