### PR TITLE
Repair PR #1665: Remove AI slop, centralize model variables, and clarify model alias

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,7 +178,7 @@ When multiple agents work simultaneously:
 - CI enforces bundle size and TypeScript `any` count via GitHub Actions variables
 - After intentional approved debt increases, update baselines:
   ```bash
-  gh variable set BUNDLE_BASELINE_KB --body 3100
+  gh variable set BUNDLE_BASELINE_KB --body 3080
   gh variable set ANY_COUNT_BASELINE --body 42
   ```
 

--- a/USAGE_NOTES.md
+++ b/USAGE_NOTES.md
@@ -60,7 +60,7 @@ When a PR intentionally and legitimately increases one of these metrics, an admi
 
 ```bash
 # Update bundle size baseline to 3100KB
-gh variable set BUNDLE_BASELINE_KB --body 3100
+gh variable set BUNDLE_BASELINE_KB --body 3080
 
 # Update 'any' count baseline to 50
 gh variable set ANY_COUNT_BASELINE --body 50

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -22,7 +22,7 @@ We use **GitHub Actions Variables** to manage thresholds for technical debt. Thi
 
 | Variable             | Default | Description                                                                     |
 | -------------------- | ------- | ------------------------------------------------------------------------------- |
-| `BUNDLE_BASELINE_KB` | `3100`  | The baseline size of the production bundle. CI fails if size > baseline + 50KB. |
+| `BUNDLE_BASELINE_KB` | `3080`  | The baseline size of the production bundle. CI fails if size > baseline + 50KB. |
 | `ANY_COUNT_BASELINE` | `0`     | The maximum allowed number of `any` types in the codebase.                      |
 
 ### Suppression Inventory

--- a/dev-tools/dev_tools_sdk/config.py
+++ b/dev-tools/dev_tools_sdk/config.py
@@ -14,6 +14,7 @@ class ProjectConfig:
     gh_token_env: str = "GH_TOKEN"
     use_gemini_fallback: bool = True
     ollama_model: str = "qwen2.5-coder:7b"
+    ollama_synthesis_model: str = "llama3.2"
     ollama_base_url: str = "http://localhost:11434"
     jules_api_url: str | None = None
 
@@ -49,6 +50,7 @@ def load_project_config(path: str | Path = "dev-tools/project_config.json") -> P
         gh_token_env=raw.get("gh_token_env", "GH_TOKEN"),
         use_gemini_fallback=fallback_val if fallback_val is not None else _coerce_bool(raw.get("use_gemini_fallback"), True),
         ollama_model=raw.get("ollama_model", "qwen2.5-coder:7b"),
+        ollama_synthesis_model=raw.get("ollama_synthesis_model", "llama3.2"),
         ollama_base_url=raw.get("ollama_base_url", "http://localhost:11434"),
         jules_api_url=raw.get("jules_api_url"),
     )

--- a/dev-tools/project_config.json
+++ b/dev-tools/project_config.json
@@ -5,5 +5,6 @@
   ],
   "monolithic_pr_threshold": 3,
   "base_branch": "origin/main",
-  "use_gemini_fallback": false
+  "use_gemini_fallback": false,
+  "ollama_synthesis_model": "llama3.2"
 }

--- a/dev-tools/tdw_services/orchestrator.py
+++ b/dev-tools/tdw_services/orchestrator.py
@@ -272,7 +272,7 @@ class Orchestrator:
 
     def check_bundle_size(self, update=False, baseline_file=None, threshold=50, dry_run=True):
         size = get_bundle_size()
-        baseline = self.resolve_baseline(baseline_file, 'BUNDLE_BASELINE_KB', 3100)
+        baseline = self.resolve_baseline(baseline_file, 'BUNDLE_BASELINE_KB', 3080)
         threshold_kb = baseline + threshold
         res = {"size_kb": size, "baseline_kb": baseline, "threshold_kb": threshold_kb, "status": "success" if size <= threshold_kb else "error"}
         if size > threshold_kb: res["message"] = f"Bundle size exceeds threshold ({size}KB > {threshold_kb}KB)."

--- a/dev-tools/tdw_services/services/gemini.py
+++ b/dev-tools/tdw_services/services/gemini.py
@@ -10,13 +10,14 @@ from utils import (
     is_ollama_available,
     clean_llm_output,
     get_ollama_model,
-    get_ollama_review_model
+    get_ollama_review_model,
+    get_ollama_synthesis_model
 )
 
 # Model used for per-file chunk review (code-aware, focused)
 _REVIEW_MODEL = get_ollama_review_model()
 # Lighter/faster model used only for the final synthesis step
-_SYNTHESIS_MODEL = "llama3.2"
+_SYNTHESIS_MODEL = get_ollama_synthesis_model()
 
 # Per-file chunk review schema (small – easy for a 7B model)
 _CHUNK_SCHEMA = {

--- a/dev-tools/utils.py
+++ b/dev-tools/utils.py
@@ -30,8 +30,14 @@ def get_ollama_model() -> str:
     return os.environ.get("OLLAMA_MODEL", "qwen2.5-coder:7b")
 
 def get_ollama_review_model() -> str:
-    """Dynamic getter for the dedicated Code Reviewer model."""
+    """Dynamic getter for the dedicated Code Reviewer model.
+    'code-reviewer' is a custom alias defined in dev-tools/CodeReviewer.mf which is based on qwen2.5-coder:7b.
+    """
     return os.environ.get("OLLAMA_REVIEW_MODEL", "code-reviewer")
+
+def get_ollama_synthesis_model() -> str:
+    """Dynamic getter for the Synthesis model."""
+    return os.environ.get("OLLAMA_SYNTHESIS_MODEL", "llama3.2")
 
 def clean_llm_output(text: str) -> str:
     """Removes markdown code blocks if present."""

--- a/dev-tools/utils.py
+++ b/dev-tools/utils.py
@@ -36,8 +36,26 @@ def get_ollama_review_model() -> str:
     return os.environ.get("OLLAMA_REVIEW_MODEL", "code-reviewer")
 
 def get_ollama_synthesis_model() -> str:
-    """Dynamic getter for the Synthesis model."""
-    return os.environ.get("OLLAMA_SYNTHESIS_MODEL", "llama3.2")
+    """Dynamic getter for the Synthesis model, checking env, then config, then fallback."""
+    env_val = os.environ.get("OLLAMA_SYNTHESIS_MODEL")
+    if env_val:
+        return env_val
+    try:
+        from dev_tools_sdk.config import load_project_config
+        config = load_project_config()
+        return config.ollama_synthesis_model
+    except Exception:
+        # Fallback to direct json reading if sdk not available
+        try:
+            import json
+            config_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "dev-tools", "project_config.json")
+            if not os.path.exists(config_path):
+                config_path = os.path.join(os.path.dirname(__file__), "project_config.json")
+            with open(config_path, "r") as f:
+                raw = json.load(f)
+                return raw.get("ollama_synthesis_model", "llama3.2")
+        except Exception:
+            return "llama3.2"
 
 def clean_llm_output(text: str) -> str:
     """Removes markdown code blocks if present."""

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -14,15 +14,15 @@ async function validateUrlNavigation(page: Page, href: string) {
     const [baseUrl, fragment] = href.split('#');
     if (page.url() !== baseUrl && page.url() !== baseUrl + '/') {
       await page.goto(baseUrl, { waitUntil: 'networkidle', timeout: 60000 });
-      await expect(page.locator('main')).toBeVisible({ timeout: 30000 });
+      await expect(page.locator('#main-content')).toBeVisible();
     }
     if (fragment) {
       const locator = page.locator(`#${fragment}`);
-      await expect(locator).toBeVisible({ timeout: 10000 });
+      await expect(locator).toBeVisible({ timeout: 5000 });
     }
   } else {
     const response = await page.goto(href, { waitUntil: 'networkidle', timeout: 60000 });
-    await expect(page.locator('main')).toBeVisible({ timeout: 30000 });
+    await expect(page.locator('#main-content')).toBeVisible({ timeout: 10000 });
     if (response !== null) {
       expect(response.status(), `Bad status at ${href}`).toBeLessThan(400);
     }
@@ -33,14 +33,14 @@ test.describe('Navigation Smoke Tests', () => {
   test.describe.configure({ timeout: 120000 }); // 2 minute timeout for these tests
   test('homepage loads without console errors', async ({ page, pageErrors }) => {
     await page.goto('./', { waitUntil: 'networkidle', timeout: 60000 });
-    await expect(page.locator('main')).toBeVisible();
+    await expect(page.locator('#main-content')).toBeVisible();
     const filteredErrors = [...pageErrors.consoleErrors, ...pageErrors.pageErrors].filter(e => !isIgnored(e));
     expect(filteredErrors).toHaveLength(0);
   });
 
   test('all nav links are reachable and error-free', async ({ page, pageErrors }) => {
     await page.goto('./', { waitUntil: 'networkidle', timeout: 60000 });
-    await expect(page.locator('main')).toBeVisible();
+    await expect(page.locator('#main-content')).toBeVisible();
 
     const links = await page.$$eval('nav a[href]', (anchors) =>
       anchors
@@ -61,8 +61,8 @@ test.describe('Navigation Smoke Tests', () => {
 
     for (const index of contentIndexes) {
       await page.goto(index, { waitUntil: 'networkidle', timeout: 60000 });
-      await expect(page.locator('main')).toBeVisible();
-      const exists = await page.$('main');
+      await expect(page.locator('#main-content')).toBeVisible();
+      const exists = await page.$('#main-content');
       if (!exists) continue;
 
       const contentLinks = await page.$$eval('a[href]', (anchors) =>


### PR DESCRIPTION
This PR repairs the previous alignment of reviewer models by addressing five key points from the AI technical audit:

1. **Reverted Bundle Size Slop:** Restored `BUNDLE_BASELINE_KB` from `3100` back to `3080` in `AGENTS.md`, `USAGE_NOTES.md`, `WORKFLOW.md`, and `orchestrator.py` because the initial PR inadvertently bumped it.
2. **Centralized Synthesis Model:** Prevented `_SYNTHESIS_MODEL` from being hardcoded to `"llama3.2"` by introducing `get_ollama_synthesis_model()` in `utils.py`.
3. **Reverted Test Timeouts:** Removed or reverted the increased Playwright test timeout durations in `smoke.spec.ts` that might mask performance regressions.
4. **Improved Locator Specificity:** Changed generic `page.locator('main')` assertions to `page.locator('#main-content')` to target the specific id added to the `Box` layout.
5. **Clarified `code-reviewer` Alias:** Added a docstring in `utils.py` outlining that the `"code-reviewer"` string refers to a custom Ollama alias built on top of `qwen2.5-coder:7b`.

---
*PR created automatically by Jules for task [5242207766525938187](https://jules.google.com/task/5242207766525938187) started by @arii*