### PR TITLE
Stabilize mobile overflow regression and add Playwright overflow test

### DIFF
--- a/src/features/home/DevLabCallout.tsx
+++ b/src/features/home/DevLabCallout.tsx
@@ -5,7 +5,7 @@ import { Box, Stack, Text } from '@/layouts/Primitives';
 
 export function DevLabCallout() {
   return (
-    <Box border radius="lg" padding={5} className="flex flex-col gap-4">
+    <Box border radius="lg" padding={5} className="w-full max-w-full min-w-0">
       {/* Header row */}
       <Stack direction="row" align="center" gap={3}>
         <Box className="shrink-0 rounded-md bg-accent/10 p-2">

--- a/src/features/home/FeaturedEventGuide.tsx
+++ b/src/features/home/FeaturedEventGuide.tsx
@@ -35,7 +35,7 @@ export function FeaturedEventGuide() {
   if (!event) return null;
 
   return (
-    <Box as="section">
+    <Box as="section" className="w-full max-w-full min-w-0">
       <Text as="h2" variant="headline" size="2xl" weight="font-black" marginBottom={4}>
         Featured Event Guide
       </Text>
@@ -45,12 +45,12 @@ export function FeaturedEventGuide() {
         border
         radius="xl"
         overflow="hidden"
-        className="grid bg-surface touch-pan-y md:grid-cols-[260px_1fr] md:h-[200px]"
+        className="grid w-full max-w-full min-w-0 bg-surface touch-pan-y md:grid-cols-[260px_1fr] md:h-[200px]"
         onTouchStart={handleTouchStart}
         onTouchEnd={handleTouchEnd}
       >
         {/* Image column — full height, strong crop */}
-        <Box position="relative" className="h-44 md:h-full">
+        <Box position="relative" className="h-44 min-w-0 md:h-full">
           <img
             src={event.heroImage}
             alt={event.title}
@@ -61,11 +61,11 @@ export function FeaturedEventGuide() {
         </Box>
 
         {/* Content */}
-        <Stack gap={3} padding={6} className="justify-between">
+        <Stack gap={3} padding={6} className="min-w-0 justify-between">
           <Stack gap={1.5}>
             <Box display="flex" align="center" gap={2}>
               <MapPin className="h-3.5 w-3.5 shrink-0 text-accent" />
-              <Text variant="mono" size="xs" color="accent" weight="font-bold" uppercase className="truncate">
+              <Text variant="mono" size="xs" color="accent" weight="font-bold" uppercase className="block max-w-full truncate">
                 {event.location}
               </Text>
             </Box>

--- a/src/features/home/GearShelf.tsx
+++ b/src/features/home/GearShelf.tsx
@@ -12,7 +12,7 @@ const PICKS = [
 
 export function GearShelf() {
   return (
-    <Box as="section">
+    <Box as="section" className="w-full max-w-full min-w-0">
       {/* Header — no card wrapper, just section heading */}
       <Box display="flex" align="center" justify="between" marginBottom={3}>
         <Text as="h2" variant="headline" size="2xl" weight="font-black">
@@ -67,18 +67,18 @@ export function GearShelf() {
       </Box>
 
       {/* Mobile: horizontal scroll of compact tiles */}
-      <Box className="overflow-x-auto pb-3 lg:hidden">
-        <Box display="flex" gap={3} className="w-max pr-4">
+      <Box className="w-full max-w-full overflow-x-auto overscroll-x-contain pb-3 lg:hidden">
+        <Box display="flex" gap={3} className="flex-nowrap pr-4">
           {PICKS.map(({ label, image, href }) => (
             <Box
               key={`mobile-${label}`}
               as={NavLink}
               to={href}
-              className="group w-28"
+              className="group w-28 min-w-0"
             >
               <Box radius="lg" overflow="hidden" border className="aspect-square bg-surface-alt transition-all group-hover:border-accent/40">
                 {image ? (
-                  <img src={`${ASSET_PREFIX}${image}`} alt="" className="h-full w-full object-cover" />
+                  <img src={`${ASSET_PREFIX}${image}`} alt="" className="block h-full w-full max-w-full object-cover" />
                 ) : (
                   <CategoryPlaceholder category="gear" size="sm" />
                 )}

--- a/src/features/home/LatestPosts.tsx
+++ b/src/features/home/LatestPosts.tsx
@@ -9,7 +9,7 @@ export function LatestPosts() {
   const posts = getPosts().slice(0, 3);
 
   return (
-    <Box as="section">
+    <Box as="section" className="w-full max-w-full min-w-0">
       <Box display="flex" align="center" justify="between" gap={2} marginBottom={4}>
         <Text as="h2" variant="headline" size="2xl" weight="font-black">
           Latest from BoomTick
@@ -37,7 +37,7 @@ export function LatestPosts() {
             display="flex"
             align="start"
             gap={4}
-            className="group border-b border-line py-3.5 transition-colors hover:bg-surface/50"
+            className="group w-full max-w-full min-w-0 border-b border-line py-3.5 transition-colors hover:bg-surface/50"
           >
             {/* Thumbnail — rectangular, 72×56 desktop feel */}
             <Box
@@ -46,7 +46,7 @@ export function LatestPosts() {
               className="mt-0.5 h-14 w-[72px] shrink-0 bg-surface-alt"
             >
               {post.image ? (
-                <img src={post.image} alt={post.title} className="h-full w-full object-cover" />
+                <img src={post.image} alt={post.title} className="block h-full w-full max-w-full object-cover" />
               ) : (
                 <CategoryPlaceholder category={post.category} size="sm" />
               )}

--- a/src/features/home/TopicGrid.tsx
+++ b/src/features/home/TopicGrid.tsx
@@ -29,7 +29,7 @@ const TOPICS = [
 
 export function TopicGrid() {
   return (
-    <Box as="section">
+    <Box as="section" className="w-full max-w-full min-w-0">
       <Text as="h2" variant="headline" size="xl" weight="font-black" marginBottom={3}>
         Explore by topic
       </Text>
@@ -43,7 +43,7 @@ export function TopicGrid() {
             padding={6}
             border
             radius="lg"
-            className="group min-h-[145px] md:h-[150px] transition-all duration-200 hover:border-accent/40 hover:bg-surface/60"
+            className="group w-full max-w-full min-w-0 min-h-[145px] md:h-[150px] transition-all duration-200 hover:border-accent/40 hover:bg-surface/60"
           >
             {/* Icon — exactly 32px container */}
             <Box className="w-8 h-8 flex items-center justify-center rounded-md bg-accent/10">

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -45,7 +45,7 @@ export function MainLayout({ children }: { children: ReactNode }) {
         aria-atomic="true"
         className="sr-only"
       />
-      <Stack minHeight="screen" width="full" className="max-w-full min-w-0 overflow-x-clip">
+      <Stack minHeight="screen" width="full" className="w-full max-w-full min-w-0 overflow-x-clip">
         <Navigation />
         <ScrollToTopButton scrollRef={scrollRef} />
         <Stack
@@ -60,7 +60,7 @@ export function MainLayout({ children }: { children: ReactNode }) {
           width="full"
           surface="bg"
           direction="col"
-          className="min-w-0 max-w-full overflow-x-clip"
+          className="w-full max-w-full min-w-0 overflow-x-clip"
         >
           <Stack
             paddingX={{ base: 4, md: 6, lg: 10 }}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -12,7 +12,7 @@ import { HeroSection } from '@/components/ui/HeroSection';
 
 export default function Home() {
   return (
-    <Box as="section" aria-label="Home content" className="pb-safe-bottom mx-auto w-full max-w-[1240px] min-w-0 max-w-full overflow-x-clip">
+    <Box as="section" aria-label="Home content" className="mx-auto w-full max-w-[1240px] min-w-0 overflow-x-clip px-4 sm:px-6 lg:px-8 pb-safe-bottom">
       <SEO
         title="Home"
         description="BoomTick: Training tips, travel guides, and gear reviews for West Coast Swing dancers."
@@ -23,19 +23,19 @@ export default function Home() {
       <Box
         as="section"
         display="grid"
-        className="items-center gap-10 lg:grid-cols-[minmax(0,1fr)_420px]"
+        className="w-full max-w-full min-w-0 items-center gap-10 lg:grid-cols-[minmax(0,1fr)_420px]"
       >
         <HeroSection />
         <FeaturedGuidePanel />
       </Box>
 
       {/* Remaining sections — tighter vertical rhythm on mobile */}
-      <Stack gap={{ base: 10, lg: 14 }} className="mt-12 lg:mt-16">
+      <Stack gap={{ base: 10, lg: 14 }} className="mt-12 w-full max-w-full min-w-0 lg:mt-16">
         <TopicGrid />
 
         <Box
           display="grid"
-          className="gap-8 lg:grid-cols-[minmax(0,1.6fr)_minmax(300px,0.8fr)]"
+          className="w-full max-w-full min-w-0 gap-8 lg:grid-cols-[minmax(0,1.6fr)_minmax(300px,0.8fr)]"
         >
           <FeaturedEventGuide />
           <GearShelf />
@@ -43,7 +43,7 @@ export default function Home() {
 
         <Box
           display="grid"
-          className="gap-8 lg:grid-cols-[minmax(0,1.6fr)_minmax(300px,0.8fr)]"
+          className="w-full max-w-full min-w-0 gap-8 lg:grid-cols-[minmax(0,1.6fr)_minmax(300px,0.8fr)]"
         >
           <LatestPosts />
           <DevLabCallout />

--- a/tests/home-layout.spec.ts
+++ b/tests/home-layout.spec.ts
@@ -82,3 +82,46 @@ test.describe('Home Page Layout and Navigation', () => {
   });
 
 });
+
+
+test('mobile pages do not create horizontal overflow', async ({ page }) => {
+  const routes = ['/', '/gear', '/blog', '/events', '/about'];
+  const viewports = [{ width: 375, height: 812 }, { width: 390, height: 844 }];
+
+  for (const viewport of viewports) {
+    for (const route of routes) {
+      await page.setViewportSize(viewport);
+      await page.goto(`${BASE_PATH || ''}${route}`);
+
+      const result = await page.evaluate(() => {
+        const viewportWidth = window.innerWidth;
+        const offenders = [...document.querySelectorAll('body *')]
+          .map((el) => {
+            const rect = el.getBoundingClientRect();
+            return {
+              tag: el.tagName,
+              className: String((el as HTMLElement).className || ''),
+              text: (el.textContent || '').trim().slice(0, 80),
+              left: rect.left,
+              right: rect.right,
+              width: rect.width,
+            };
+          })
+          .filter((x) => x.right > viewportWidth + 1 || x.left < -1)
+          .slice(0, 20);
+
+        return {
+          viewport: viewportWidth,
+          documentWidth: document.documentElement.scrollWidth,
+          bodyWidth: document.body.scrollWidth,
+          offenders,
+        };
+      });
+
+      expect(result.documentWidth, `${route} @ ${viewport.width} => ${JSON.stringify(result.offenders, null, 2)}`)
+        .toBeLessThanOrEqual(result.viewport);
+      expect(result.bodyWidth, `${route} @ ${viewport.width} => ${JSON.stringify(result.offenders, null, 2)}`)
+        .toBeLessThanOrEqual(result.viewport);
+    }
+  }
+});


### PR DESCRIPTION
### Motivation
- Recent changes introduced a horizontal overflow regression on mobile (clipped headings, cards extending past viewport, and off-screen nav), so the branch should focus on stabilization rather than updating visual snapshots. 
- Add automated guardrail coverage so mobile overflow is impossible to miss in CI and developers get actionable offender output.

### Description
- Add a Playwright route-level overflow regression test that checks `'/','/gear','/blog','/events','/about'` at 375px and 390px and prints a structured offenders list on failure (`tests/home-layout.spec.ts`).
- Harden global containment by applying `w-full max-w-full min-w-0 overflow-x-clip` wrappers at the app shell and main scroll container (`src/layouts/MainLayout.tsx`).
- Apply shrink/sizing safeguards and clipping on home shells and overflow-prone modules (`src/pages/Home.tsx`, `src/features/home/FeaturedEventGuide.tsx`, `src/features/home/GearShelf.tsx`, `src/features/home/LatestPosts.tsx`, `src/features/home/DevLabCallout.tsx`, `src/features/home/TopicGrid.tsx`) including `min-w-0`, `max-w-full`, `overflow-x-auto overscroll-x-contain` for horizontal shelves, and `block max-w-full` on images.
- Do not update Playwright visual snapshots in this PR; the branch is aimed at layout stabilization and guardrail coverage only.

### Testing
- `python3 dev-tools/td_cli.py gh conflicts` failed in this environment due to a malformed/missing `origin` remote and printed a clear remediation message. 
- `pnpm run audit` completed successfully with no anti-patterns detected. 
- `pnpm run -s test -- tests/home-layout.spec.ts --runInBand` passed (test run showed tests completed successfully). 
- `python3 dev-tools/td_cli.py gh pre-submit` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1733fadbe08325a3c5ee6a105054a1)