### PR TITLE
fix: polish footer dev mode version display

### DIFF
--- a/src/layouts/Footer.tsx
+++ b/src/layouts/Footer.tsx
@@ -36,16 +36,22 @@ export function Footer() {
           <Box className="hidden md:block w-px h-3 bg-white/10 shrink-0" />
           <Text size="micro" color="dim" className="opacity-80 hover:opacity-100 transition-opacity whitespace-nowrap">
             <span className="font-mono tracking-wider uppercase">
-              {isDev ? 'dev' : `v${appVersion}`} (
-              <a
-                href={`https://github.com/arii/tech-dancer/commit/${commitSha}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="hover:text-accent transition-colors underline decoration-white/20 underline-offset-2"
-              >
-                {commitSha.substring(0, 7)}
-              </a>
-              )
+              {isDev ? (
+                'dev'
+              ) : (
+                <>
+                  v{appVersion} (
+                  <a
+                    href={`https://github.com/arii/tech-dancer/commit/${commitSha}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="hover:text-accent transition-colors underline decoration-white/20 underline-offset-2"
+                  >
+                    {commitSha.substring(0, 7)}
+                  </a>
+                  )
+                </>
+              )}
             </span>
             {lastUpdated && ` · Last updated ${lastUpdated}`}
           </Text>


### PR DESCRIPTION
This commit refines the footer's version and commit display logic to prevent 'dev (dev)' from appearing when the environment is in development mode. It wraps the version string and commit sha link in a fragment that is only conditionally rendered when not in development, ensuring that 'dev' mode neatly displays only 'dev'.

---
*PR created automatically by Jules for task [3192412316747780468](https://jules.google.com/task/3192412316747780468) started by @arii*