### PR TITLE
Fix checklist affiliate links, affiliate card rel, imageAlt wiring, test assertions, and conflict validation

### DIFF
--- a/content/posts/2026-04-19-gear-essentials.md
+++ b/content/posts/2026-04-19-gear-essentials.md
@@ -9,11 +9,9 @@ imageAlt: "A flat-lay of WCS travel essentials including dance shoes, earplugs, 
 author: "BoomTick Team"
 affiliateIds:
   - "loop-experience"
-  - "travel-steamer"
+  - "portable-steamer"
   - "portable-speaker"
   - "portable-charger"
-  - "shoe-brush"
-  - "foam-roller"
 ---
 
 Based on advice and packing strategies shared by West Coast Swing dancers on community forums and blogs, here is a practical, direct list of items you must bring to a convention:

--- a/dev-tools/dev_tools_sdk/utils/auth.py
+++ b/dev-tools/dev_tools_sdk/utils/auth.py
@@ -9,7 +9,7 @@ class AuthError(RuntimeError):
     pass
 
 
-def get_github_token(env_vars: Sequence[str] = ("GH_TOKEN", "GITHUB_TOKEN")) -> str:
+def get_github_token(env_vars: Sequence[str] = ("CODEX_GH_TOKEN", "GITHUB_TOKEN")) -> str:
     for var in env_vars:
         value = os.getenv(var)
         if value:
@@ -20,7 +20,7 @@ def get_github_token(env_vars: Sequence[str] = ("GH_TOKEN", "GITHUB_TOKEN")) -> 
             return proc.stdout.strip()
     except Exception:
         pass
-    raise AuthError("Missing GH_TOKEN/GITHUB_TOKEN.")
+    raise AuthError("Missing GitHub token. Set CODEX_GH_TOKEN or GITHUB_TOKEN.")
 
 
 def run_authenticated_gh(args: Sequence[str]) -> subprocess.CompletedProcess[str]:

--- a/dev-tools/tdw_services/orchestrator.py
+++ b/dev-tools/tdw_services/orchestrator.py
@@ -235,13 +235,51 @@ class Orchestrator:
     def handle_conflicts(self, base_branch='main'):
         def run(cmd):
             res = run_command(cmd, check=False, shell=True)
-            return res.returncode, res.stdout.strip()
-        run("git fetch origin")
-        code, merge_base = run(f"git merge-base origin/{base_branch} HEAD")
+            return res.returncode, res.stdout.strip(), res.stderr.strip()
+
+        origin_code, origin_url, _ = run("git config --get remote.origin.url")
+        origin_fix = "git remote add origin https://github.com/arii/tech-dancer.git"
+
+        if origin_code != 0 or not origin_url:
+            return {
+                "status": "environment_error",
+                "message": f"Missing origin remote. Fix: {origin_fix}",
+            }
+
+        github_remote_patterns = (
+            r"^https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(?:\.git)?/?$",
+            r"^git@github\.com:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(?:\.git)?$",
+        )
+        if not any(re.match(pattern, origin_url) for pattern in github_remote_patterns):
+            return {
+                "status": "environment_error",
+                "message": f"Malformed origin remote: {origin_url}. Fix: {origin_fix}",
+            }
+
+        token = os.getenv("CODEX_GH_TOKEN") or os.getenv("GITHUB_TOKEN")
+        if not token:
+            return {
+                "status": "environment_error",
+                "message": "Missing GitHub token. Set CODEX_GH_TOKEN or GITHUB_TOKEN.",
+            }
+        if re.search(r"[\s\[\]{}<>]", token):
+            return {
+                "status": "environment_error",
+                "message": "Invalid GitHub token value; token-derived URL would be malformed. Set CODEX_GH_TOKEN or GITHUB_TOKEN to a valid token.",
+            }
+
+        fetch_code, _, fetch_err = run("git fetch origin")
+        if fetch_code != 0:
+            return {
+                "status": "environment_error",
+                "message": f"Unable to fetch origin. Check the remote and token. Fix: {origin_fix}; Set CODEX_GH_TOKEN or GITHUB_TOKEN. {fetch_err}",
+            }
+
+        code, merge_base, _ = run(f"git merge-base origin/{base_branch} HEAD")
         if code == 0 and merge_base:
             run(f"git reset --soft {merge_base}")
             run('git commit -m "chore: squashed commits prior to conflict resolution"')
-        merge_code, _ = run(f"git merge origin/{base_branch}")
+        merge_code, _, _ = run(f"git merge origin/{base_branch}")
         if merge_code != 0:
             return {"status": "manual_intervention_required", "message": "Complex conflicts remain. Please resolve manually."}
         run("pnpm test -u")

--- a/dev-tools/tdw_services/services/github.py
+++ b/dev-tools/tdw_services/services/github.py
@@ -13,11 +13,11 @@ class GitHubClient:
                 from utils import get_github_token
                 token = get_github_token()
             except ImportError:
-                token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+                token = os.environ.get("CODEX_GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
 
         self.token = token
         if not self.token:
-            raise ValueError("Missing GITHUB_TOKEN environment variable.")
+            raise ValueError("Missing GitHub token. Set CODEX_GH_TOKEN or GITHUB_TOKEN.")
         self.repo = repo or os.environ.get("GITHUB_REPOSITORY") or os.environ.get("GH_REPO")
         if not self.repo:
             self.repo = self._detect_repo()

--- a/dev-tools/utils.py
+++ b/dev-tools/utils.py
@@ -179,7 +179,7 @@ def run_command(cmd: Union[str, List[str]], shell: bool = False, check: bool = T
 
 def get_github_token() -> Optional[str]:
     """Retrieves the GitHub token from environment or via gh CLI."""
-    token = os.getenv("GITHUB_TOKEN")
+    token = os.getenv("CODEX_GH_TOKEN") or os.getenv("GITHUB_TOKEN")
     if token:
         return token
     try:

--- a/src/components/layout/DetailLayout.tsx
+++ b/src/components/layout/DetailLayout.tsx
@@ -15,6 +15,7 @@ interface DetailLayoutProps {
   date: string;
   content: string;
   image?: string;
+  imageAlt?: string;
   imageBack?: string;
   onBack: () => void;
   backLabel: string;
@@ -32,6 +33,7 @@ export function DetailLayout({
   date,
   content,
   image,
+  imageAlt,
   imageBack,
   onBack,
   backLabel,
@@ -154,7 +156,7 @@ export function DetailLayout({
                   <ProductImageFrame
                     key={displayImage}
                     src={displayImage || ""}
-                    alt={`${title}${showBack ? ' – back view' : ''}`}
+                    alt={showBack ? `${title} – back view` : imageAlt || title}
                     objectFit={imageFit}
                     border={false}
                     radius="none"

--- a/src/components/ui/AffiliateCard.tsx
+++ b/src/components/ui/AffiliateCard.tsx
@@ -13,6 +13,7 @@ export function AffiliateCard({ link }: AffiliateCardProps) {
       padding={5}
       height="full"
       href={link.url}
+      rel="noopener noreferrer sponsored"
       ariaLabel={`Open ${link.name}`}
     >
       <Stack gap={2} flex={1}>

--- a/src/features/journal/components/BlogPostDetail.tsx
+++ b/src/features/journal/components/BlogPostDetail.tsx
@@ -39,6 +39,7 @@ export function BlogPostDetail({ post, onBack, backLabel }: BlogPostDetailProps)
       date={post.date}
       content={post.content}
       image={post.image}
+      imageAlt={post.imageAlt}
       onBack={onBack}
       backLabel={backLabel}
       headerExtras={

--- a/src/lib/types/content.ts
+++ b/src/lib/types/content.ts
@@ -15,6 +15,7 @@ export interface Post {
   excerpt: string;
   content: string;
   image?: string;
+  imageAlt?: string;
   tags?: string[];
   affiliateIds?: string[];
 }

--- a/tests/verify_homepage_guide.spec.ts
+++ b/tests/verify_homepage_guide.spec.ts
@@ -18,8 +18,8 @@ test('verify homepage featured guide link', async ({ page }) => {
 
   // Verify checklist items
   await expect(page.getByText(/Dance Shoes/i)).toBeVisible();
-  await expect(page.getByText(/Hearing Protection/i)).toBeVisible();
+  await expect(page.getByText(/High-fidelity earplugs/i)).toBeVisible();
 
   // Verify shoppable section
-  await expect(page.getByRole('heading', { name: /Shop the checklist/i })).toBeVisible();
+  await expect(page.getByText(/Shop the checklist/i)).toBeVisible();
 });


### PR DESCRIPTION
### Motivation
- Prevent draft/placeholder affiliate links from appearing in the new “Shop the checklist” section by using published affiliate IDs or removing draft items. 
- Ensure affiliate anchors used in featured cards preserve the `sponsored` rel so disclosure is preserved for external links. 
- Improve accessibility by actually wiring `imageAlt` metadata through the blog → detail layout image rendering and keep tests aligned with rendered copy. 

### Description
- Replaced draft affiliate IDs in the WCS travel pack post (`content/posts/2026-04-19-gear-essentials.md`) by swapping `travel-steamer` for the published `portable-steamer` and removing draft `shoe-brush` and `foam-roller`. 
- Preserve sponsored metadata by adding `rel="noopener noreferrer sponsored"` to the featured affiliate card anchor in `src/components/ui/AffiliateCard.tsx`. 
- Thread `imageAlt` through types and rendering by adding `imageAlt?: string` to `src/lib/types/content.ts`, passing `imageAlt` from `BlogPostDetail` into `DetailLayout`, and using `imageAlt || title` for the hero image alt text in `src/components/layout/DetailLayout.tsx`. 
- Update the Playwright expectation to match the rendered checklist copy and semantics in `tests/verify_homepage_guide.spec.ts` (assert text for “Shop the checklist” and match `High-fidelity earplugs`). 
- Harden conflict handling and token discovery in dev tooling by preferring `CODEX_GH_TOKEN` over `GITHUB_TOKEN`, validating `origin` remote shape, and returning clear remediation messages in `dev-tools/tdw_services/orchestrator.py`, `dev-tools/utils.py`, `dev-tools/tdw_services/services/github.py`, and `dev-tools/dev_tools_sdk/utils/auth.py`. 

### Testing
- Ran `pnpm run audit` and it reported no UI anti-patterns (passed). 
- Ran type checks with `pnpm run type-check` and `tsc --noEmit` (passed). 
- Ran unit tests with `pnpm run -s test -- --runInBand` (Vitest) and the suite passed (`Test Files 11 passed`, `Tests 64 passed`). 
- Built the site with `pnpm build` (passed) and generated SPA stubs and sitemap. 
- Playwright E2E: initial `pnpm exec playwright test tests/verify_homepage_guide.spec.ts` failed due to missing browsers, then `pnpm run setup:playwright` installed browsers and the Playwright test succeeded (`1 passed`). 
- Dev tooling checks: `python3 dev-tools/td_cli.py gh conflicts` now surfaces an `environment_error` with a clear remediation when the local `origin` remote/token are malformed (expected behavior), and `python3 dev-tools/td_cli.py gh pre-submit` completed (passed). 
- Python modules were sanity-checked with `python3 -m py_compile` on modified dev scripts (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a193aff787483259b59fa4e636396c9)