### PR TITLE
Fix list-row image visibility and clean affiliate mappings

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lint:ox": "oxlint --deny-warnings",
     "lint:eslint": "eslint . --max-warnings 0",
     "lint:types": "tsc --noEmit",
-    "knip": "knip",
+    "knip": "knip --exclude exports",
     "type-check": "tsc --noEmit",
     "audit": "node scripts/detect-antipatterns.mjs",
     "audit:inventory": "node scripts/check-suppression-inventory.mjs",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lint:ox": "oxlint --deny-warnings",
     "lint:eslint": "eslint . --max-warnings 0",
     "lint:types": "tsc --noEmit",
-    "knip": "knip --exclude exports",
+    "knip": "knip",
     "type-check": "tsc --noEmit",
     "audit": "node scripts/detect-antipatterns.mjs",
     "audit:inventory": "node scripts/check-suppression-inventory.mjs",

--- a/src/components/ui/GearCard.tsx
+++ b/src/components/ui/GearCard.tsx
@@ -176,7 +176,7 @@ export function GearCard(props: GearCardProps) {
               className="bg-accent/60 text-accent-sky backdrop-blur-md shadow-sm"
             >
               <Text variant="mono" size="micro" weight="font-bold" className="uppercase tracking-wide text-xs">
-                Earns Commission
+                Amazon affiliate link
               </Text>
             </Box>
           )}
@@ -225,7 +225,7 @@ export function GearCard(props: GearCardProps) {
       <Box display="flex" align="center" justify="end" marginTop="auto" paddingTop={3} border="t" className="border-line/30">
         <Box display="flex" align="center" gap={1.5} className="group-hover:translate-x-1 transition-transform">
           <Text variant="body" size="sm" weight="font-semibold" color="accent" className="font-semibold">
-            {isExternal ? "View product" : "Read review"}
+            {isExternal ? "Paid Amazon link" : "Read review"}
           </Text>
           {isExternal ? (
             <ExternalLink className="w-4 h-4 text-accent" aria-hidden="true" />

--- a/src/components/ui/ListRow.tsx
+++ b/src/components/ui/ListRow.tsx
@@ -15,16 +15,21 @@ interface ListRowProps {
   date?: string;
   basePath: string;
   content?: string;
+  image?: string;
   [key: string]: unknown;
 }
 
 export function ListRow(props: ListRowProps) {
-  const { slug, title, category, excerpt, date, basePath, content } = props;
+  const { slug, title, category, excerpt, date, basePath, content, image } = props;
   const rest = pickRest(props, [
     ...CONTENT_METADATA_KEYS,
     'basePath'
   ] as (keyof ListRowProps)[]);
   const rt = readingTime(content, excerpt);
+
+  const normalizedImage = (image && image.startsWith('/') && !image.startsWith(import.meta.env.BASE_URL))
+    ? `${import.meta.env.BASE_URL.replace(/\/$/, '')}${image}`
+    : image;
 
   return (
     <Box as={NavLink} to={`${basePath}/${slug}`}
@@ -34,7 +39,11 @@ export function ListRow(props: ListRowProps) {
     >
       <Box width={1} shrink={0} self="stretch" opacity={0} className="bg-accent group-hover:opacity-100 transition-opacity" />
       <Box width={12} height={12} margin={4} shrink={0} radius="md" overflow="hidden" display="flex" align="center" justify="center" border className="bg-surface-alt/30 border-line/30">
-        <CategoryPlaceholder category={category} size="md" />
+        {normalizedImage ? (
+          <img src={normalizedImage} alt={title} className="h-full w-full object-cover" loading="lazy" />
+        ) : (
+          <CategoryPlaceholder category={category} size="md" />
+        )}
       </Box>
       <Stack gap={1} flex paddingY={3} className="min-w-0">
         <Box display="flex" align="center" gap={3}>

--- a/src/data/affiliates.json
+++ b/src/data/affiliates.json
@@ -104,10 +104,9 @@
     "epsom-salt": {
         "id": "epsom-salt",
         "name": "Epsom Salt / Bath Bombs",
-        "url": "https://amazon.com",
+        "url": "https://www.amazon.com/s?k=epsom+salt+bath+soak&tag=onasafari04-20",
         "category": "recovery",
         "description": "Soothe tired muscles and refresh your skin after a long weekend.",
-        "image": "/images/gear/amazon/mebak-piercing-aftercare-swabs-saline-solution-for-piercings-earring-n.jpg",
         "draft": true
     },
     "foam-roller": {
@@ -179,19 +178,17 @@
     "travel-pillow": {
         "id": "travel-pillow",
         "name": "Memory Foam Travel Pillow",
-        "url": "https://www.amazon.com/dp/B09QRZNV8R?tag=onasafari04-20&linkCode=ll2&language=en_US",
+        "url": "https://www.amazon.com/s?k=memory+foam+travel+pillow&tag=onasafari04-20",
         "category": "travel",
         "description": "Essential for catching some sleep on flights or between sessions.",
-        "image": "/images/gear/amazon/ablanczoom-hoodies-for-women-casual-full-zip-up-hoodie-comfortable-wom.jpg",
         "draft": true
     },
     "dry-shampoo": {
         "id": "dry-shampoo",
         "name": "Batiste Dry Shampoo",
-        "url": "https://amazon.com",
+        "url": "https://www.amazon.com/s?k=batiste+dry+shampoo&tag=onasafari04-20",
         "category": "travel",
         "description": "Refresh your hair quickly between workshops and social dancing.",
-        "image": "/images/gear/amazon/convenience-kits-international-women-s-15-pc-kit-featuring-palmer-s-ha.jpg",
         "draft": true
     },
     "electric-fan": {
@@ -206,10 +203,9 @@
     "liquid-iv": {
         "id": "liquid-iv",
         "name": "Liquid I.V. Hydration Multiplier",
-        "url": "https://amazon.com",
+        "url": "https://www.amazon.com/s?k=liquid+iv+hydration+multiplier&tag=onasafari04-20",
         "category": "recovery",
         "description": "Stay hydrated and maintain electrolyte balance during intense weekends.",
-        "image": "/images/gear/amazon/wllhyf-2-pieces-bling-pill-container-waterproof-pill-bottle-case-porta.jpg",
         "draft": true
     },
     "shoe-brush": {

--- a/src/data/affiliates.json
+++ b/src/data/affiliates.json
@@ -104,10 +104,11 @@
     "epsom-salt": {
         "id": "epsom-salt",
         "name": "Epsom Salt / Bath Bombs",
-        "url": "https://www.amazon.com/s?k=epsom+salt+bath+soak&tag=onasafari04-20",
+        "url": "https://www.amazon.com/Amazon-Basics-Magnesium-Sulfate-1-Pack/dp/B0BXTS6L35?tag=onasafari04-20&linkCode=ll2&language=en_US",
         "category": "recovery",
-        "description": "Soothe tired muscles and refresh your skin after a long weekend.",
-        "draft": true
+        "description": "I like to pack a ziplock bag of this or just order prime groceries at the event and include this",
+        "draft": true,
+        "image": "https://m.media-amazon.com/images/I/71LqUR0-ceL._AC_SL1500_.jpg"
     },
     "foam-roller": {
         "id": "foam-roller",
@@ -178,18 +179,20 @@
     "travel-pillow": {
         "id": "travel-pillow",
         "name": "Memory Foam Travel Pillow",
-        "url": "https://www.amazon.com/s?k=memory+foam+travel+pillow&tag=onasafari04-20",
+        "url": "https://a.co/d/0enuFqp9?tag=onasafari04-20&linkCode=ll2&language=en_US",
         "category": "travel",
-        "description": "Essential for catching some sleep on flights or between sessions.",
-        "draft": true
+        "description": "this is good for long flights and has straps to secure the pillow and your neck",
+        "draft": true,
+        "image": "https://m.media-amazon.com/images/I/51bHGyZRrgL._AC_SL1080_.jpg"
     },
     "dry-shampoo": {
         "id": "dry-shampoo",
-        "name": "Batiste Dry Shampoo",
-        "url": "https://www.amazon.com/s?k=batiste+dry+shampoo&tag=onasafari04-20",
+        "name": "Oribe Dry Texturizing Spray",
+        "url": "https://a.co/d/06dLoxbA?tag=onasafari04-20",
         "category": "travel",
-        "description": "Refresh your hair quickly between workshops and social dancing.",
-        "draft": true
+        "description": "I love Oribe products and this one smells amazing while refreshing your hair between workshops and socials.",
+        "draft": true,
+        "image": "https://m.media-amazon.com/images/I/71enRpyGa+L._SL1500_.jpg"
     },
     "electric-fan": {
         "id": "electric-fan",
@@ -203,10 +206,11 @@
     "liquid-iv": {
         "id": "liquid-iv",
         "name": "Liquid I.V. Hydration Multiplier",
-        "url": "https://www.amazon.com/s?k=liquid+iv+hydration+multiplier&tag=onasafari04-20",
+        "url": "https://a.co/d/0gUbbjrc?&tag=onasafari04-20",
         "category": "recovery",
         "description": "Stay hydrated and maintain electrolyte balance during intense weekends.",
-        "draft": true
+        "draft": true,
+        "image": "https://m.media-amazon.com/images/I/41kfwQ6qx9L._AC_.jpg"
     },
     "shoe-brush": {
         "id": "shoe-brush",
@@ -411,6 +415,42 @@
         "description": "Fast boot dryer with timer to keep dance shoes fresh and ready for the next event.",
         "gearSlug": "2024-06-01-shoe-dryer",
         "image": "/images/gear/sketches/shoe-dryer-and-deodorizer-enhanced-deodorising-boot-dryer-with-timer-s.jpeg",
+        "draft": true
+    },
+    "piercing-aftercare-swabs": {
+        "id": "piercing-aftercare-swabs",
+        "name": "Dr. Piercing Aftercare Swabs",
+        "url": "https://a.co/d/0heZRdhE?tag=onasafari04-20&linkCode=ll2&language=en_US",
+        "category": "travel",
+        "description": "perfect for travel individually wrapped swabs",
+        "image": "/images/gear/amazon/mebak-piercing-aftercare-swabs-saline-solution-for-piercings-earring-n.jpg",
+        "draft": true
+    },
+    "womens-long-zip-hoodie": {
+        "id": "womens-long-zip-hoodie",
+        "name": "Womens Long Zip Up Hoodies",
+        "url": "https://a.co/d/0cgqoZH5?tag=onasafari04-20&linkCode=ll2&language=en_US",
+        "category": "gear",
+        "description": "Fun long hoodie perfect for a chilly ballroom length is nice for keeping part of your legs warm and looks good",
+        "image": "/images/gear/amazon/ablanczoom-hoodies-for-women-casual-full-zip-up-hoodie-comfortable-wom.jpg",
+        "draft": true
+    },
+    "convenience-travel-kit": {
+        "id": "convenience-travel-kit",
+        "name": "Convenience Travel Kit",
+        "url": "https://a.co/d/0eajAb55?tag=onasafari04-20",
+        "category": "travel",
+        "description": "when flying baggage prices are so high it can be more convenient and cheaper to ship products directly to the hotel",
+        "image": "/images/gear/amazon/convenience-kits-international-women-s-15-pc-kit-featuring-palmer-s-ha.jpg",
+        "draft": true
+    },
+    "bling-keychain-pill-case": {
+        "id": "bling-keychain-pill-case",
+        "name": "Bling Keychain Pill Case",
+        "url": "https://amazon.com",
+        "category": "travel",
+        "description": "Bling keychain pill case that is good for keeping small earplugs in.",
+        "image": "/images/gear/amazon/wllhyf-2-pieces-bling-pill-container-waterproof-pill-bottle-case-porta.jpg",
         "draft": true
     }
 }


### PR DESCRIPTION
### Motivation
- Restore list-view UX so product rows show real images instead of always falling back to `CategoryPlaceholder`, improving discoverability outside card view.
- Remove or correct misleading affiliate mappings that referenced generic `amazon.com` URLs or wrong images for `epsom-salt`, `travel-pillow`, `dry-shampoo`, and `liquid-iv` to avoid incorrect product associations.
- Keep tooling and disclosure behavior consistent by reverting an unrelated `knip` change and making external affiliate copy explicit for transparency.

### Description
- Reverted the `knip` script change in `package.json` back to `"knip"` to avoid mixing unrelated tooling edits.
- Updated `src/components/ui/ListRow.tsx` to accept an `image` prop, normalize root-relative paths against `import.meta.env.BASE_URL`, and render a lazy `img` in the row thumbnail with `CategoryPlaceholder` as a fallback.
- Audited and updated `src/data/affiliates.json` entries for `epsom-salt`, `travel-pillow`, `dry-shampoo`, and `liquid-iv` by replacing generic root URLs with explicit tagged Amazon search links and removing mismatched image assignments.
- Clarified affiliate UX in `src/components/ui/GearCard.tsx` by changing the image badge to read `Amazon affiliate link` and the CTA text for external links to `Paid Amazon link`.
- Documented non-image UX notes in the PR context: `AffiliateDisclosure` usage, filter UI behavior, `imageMode`/card layout semantics, and merch filtering remain as intended and were not functionally changed by this patch.

### Testing
- Ran `pnpm run audit` which completed successfully with no anti-patterns detected.
- Ran unit tests via `pnpm run -s test -- --runInBand` where all test files passed (`12 files`, `66 tests` passed).
- Performed a production build with `pnpm build` which completed successfully and generated the `dist` artifacts.
- Completed repository pre-submit checks with `python3 dev-tools/td_cli.py gh pre-submit`, which finished without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1747af961c83258b97de0b9a19711f)