### PR TITLE
Centralize Architectural Asset Paths and Descriptions

### DIFF
--- a/src/config/devai-assets.ts
+++ b/src/config/devai-assets.ts
@@ -1,0 +1,39 @@
+export interface DevAIAsset {
+  path: string;
+  label: string;
+  description: string;
+  toolId: string;
+}
+
+export const DEVAI_ASSETS: DevAIAsset[] = [
+  {
+    path: 'dev-tools/scope_check.py',
+    label: 'Impact Analyzer',
+    description: 'Calculates semantic blast radius of code changes.',
+    toolId: 'scope-blast-radius'
+  },
+  {
+    path: 'dev-tools/workflow_summary.py',
+    label: 'SDLC Profiler',
+    description: 'Analyzes GitHub Workflow execution metrics.',
+    toolId: 'scope-blast-radius'
+  },
+  {
+    path: 'dev-tools/mergellama.py',
+    label: 'PR Auditor',
+    description: 'Autonomous LLM-based code review agent.',
+    toolId: 'gitops-pr-reviewer'
+  },
+  {
+    path: 'dev-tools/ollama_reviewer.py',
+    label: 'Local LLM Reviewer',
+    description: 'Local-first model execution for privacy-safe reviews.',
+    toolId: 'gitops-pr-reviewer'
+  },
+  {
+    path: 'dev-tools/td_cli.py',
+    label: 'CLI Manager',
+    description: 'Unified command-line interface for DevAI operations.',
+    toolId: 'gitops-pr-reviewer'
+  }
+];

--- a/src/config/devai-assets.ts
+++ b/src/config/devai-assets.ts
@@ -1,3 +1,5 @@
+import { TOOL_ID_SCOPE_BLAST_RADIUS, TOOL_ID_GITOPS_PR_REVIEWER } from './devai-tool-ids';
+
 export interface DevAIAsset {
   path: string;
   label: string;
@@ -10,30 +12,30 @@ export const DEVAI_ASSETS: DevAIAsset[] = [
     path: 'dev-tools/scope_check.py',
     label: 'Impact Analyzer',
     description: 'Calculates semantic blast radius of code changes.',
-    toolId: 'scope-blast-radius'
+    toolId: TOOL_ID_SCOPE_BLAST_RADIUS
   },
   {
     path: 'dev-tools/workflow_summary.py',
     label: 'SDLC Profiler',
     description: 'Analyzes GitHub Workflow execution metrics.',
-    toolId: 'scope-blast-radius'
+    toolId: TOOL_ID_SCOPE_BLAST_RADIUS
   },
   {
     path: 'dev-tools/mergellama.py',
     label: 'PR Auditor',
     description: 'Autonomous LLM-based code review agent.',
-    toolId: 'gitops-pr-reviewer'
+    toolId: TOOL_ID_GITOPS_PR_REVIEWER
   },
   {
     path: 'dev-tools/ollama_reviewer.py',
     label: 'Local LLM Reviewer',
     description: 'Local-first model execution for privacy-safe reviews.',
-    toolId: 'gitops-pr-reviewer'
+    toolId: TOOL_ID_GITOPS_PR_REVIEWER
   },
   {
     path: 'dev-tools/td_cli.py',
     label: 'CLI Manager',
     description: 'Unified command-line interface for DevAI operations.',
-    toolId: 'gitops-pr-reviewer'
+    toolId: TOOL_ID_GITOPS_PR_REVIEWER
   }
 ];

--- a/src/config/devai-tool-ids.ts
+++ b/src/config/devai-tool-ids.ts
@@ -1,0 +1,2 @@
+export const TOOL_ID_SCOPE_BLAST_RADIUS = 'scope-blast-radius';
+export const TOOL_ID_GITOPS_PR_REVIEWER = 'gitops-pr-reviewer';

--- a/src/features/research/components/ArchitecturalAssetsList.tsx
+++ b/src/features/research/components/ArchitecturalAssetsList.tsx
@@ -36,20 +36,22 @@ export function ArchitecturalAssetsList({ assets }: ArchitecturalAssetsListProps
           const Icon = asset.icon || getIconForPath(asset.path);
           return (
             <Box key={asset.path} border radius="md" surface="surface" padding={3}>
-              <Stack gap={2}>
-                <Box display="flex" align="center" gap={3}>
+              <Box display="flex" gap={3}>
+                <Box className="shrink-0" paddingTop={0.5}>
                   <Icon size={16} className="text-accent" />
-                  <Text variant="mono" size="xs">{asset.path}</Text>
-                  <Text variant="mono" size="micro" color="dim" marginLeft="auto" opacity={0.6}>{asset.label}</Text>
                 </Box>
-                {asset.description && (
-                  <Box paddingLeft={7}>
+                <Stack gap={2} width="full">
+                  <Box display="flex" align="center" justify="between" width="full">
+                    <Text variant="mono" size="xs">{asset.path}</Text>
+                    <Text variant="mono" size="micro" color="dim" opacity={0.6}>{asset.label}</Text>
+                  </Box>
+                  {asset.description && (
                     <Text variant="body" size="micro" color="dim">
                       {asset.description}
                     </Text>
-                  </Box>
-                )}
-              </Stack>
+                  )}
+                </Stack>
+              </Box>
             </Box>
           );
         })}

--- a/src/features/research/components/ArchitecturalAssetsList.tsx
+++ b/src/features/research/components/ArchitecturalAssetsList.tsx
@@ -4,6 +4,7 @@ import { FileCode, Terminal, LucideIcon } from 'lucide-react';
 export interface ArchitecturalAsset {
   path: string;
   label: string;
+  description?: string;
   icon?: LucideIcon;
 }
 
@@ -34,10 +35,21 @@ export function ArchitecturalAssetsList({ assets }: ArchitecturalAssetsListProps
         {assets.map((asset) => {
           const Icon = asset.icon || getIconForPath(asset.path);
           return (
-            <Box key={asset.path} display="flex" align="center" gap={3} padding={3} border radius="md" surface="surface">
-              <Icon size={16} className="text-accent" />
-              <Text variant="mono" size="xs">{asset.path}</Text>
-              <Text variant="mono" size="micro" color="dim" marginLeft="auto" opacity={0.6}>{asset.label}</Text>
+            <Box key={asset.path} border radius="md" surface="surface" padding={3}>
+              <Stack gap={2}>
+                <Box display="flex" align="center" gap={3}>
+                  <Icon size={16} className="text-accent" />
+                  <Text variant="mono" size="xs">{asset.path}</Text>
+                  <Text variant="mono" size="micro" color="dim" marginLeft="auto" opacity={0.6}>{asset.label}</Text>
+                </Box>
+                {asset.description && (
+                  <Box paddingLeft={7}>
+                    <Text variant="body" size="micro" color="dim">
+                      {asset.description}
+                    </Text>
+                  </Box>
+                )}
+              </Stack>
             </Box>
           );
         })}

--- a/src/features/research/components/BlastRadiusTool.tsx
+++ b/src/features/research/components/BlastRadiusTool.tsx
@@ -1,13 +1,11 @@
 import { Box, Stack, Text, Grid } from '@/layouts/Primitives';
 import { GitBranch, Layers, Activity } from 'lucide-react';
 import { ArchitecturalAssetsList } from './ArchitecturalAssetsList';
-
-const BLAST_RADIUS_ASSETS = [
-  { path: 'dev-tools/scope_check.py', label: 'Impact Analyzer' },
-  { path: 'dev-tools/workflow_summary.py', label: 'SDLC Profiler' }
-];
+import { DEVAI_ASSETS } from '@/config/devai-assets';
 
 export function BlastRadiusTool() {
+  const assets = DEVAI_ASSETS.filter(a => a.toolId === 'scope-blast-radius');
+
   return (
     <Box border radius="lg" padding={8} surface="default">
       <Stack gap={8}>
@@ -51,7 +49,7 @@ export function BlastRadiusTool() {
           </Box>
         </Stack>
 
-        <ArchitecturalAssetsList assets={BLAST_RADIUS_ASSETS} />
+        <ArchitecturalAssetsList assets={assets} />
       </Stack>
     </Box>
   );

--- a/src/features/research/components/BlastRadiusTool.tsx
+++ b/src/features/research/components/BlastRadiusTool.tsx
@@ -2,9 +2,10 @@ import { Box, Stack, Text, Grid } from '@/layouts/Primitives';
 import { GitBranch, Layers, Activity } from 'lucide-react';
 import { ArchitecturalAssetsList } from './ArchitecturalAssetsList';
 import { DEVAI_ASSETS } from '@/config/devai-assets';
+import { TOOL_ID_SCOPE_BLAST_RADIUS } from '@/config/devai-tool-ids';
 
 export function BlastRadiusTool() {
-  const assets = DEVAI_ASSETS.filter(a => a.toolId === 'scope-blast-radius');
+  const assets = DEVAI_ASSETS.filter(a => a.toolId === TOOL_ID_SCOPE_BLAST_RADIUS);
 
   return (
     <Box border radius="lg" padding={8} surface="default">

--- a/src/features/research/components/GitOpsReviewerTool.tsx
+++ b/src/features/research/components/GitOpsReviewerTool.tsx
@@ -2,9 +2,10 @@ import { Box, Stack, Text, Grid } from '@/layouts/Primitives';
 import { Cpu, ShieldAlert } from 'lucide-react';
 import { ArchitecturalAssetsList } from './ArchitecturalAssetsList';
 import { DEVAI_ASSETS } from '@/config/devai-assets';
+import { TOOL_ID_GITOPS_PR_REVIEWER } from '@/config/devai-tool-ids';
 
 export function GitOpsReviewerTool() {
-  const assets = DEVAI_ASSETS.filter(a => a.toolId === 'gitops-pr-reviewer');
+  const assets = DEVAI_ASSETS.filter(a => a.toolId === TOOL_ID_GITOPS_PR_REVIEWER);
 
   return (
     <Box border radius="lg" padding={8} surface="default">

--- a/src/features/research/components/GitOpsReviewerTool.tsx
+++ b/src/features/research/components/GitOpsReviewerTool.tsx
@@ -1,14 +1,11 @@
 import { Box, Stack, Text, Grid } from '@/layouts/Primitives';
 import { Cpu, ShieldAlert } from 'lucide-react';
 import { ArchitecturalAssetsList } from './ArchitecturalAssetsList';
-
-const GITOPS_ASSETS = [
-  { path: 'dev-tools/mergellama.py', label: 'PR Auditor' },
-  { path: 'dev-tools/ollama_reviewer.py', label: 'Local LLM Reviewer' },
-  { path: 'dev-tools/td_cli.py', label: 'CLI Manager' }
-];
+import { DEVAI_ASSETS } from '@/config/devai-assets';
 
 export function GitOpsReviewerTool() {
+  const assets = DEVAI_ASSETS.filter(a => a.toolId === 'gitops-pr-reviewer');
+
   return (
     <Box border radius="lg" padding={8} surface="default">
       <Stack gap={8}>
@@ -40,7 +37,7 @@ export function GitOpsReviewerTool() {
           </Stack>
         </Grid>
 
-        <ArchitecturalAssetsList assets={GITOPS_ASSETS} />
+        <ArchitecturalAssetsList assets={assets} />
       </Stack>
     </Box>
   );


### PR DESCRIPTION
This change centralizes architectural asset configurations (paths, labels, and descriptions) into src/config/devai-assets.ts. 

Key changes:
- Created a new configuration file `src/config/devai-assets.ts` to hold asset metadata, indexed by `toolId`.
- Updated `ArchitecturalAssetsList.tsx` to include an optional `description` field and render it using repository-standard layout primitives (`Box`, `Stack`) to avoid UI anti-pattern violations.
- Refactored `BlastRadiusTool.tsx` and `GitOpsReviewerTool.tsx` to remove hardcoded asset arrays and instead filter the centralized `DEVAI_ASSETS` list.
- Verified that descriptions are correctly displayed in the UI via Playwright screenshots.
- Passed all type checks, unit tests, and the strict UI anti-pattern audit.

Fixes #1561

---
*PR created automatically by Jules for task [2553588288800026437](https://jules.google.com/task/2553588288800026437) started by @arii*