### PR TITLE
Refactor GitHub Token check and implement session sync

### DIFF
--- a/dev-tools/tdw_services/cli.py
+++ b/dev-tools/tdw_services/cli.py
@@ -350,8 +350,8 @@ def dispatch(ctx, branch, task):
 def sync(ctx):
     """Sync active agent sessions."""
     orch = ctx.obj['ORCHESTRATOR']
-    res = orch.jules.list_sources() # Placeholder for actual session sync
-    out(ctx, "Agent sync complete.", data={"sources": res})
+    res = orch.jules.list_sessions()
+    out(ctx, "Agent sync complete.", data={"sessions": res})
 
 @agent_group.command()
 @click.option('--pr-number', type=int)

--- a/dev-tools/tdw_services/services/github.py
+++ b/dev-tools/tdw_services/services/github.py
@@ -8,7 +8,7 @@ from typing import Optional, List, Dict, Any
 class GitHubClient:
     def __init__(self, token: Optional[str] = None, repo: Optional[str] = None):
         from utils import get_github_token
-        self.token = token or os.environ.get("CODEX_GH_TOKEN") or os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN") or get_github_token()
+        self.token = token or get_github_token()
         if not self.token:
             raise ValueError("Missing GITHUB_TOKEN environment variable.")
         self.repo = repo or os.environ.get("GITHUB_REPOSITORY") or os.environ.get("GH_REPO")

--- a/dev-tools/tdw_services/services/jules.py
+++ b/dev-tools/tdw_services/services/jules.py
@@ -25,6 +25,16 @@ class JulesClient:
             print(f"⚠️  Jules API list_sources failed: {e}")
             return []
 
+    def list_sessions(self) -> List[Dict[str, Any]]:
+        url = f"{self.base_url}/sessions"
+        try:
+            response = requests.get(url, headers=self.headers, timeout=10)
+            response.raise_for_status()
+            return response.json().get("sessions", [])
+        except Exception as e:
+            print(f"⚠️  Jules API list_sessions failed: {e}")
+            return []
+
     def discover_source_id(self, repo_full_name: str) -> Optional[str]:
         sources = self.list_sources()
         for s in sources:


### PR DESCRIPTION
Refactor GitHub Token check and implement session sync

- Modified `GitHubClient.__init__` in `dev-tools/tdw_services/services/github.py` to remove redundant environment variable checks for `CODEX_GH_TOKEN`, `GH_TOKEN`, and `GITHUB_TOKEN`. Token extraction now correctly relies exclusively on the provided `token` argument or the `get_github_token()` utility, which acts as the single source of truth.
- Implemented actual session sync in `dev-tools/tdw_services/services/jules.py` by adding a `list_sessions()` method that queries the `/sessions` API endpoint.
- Updated the `sync` command in `dev-tools/tdw_services/cli.py` to utilize `orch.jules.list_sessions()`, replacing the placeholder logic and outputting under the `sessions` key.

---
*PR created automatically by Jules for task [6170380798344805014](https://jules.google.com/task/6170380798344805014) started by @arii*