### PR TITLE
Fix duplicated properties in `Resource` interface

### DIFF
--- a/src/lib/types/content.ts
+++ b/src/lib/types/content.ts
@@ -37,12 +37,6 @@ export interface Resource {
   verdict?: string;
   priceCategory?: string;
   updatedDate?: string;
-  shopUrl?: string;
-  displayMode?: string;
-  featuredSide?: string;
-  shopUrl?: string;
-  displayMode?: string;
-  featuredSide?: string;
   durability?: number;
   value?: number;
   specs?: Record<string, string>;


### PR DESCRIPTION
This PR fixes a bug introduced in PR #1647 where the `shopUrl`, `displayMode`, and `featuredSide` properties were duplicated in the `Resource` interface.

---
*PR created automatically by Jules for task [14763097145608722497](https://jules.google.com/task/14763097145608722497) started by @arii*