### PR TITLE
Exclude /preview from sitemap and robots indexing

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,6 @@
+# GENERATED FILE - DO NOT EDIT MANUALLY
+# Source: scripts/generate-robots.ts
+
 User-agent: *
 Allow: /
 Disallow: /preview

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,6 @@
 User-agent: *
 Allow: /
+Disallow: /preview
 Disallow: /previews/
 Disallow: /404.html
 

--- a/scripts/generate-robots.ts
+++ b/scripts/generate-robots.ts
@@ -6,6 +6,7 @@ const hostname = APP_URL.replace(/\/$/, '');
 
 const robotsContent = `User-agent: *
 Allow: /
+Disallow: /preview
 Disallow: /previews/
 Disallow: /404.html
 

--- a/scripts/generate-robots.ts
+++ b/scripts/generate-robots.ts
@@ -4,7 +4,10 @@ import path from 'path';
 const APP_URL = process.env.VITE_APP_URL || 'https://boomtick.blog';
 const hostname = APP_URL.replace(/\/$/, '');
 
-const robotsContent = `User-agent: *
+const robotsContent = `# GENERATED FILE - DO NOT EDIT MANUALLY
+# Source: scripts/generate-robots.ts
+
+User-agent: *
 Allow: /
 Disallow: /preview
 Disallow: /previews/

--- a/scripts/generate-spa-stubs.mjs
+++ b/scripts/generate-spa-stubs.mjs
@@ -11,10 +11,12 @@ const DIST_DIR = path.resolve(__dirname, '../dist');
 const INDEX_HTML = path.join(DIST_DIR, 'index.html');
 
 // Automatically discover all routes
-const { stubs: STUB_ROUTES } = getAllRoutes();
+const { detailed: ROUTES_DETAILS } = getAllRoutes();
 
-// Filter out root path as it already has index.html
-const filteredRoutes = STUB_ROUTES.filter(route => route !== '/');
+// Filter out root path as it already has index.html, and only include routes intended for sitemap
+const filteredRoutes = ROUTES_DETAILS
+  .filter(route => route.path !== '/' && route.sitemap)
+  .map(route => route.path);
 
 async function generateStubs() {
   if (!fs.existsSync(INDEX_HTML)) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -72,7 +72,7 @@ export default defineConfig(({mode}) => {
         basePath: base.replace(/\/$/, ''),
         dynamicRoutes: dynamicRoutes.filter(route => route !== '/').map(route => route.replace(/\/$/, '') || '/'),
         // Exclude infrastructure pages that are not real app routes
-        exclude: ['/404', '/previews', '/previews/'],
+        exclude: ['/404', '/preview', '/previews', '/previews/'],
         generateRobotsTxt: false,
         xmlns: {
           news: false,


### PR DESCRIPTION
This change ensures that the `/preview` route is completely hidden from search engines. It implements a multi-layered approach:
1. **Sitemap Exclusion**: Explicitly adds `/preview` to the `exclude` list of the sitemap plugin.
2. **Robots.txt Disallow**: Adds a directive to `robots.txt` to prevent crawlers from accessing the `/preview` path.
3. **SPA Stub Suppression**: Updates the build-time SPA stub generator to only create physical `index.html` files for routes intended for public indexing. This prevents crawlers from finding the path via direct file discovery in the build output.

These changes address reported 404 errors in Google Search Console by ensuring internal preview routes are not advertised to search bots.

---
*PR created automatically by Jules for task [14804620589403337728](https://jules.google.com/task/14804620589403337728) started by @arii*