### PR TITLE
refactor: simplify `_transform` function for flattening Event interfaces

### DIFF
--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -80,18 +80,10 @@ export function _transform<T extends { date?: string; draft?: boolean }>(
         date: String(data.date || ""),
         author: String(data.author || ""),
         startDate: data.startDate ? String(data.startDate) : undefined,
-        earlyBirdDate: data.earlyBirdDate
-          ? String(data.earlyBirdDate)
-          : undefined,
-        registrationDeadline: data.registrationDeadline
-          ? String(data.registrationDeadline)
-          : undefined,
-        hotelCutoffDate: data.hotelCutoffDate
-          ? String(data.hotelCutoffDate)
-          : undefined,
-        packingReminderDate: data.packingReminderDate
-          ? String(data.packingReminderDate)
-          : undefined,
+        earlyBirdDate: data.earlyBirdDate ? String(data.earlyBirdDate) : undefined,
+        registrationDeadline: data.registrationDeadline ? String(data.registrationDeadline) : undefined,
+        hotelCutoffDate: data.hotelCutoffDate ? String(data.hotelCutoffDate) : undefined,
+        packingReminderDate: data.packingReminderDate ? String(data.packingReminderDate) : undefined,
         tags: asArray(data.tags),
         affiliateIds: asArray(data.affiliateIds),
         content: content || "",
@@ -99,10 +91,11 @@ export function _transform<T extends { date?: string; draft?: boolean }>(
       };
 
       if (data.type === "event") {
-        const getString = (nestedVal: unknown, flatVal: unknown) =>
-          nestedVal ? String(nestedVal) : flatVal ? String(flatVal) : undefined;
+        const getString = (nestedVal: unknown, flatVal: unknown) => {
+          const value = nestedVal ?? flatVal;
+          return value == null || value === "" ? undefined : String(value);
+        };
 
-        // Flatten nested theme if present
         const nestedTheme = data.theme as Record<string, unknown> | undefined;
         result.themeName = getString(nestedTheme?.name, data.themeName);
         result.themeLabel = getString(nestedTheme?.label, data.themeLabel);
@@ -111,22 +104,17 @@ export function _transform<T extends { date?: string; draft?: boolean }>(
         result.themeOutfitIds = asArray(nestedTheme?.outfitIds || data.themeOutfitIds);
         result.themeAccessoryIds = asArray(nestedTheme?.accessoryIds || data.themeAccessoryIds);
 
-        // Flatten nested gear if present
         const nestedGear = data.gear as Record<string, unknown> | undefined;
-        result.gearOutfitIds = asArray(nestedGear?.outfitIds || data.gearOutfitIds);
-        result.gearOutfitDescription = getString(nestedGear?.outfitDescription, data.gearOutfitDescription);
-        result.gearAccessoryIds = asArray(nestedGear?.accessoryIds || data.gearAccessoryIds);
-        result.gearAccessoryDescription = getString(nestedGear?.accessoryDescription, data.gearAccessoryDescription);
-        result.gearShoeIds = asArray(nestedGear?.shoeIds || data.gearShoeIds);
-        result.gearShoeDescription = getString(nestedGear?.shoeDescription, data.gearShoeDescription);
-        result.gearEssentialIds = asArray(nestedGear?.essentialIds || data.gearEssentialIds);
-        result.gearEssentialDescription = getString(nestedGear?.essentialDescription, data.gearEssentialDescription);
-        result.gearTravelIds = asArray(nestedGear?.travelIds || data.gearTravelIds);
-        result.gearTravelDescription = getString(nestedGear?.travelDescription, data.gearTravelDescription);
+        const gearTypes = ['Outfit', 'Accessory', 'Shoe', 'Essential', 'Travel'];
+
+        gearTypes.forEach(type => {
+          const lowerType = type.toLowerCase();
+          result[`gear${type}Ids`] = asArray(nestedGear?.[`${lowerType}Ids`] || data[`gear${type}Ids`]);
+          result[`gear${type}Description`] = getString(nestedGear?.[`${lowerType}Description`], data[`gear${type}Description`]);
+        });
 
         result.relatedEvents = asArray(data.relatedEvents);
 
-        // Cleanup nested objects
         delete result.theme;
         delete result.gear;
       }

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -99,11 +99,14 @@ export function _transform<T extends { date?: string; draft?: boolean }>(
       };
 
       if (data.type === "event") {
+        const getString = (nestedVal: unknown, flatVal: unknown) =>
+          nestedVal ? String(nestedVal) : flatVal ? String(flatVal) : undefined;
+
         // Flatten nested theme if present
         const nestedTheme = data.theme as Record<string, unknown> | undefined;
-        result.themeName = nestedTheme?.name ? String(nestedTheme.name) : (data.themeName ? String(data.themeName) : undefined);
-        result.themeLabel = nestedTheme?.label ? String(nestedTheme.label) : (data.themeLabel ? String(data.themeLabel) : undefined);
-        result.themeDescription = nestedTheme?.description ? String(nestedTheme.description) : (data.themeDescription ? String(data.themeDescription) : undefined);
+        result.themeName = getString(nestedTheme?.name, data.themeName);
+        result.themeLabel = getString(nestedTheme?.label, data.themeLabel);
+        result.themeDescription = getString(nestedTheme?.description, data.themeDescription);
         result.themeColors = asArray(nestedTheme?.colors || data.themeColors);
         result.themeOutfitIds = asArray(nestedTheme?.outfitIds || data.themeOutfitIds);
         result.themeAccessoryIds = asArray(nestedTheme?.accessoryIds || data.themeAccessoryIds);
@@ -111,15 +114,15 @@ export function _transform<T extends { date?: string; draft?: boolean }>(
         // Flatten nested gear if present
         const nestedGear = data.gear as Record<string, unknown> | undefined;
         result.gearOutfitIds = asArray(nestedGear?.outfitIds || data.gearOutfitIds);
-        result.gearOutfitDescription = nestedGear?.outfitDescription ? String(nestedGear.outfitDescription) : (data.gearOutfitDescription ? String(data.gearOutfitDescription) : undefined);
+        result.gearOutfitDescription = getString(nestedGear?.outfitDescription, data.gearOutfitDescription);
         result.gearAccessoryIds = asArray(nestedGear?.accessoryIds || data.gearAccessoryIds);
-        result.gearAccessoryDescription = nestedGear?.accessoryDescription ? String(nestedGear.accessoryDescription) : (data.gearAccessoryDescription ? String(data.gearAccessoryDescription) : undefined);
+        result.gearAccessoryDescription = getString(nestedGear?.accessoryDescription, data.gearAccessoryDescription);
         result.gearShoeIds = asArray(nestedGear?.shoeIds || data.gearShoeIds);
-        result.gearShoeDescription = nestedGear?.shoeDescription ? String(nestedGear.shoeDescription) : (data.gearShoeDescription ? String(data.gearShoeDescription) : undefined);
+        result.gearShoeDescription = getString(nestedGear?.shoeDescription, data.gearShoeDescription);
         result.gearEssentialIds = asArray(nestedGear?.essentialIds || data.gearEssentialIds);
-        result.gearEssentialDescription = nestedGear?.essentialDescription ? String(nestedGear.essentialDescription) : (data.gearEssentialDescription ? String(data.gearEssentialDescription) : undefined);
+        result.gearEssentialDescription = getString(nestedGear?.essentialDescription, data.gearEssentialDescription);
         result.gearTravelIds = asArray(nestedGear?.travelIds || data.gearTravelIds);
-        result.gearTravelDescription = nestedGear?.travelDescription ? String(nestedGear.travelDescription) : (data.gearTravelDescription ? String(data.gearTravelDescription) : undefined);
+        result.gearTravelDescription = getString(nestedGear?.travelDescription, data.gearTravelDescription);
 
         result.relatedEvents = asArray(data.relatedEvents);
 


### PR DESCRIPTION
This PR applies improvements directly suggested by the Principal Engineer's AI audit feedback. 
It replaces repetitive inline fallback logic within `_transform`'s string fields for Event formatting, instead employing a custom `getString` helper to safely cast text from fallback values efficiently.

---
*PR created automatically by Jules for task [6870580924407315665](https://jules.google.com/task/6870580924407315665) started by @arii*