### PR TITLE
Force sequential GitHub Pages deployment and prevent skipped runs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,12 +16,8 @@ permissions:
   pull-requests: write
   issues: write
 
-concurrency:
-  group: "pages"
-  cancel-in-progress: false
-
 jobs:
-  build_and_deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Branch
@@ -86,16 +82,34 @@ jobs:
 
           git log -1 --format=%ct > dist/.timestamp
 
+      - name: Upload dist artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-assets
+          path: dist/
+          retention-days: 1
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    concurrency:
+      # Use a global concurrency group for all gh-pages writes to prevent conflicts
+      # and ensure sequential deployment across all branches.
+      group: gh-pages-deploy
+      cancel-in-progress: false
+    steps:
+      - name: Download dist artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dist-assets
+          path: ../dist-assets
+
       - name: Deploy to gh-pages branch
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REF_NAME: ${{ github.ref_name }}
           REPOSITORY: ${{ github.repository }}
         run: |
-          # Prepare dist assets in a stable location
-          mkdir -p ../dist-assets
-          cp -r dist/* ../dist-assets/
-
           # Deployment parameters
           if [ "$REF_NAME" = "main" ]; then
             DEST_DIR="."
@@ -122,16 +136,37 @@ jobs:
             fi
 
             # 2. Sync build artifacts
-            mkdir -p "$DEST_DIR"
-            cp -r ../dist-assets/* "$DEST_DIR/"
+            if [ "$DEST_DIR" != "." ]; then
+              # Clean sync for branch subdirectories
+              rm -rf "$DEST_DIR"
+              mkdir -p "$DEST_DIR"
+              cp -r ../dist-assets/* "$DEST_DIR/"
+            else
+              # Root deployment for main branch
+              # We use selective copy to avoid deleting other branch folders
+              cp -r ../dist-assets/* .
+            fi
             touch .nojekyll
 
-            # 3. Update root 404.html for redirects
+            # 3. Handle Main-specific requirements (tech-dancer/ subfolder and SEO)
+            if [ "$REF_NAME" = "main" ]; then
+              # Also deploy to tech-dancer/ subdirectory for root domain support
+              mkdir -p tech-dancer
+              # Clean sync to tech-dancer
+              rm -rf tech-dancer/*
+              cp -r ../dist-assets/* tech-dancer/
+
+              # Ensure SEO assets are at the root
+              cp ../dist-assets/sitemap.xml ./sitemap.xml 2>/dev/null || true
+              cp ../dist-assets/robots.txt ./robots.txt 2>/dev/null || true
+            fi
+
+            # 4. Update root 404.html for redirects (only for previews)
             if [ "$REF_NAME" != "main" ]; then
               cp "$DEST_DIR/404.html" ./404.html
             fi
 
-            # 4. Update Previews Index and Metadata
+            # 5. Update Previews Index and Metadata
             mkdir -p previews
             find . -maxdepth 3 -name "index.html" | while read -r index_file; do
               DIR=$(dirname "$index_file" | sed 's|^\./||')
@@ -146,16 +181,10 @@ jobs:
               echo "$DIR $TS"
             done | jq -R -n '[inputs | select(length > 0) | split(" ") | select(length == 2 and .[1] != "") | {(.[0]): (.[1] | tonumber)}] | add // {}' > previews/data.json
 
-            # Use the latest dashboard UI
-            if [ "$DEST_DIR" != "." ]; then
-              cp "$DEST_DIR/previews/index.html" previews/index.html
-            fi
-             # Copy sitemap.xml to gh-pages root so arii.github.io/sitemap.xml resolves
-             if [ "$REF_NAME" = "main" ] && [ -f "tech-dancer/sitemap.xml" ]; then
-               cp tech-dancer/sitemap.xml ./sitemap.xml
-             fi
+            # Use the latest dashboard UI from the current deployment
+            cp ../dist-assets/previews/index.html previews/index.html
 
-            # 5. Commit and Push
+            # 6. Commit and Push
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git add .
@@ -176,32 +205,6 @@ jobs:
 
           echo "Failed to deploy after $MAX_RETRIES attempts."
           exit 1
-
-      - name: Prepare Root SEO Assets
-        if: github.ref_name == 'main'
-        run: |
-          mkdir -p root-seo
-          cp dist/sitemap.xml root-seo/
-          cp dist/robots.txt root-seo/
-
-      - name: Deploy SEO Assets to Root Domain - arii.github.io
-        if: github.ref_name == 'main'
-        uses: JamesIves/github-pages-deploy-action@v4
-        with:
-          token: ${{ secrets.DEPLOY_TOKEN }}
-          branch: gh-pages
-          folder: root-seo
-          clean: false # Do not delete other files in arii.github.io
-
-      - name: Deploy Full Site to Root Domain Subdirectory - arii.github.io
-        if: github.ref_name == 'main'
-        uses: JamesIves/github-pages-deploy-action@v4
-        with:
-          token: ${{ secrets.DEPLOY_TOKEN }}
-          branch: gh-pages
-          folder: dist
-          target-folder: tech-dancer
-          clean: true
 
       - name: Update Deployment Feedback
         uses: actions/github-script@v7

--- a/.github/workflows/prune-stale-previews.yml
+++ b/.github/workflows/prune-stale-previews.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch: # Allows manual triggering
 
 concurrency:
-  group: "pages"
+  group: gh-pages-deploy
   cancel-in-progress: false
 
 


### PR DESCRIPTION
This change addresses the issue where rapid triggers of the GitHub Pages deployment workflow caused race conditions and skipped deployments. By splitting the workflow into a parallel build job and a serialized deploy job with a global concurrency lock (`gh-pages-deploy`), we ensure that all writes to the `gh-pages` branch happen sequentially and no queued runs are canceled. The deployment logic has been consolidated into a single bash script to reduce the number of separate git operations and ensure consistency across site assets, preview folders, and SEO metadata.

Fixes #1690

---
*PR created automatically by Jules for task [3560570511423755970](https://jules.google.com/task/3560570511423755970) started by @arii*