### PR TITLE
Fix SEO Sitemap and 404s for Hidden Routes

### DIFF
--- a/public/previews/dashboard.js
+++ b/public/previews/dashboard.js
@@ -5,7 +5,15 @@
 
 const REPO_OWNER = 'arii';
 const REPO_NAME = 'tech-dancer';
-const BASE_URL = `https://${REPO_OWNER}.github.io/${REPO_NAME}`;
+
+const IS_CUSTOM_DOMAIN =
+  window.location.hostname === 'boomtick.blog' ||
+  window.location.hostname === 'www.boomtick.blog';
+
+const BASE_URL = IS_CUSTOM_DOMAIN
+  ? window.location.origin
+  : `https://${REPO_OWNER}.github.io/${REPO_NAME}`;
+
 const GITHUB_REPO_URL = `https://github.com/${REPO_OWNER}/${REPO_NAME}`;
 const TRACKING_URL = `${BASE_URL}/REVIEW_TRACKING.md`;
 const EXCLUDED = ['assets', 'previews', 'css', 'js', 'img', 'images', 'public'];

--- a/public/previews/dashboard.js
+++ b/public/previews/dashboard.js
@@ -6,13 +6,12 @@
 const REPO_OWNER = 'arii';
 const REPO_NAME = 'tech-dancer';
 
-const IS_CUSTOM_DOMAIN =
-  window.location.hostname === 'boomtick.blog' ||
-  window.location.hostname === 'www.boomtick.blog';
+const IS_GITHUB_PROJECT_SITE =
+  window.location.hostname === `${REPO_OWNER}.github.io`;
 
-const BASE_URL = IS_CUSTOM_DOMAIN
-  ? window.location.origin
-  : `https://${REPO_OWNER}.github.io/${REPO_NAME}`;
+const BASE_URL = IS_GITHUB_PROJECT_SITE
+  ? `https://${REPO_OWNER}.github.io/${REPO_NAME}`
+  : window.location.origin;
 
 const GITHUB_REPO_URL = `https://github.com/${REPO_OWNER}/${REPO_NAME}`;
 const TRACKING_URL = `${BASE_URL}/REVIEW_TRACKING.md`;

--- a/public/previews/index.html
+++ b/public/previews/index.html
@@ -106,6 +106,6 @@
             </p>
         </footer>
     </div>
-    <script src="./dashboard.js"></script>
+    <script src="/previews/dashboard.js"></script>
 </body>
 </html>

--- a/public/previews/index.html
+++ b/public/previews/index.html
@@ -106,6 +106,11 @@
             </p>
         </footer>
     </div>
-    <script src="/previews/dashboard.js"></script>
+<script>
+  if (!window.location.pathname.endsWith('/')) {
+    window.location.replace(`${window.location.pathname}/${window.location.search}${window.location.hash}`);
+  }
+</script>
+<script src="./dashboard.js"></script>
 </body>
 </html>

--- a/scripts/generate-spa-stubs.mjs
+++ b/scripts/generate-spa-stubs.mjs
@@ -11,7 +11,7 @@ const DIST_DIR = path.resolve(__dirname, '../dist');
 const INDEX_HTML = path.join(DIST_DIR, 'index.html');
 
 // Automatically discover all routes
-const { all: STUB_ROUTES } = getAllRoutes();
+const { stubs: STUB_ROUTES } = getAllRoutes();
 
 // Filter out root path as it already has index.html
 const filteredRoutes = STUB_ROUTES.filter(route => route !== '/');

--- a/src/lib/routes-discovery.test.ts
+++ b/src/lib/routes-discovery.test.ts
@@ -8,20 +8,22 @@ describe('getAllRoutes', () => {
     expect(all.length).toBe(unique.size);
   });
 
-  it('should exclude /preview from the sitemap', () => {
-    const { all } = getAllRoutes();
-    expect(all).not.toContain('/preview');
+  it('should exclude /preview from the sitemap but include in stubs', () => {
+    const { sitemap, stubs } = getAllRoutes();
+    expect(sitemap).not.toContain('/preview');
+    expect(stubs).toContain('/preview');
   });
 
-  it('should exclude catch-all route', () => {
-    const { all } = getAllRoutes();
-    expect(all).not.toContain('*');
+  it('should exclude catch-all route from both sitemap and stubs', () => {
+    const { sitemap, stubs } = getAllRoutes();
+    expect(sitemap).not.toContain('*');
+    expect(stubs).not.toContain('*');
   });
 
   it('should use canonical path for UX Auditor', () => {
-    const { all } = getAllRoutes();
-    expect(all).toContain('/ux-auditor');
-    expect(all).not.toContain('/research/ux-auditor');
+    const { sitemap } = getAllRoutes();
+    expect(sitemap).toContain('/ux-auditor');
+    expect(sitemap).not.toContain('/research/ux-auditor');
   });
 
   it('should handle tool routes correctly', () => {

--- a/src/lib/routes-discovery.ts
+++ b/src/lib/routes-discovery.ts
@@ -54,9 +54,9 @@ export function getAllRoutes() {
   });
 
   // 1. Static routes from configuration (excluding parameterized and catch-all)
-  // Use canonicalPath if available, and filter out routes marked as sitemap: false
-  const staticRoutes = routes
-    .filter(r => r.sitemap !== false && r.path !== '*' && !r.path.includes(':'))
+  // Use canonicalPath if available
+  const allStaticRoutes = routes
+    .filter(r => r.path !== '*' && !r.path.includes(':'))
     .map(r => {
       let lastmod;
       if (contentLastModMap[r.path]) {
@@ -79,7 +79,8 @@ export function getAllRoutes() {
 
       return {
         path: resolveCanonical(r.path, r),
-        lastmod
+        lastmod,
+        sitemap: r.sitemap !== false
       };
     });
 
@@ -87,29 +88,37 @@ export function getAllRoutes() {
   // Use canonicalPath if available to avoid duplicates (e.g. /ux-auditor vs /research/ux-auditor)
   const toolRoutes = RESEARCH_TOOLS.map(tool => ({
     path: resolveCanonical(`/research/${tool.id}`, tool),
-    lastmod: getFileLastMod('src/config/research-tools.ts')
+    lastmod: getFileLastMod('src/config/research-tools.ts'),
+    sitemap: true
   }));
 
-  const allRoutes = [...staticRoutes, ...toolRoutes, ...contentRoutes];
+  const contentRoutesMapped = contentRoutes.map(r => ({ ...r, sitemap: true }));
+
+  const allRoutesRaw = [...allStaticRoutes, ...toolRoutes, ...contentRoutesMapped];
 
   // Deduplicate routes to ensure each path is only listed once, prioritizing the one with the most recent lastmod if duplicates exist
-  const uniqueRoutesMap = new Map<string, string>();
-  allRoutes.forEach(r => {
-    if (!uniqueRoutesMap.has(r.path) || r.lastmod > uniqueRoutesMap.get(r.path)!) {
-      uniqueRoutesMap.set(r.path, r.lastmod);
+  const uniqueRoutesMap = new Map<string, { lastmod: string, sitemap: boolean }>();
+  allRoutesRaw.forEach(r => {
+    const existing = uniqueRoutesMap.get(r.path);
+    if (!existing || r.lastmod > existing.lastmod) {
+      uniqueRoutesMap.set(r.path, { lastmod: r.lastmod, sitemap: r.sitemap });
     }
   });
 
-  const uniqueRoutes = Array.from(uniqueRoutesMap.entries()).map(([path, lastmod]) => ({
+  const uniqueRoutes = Array.from(uniqueRoutesMap.entries()).map(([path, info]) => ({
     path,
-    lastmod
+    ...info
   }));
 
+  const sitemapRoutes = uniqueRoutes.filter(r => r.sitemap);
+
   return {
-    static: staticRoutes.map(r => r.path),
+    static: allStaticRoutes.filter(r => r.sitemap).map(r => r.path),
     tools: toolRoutes.map(r => r.path),
     content: contentRoutes.map(r => r.path),
-    all: uniqueRoutes.map(r => r.path),
-    detailed: uniqueRoutes
+    stubs: uniqueRoutes.map(r => r.path),
+    sitemap: sitemapRoutes.map(r => r.path),
+    all: sitemapRoutes.map(r => r.path),
+    detailed: sitemapRoutes
   };
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -32,7 +32,7 @@ export default defineConfig(({mode}) => {
   const fullAppUrl = new URL(base, hostname).href;
 
   // Automatically discover dynamic routes
-  const { all: dynamicRoutes, detailed: routeDetails } = getAllRoutes();
+  const { sitemap: dynamicRoutes, detailed: routeDetails } = getAllRoutes();
 
   // Create lastmod mapping for the sitemap plugin
   const lastmodMap = Object.fromEntries(


### PR DESCRIPTION
Fixed the issue where routes excluded from the sitemap (like `/preview`) were returning 404 errors because they lacked static HTML stubs. The route discovery logic now provides two lists: one for the SEO sitemap and one for pre-rendering static stubs, ensuring all valid app routes have a landing page even if they shouldn't be indexed.

---
*PR created automatically by Jules for task [3849802210787864212](https://jules.google.com/task/3849802210787864212) started by @arii*