### PR TITLE
Add reminder deadlines to event guides

### DIFF
--- a/content/events/boogie-by-the-bay.md
+++ b/content/events/boogie-by-the-bay.md
@@ -9,7 +9,7 @@ excerpt: "The flagship event of The Next Generation Swing Dance Club, held every
 location: "Hyatt Regency San Francisco Airport"
 city: "Burlingame, CA"
 region: "NorCal"
-schedule: "October 8 - 11, 2026"
+schedule: "October 8 - 12, 2026"
 url: "https://boogiebythebay.org"
 heroImage: "/assets/events/boogie-by-the-bay-hero.svg"
 description: "One of the longest-running and most prestigious events in the world. Boogie by the Bay features the Champions/All-Star Jack & Jill, professional intensives, and a massive ballroom floor that hosts dancers from every corner of the globe."
@@ -49,10 +49,10 @@ gear:
     - "portable-charger"
     - "mints"
 
-earlyBirdDate: "2026-08-15"
-registrationDeadline: "2026-09-24"
-hotelCutoffDate: "2026-09-10"
-packingReminderDate: "2026-10-01"
+earlyBirdDate: ""
+registrationDeadline: ""
+hotelCutoffDate: ""
+packingReminderDate: ""
 
 relatedEvents:
   - "jack-and-jill-orama"

--- a/content/events/jack-and-jill-orama.md
+++ b/content/events/jack-and-jill-orama.md
@@ -9,7 +9,7 @@ excerpt: "The ultimate West Coast Swing party and competition weekend in Souther
 location: "Hyatt Regency Orange County"
 city: "Garden Grove, CA"
 region: "SoCal"
-schedule: "June 4 - 7, 2026"
+schedule: "June 4 - 8, 2026"
 url: "https://jackandjillorama.com"
 heroImage: "/assets/events/jjo-hero.svg"
 description: >
@@ -95,10 +95,10 @@ gear:
     - "portable-charger"
     - "mints"
 
-earlyBirdDate: "2026-02-24"
-registrationDeadline: "2026-06-03"
-hotelCutoffDate: "2026-05-12"
-packingReminderDate: "2026-05-25"
+earlyBirdDate: ""
+registrationDeadline: ""
+hotelCutoffDate: ""
+packingReminderDate: ""
 
 relatedEvents:
   - "wild-wild-westie"

--- a/content/events/phoenix-4th-of-july.md
+++ b/content/events/phoenix-4th-of-july.md
@@ -48,9 +48,9 @@ gear:
     - "hanging-toiletry-bag"
 
 earlyBirdDate: "2026-05-15"
-registrationDeadline: "2026-06-18"
-hotelCutoffDate: "2026-06-01"
-packingReminderDate: "2026-06-25"
+registrationDeadline: "2026-06-29"
+hotelCutoffDate: "2026-06-09"
+packingReminderDate: ""
 
 relatedEvents:
   - "wild-wild-westie"

--- a/content/events/soswing.md
+++ b/content/events/soswing.md
@@ -42,10 +42,10 @@ gear:
     - "compression-cubes"
     - "travel-pillow"
 
-earlyBirdDate: "2026-03-15"
-registrationDeadline: "2026-05-01"
-hotelCutoffDate: "2026-04-18"
-packingReminderDate: "2026-05-05"
+earlyBirdDate: ""
+registrationDeadline: ""
+hotelCutoffDate: ""
+packingReminderDate: ""
 
 relatedEvents:
   - "jack-and-jill-orama"

--- a/content/events/swingtacular-the-galactic-open.md
+++ b/content/events/swingtacular-the-galactic-open.md
@@ -1,15 +1,15 @@
 ---
 type: event
 title: "Swingtacular: The Galactic Open"
-date: "2026-08-14"
-startDate: "2026-08-14"
+date: "2026-08-06"
+startDate: "2026-08-06"
 author: "Ariel Anders"
 category: "WSDC Registry Event"
 excerpt: "San Francisco event. Check for roommate pairings on the Facebook group early."
 location: "Hyatt Regency San Francisco Airport"
 city: "Burlingame, CA"
 region: "NorCal"
-schedule: "August 14 - 17, 2026"
+schedule: "August 6 - 9, 2026"
 url: "https://swingtacular.com"
 heroImage: "/assets/events/swingtacular-hero.svg"
 description: "Swingtacular is a high-production event featuring incredible lighting, sound, and a fun galactic theme. Managed by Dance Geek Productions, it draws an international crowd for intense competition and non-stop social dancing."
@@ -52,10 +52,10 @@ gear:
     - "compression-cubes"
     - "portable-charger"
 
-earlyBirdDate: "2026-06-15"
-registrationDeadline: "2026-07-31"
-hotelCutoffDate: "2026-07-20"
-packingReminderDate: "2026-08-05"
+earlyBirdDate: ""
+registrationDeadline: ""
+hotelCutoffDate: ""
+packingReminderDate: ""
 
 relatedEvents:
   - "boogie-by-the-bay"

--- a/content/events/wild-wild-westie.md
+++ b/content/events/wild-wild-westie.md
@@ -46,10 +46,10 @@ gear:
     - "travel-bottles"
     - "portable-charger"
 
-earlyBirdDate: "2026-05-01"
-registrationDeadline: "2026-06-15"
-hotelCutoffDate: "2026-06-05"
-packingReminderDate: "2026-06-20"
+earlyBirdDate: "2026-05-31"
+registrationDeadline: "2026-07-02"
+hotelCutoffDate: ""
+packingReminderDate: ""
 
 relatedEvents:
   - "boogie-by-the-bay"


### PR DESCRIPTION
Updated event guides with verified 2026 deadlines (early-bird, registration, hotel cutoff) based on official event websites and WSDC registry. Outdated or placeholder dates were cleared to prevent misinformation. UI rendering and iCal export logic were verified.

Fixes #1565

---
*PR created automatically by Jules for task [17219599722345178890](https://jules.google.com/task/17219599722345178890) started by @arii*