### PR TITLE
Implement Split Content PR Policy and Scope Checks

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,41 @@
+# Description
+
+Please provide a summary of the changes and which content scope this PR covers.
+
+## Scope (Select One)
+
+- [ ] **Event Facts**: Factual corrections (venue, city, date, hero labels, URL).
+- [ ] **Gear/Assets**: Broken or incorrect image/path fixes.
+- [ ] **Merch Catalog**: Copy or layout updates for products.
+- [ ] **Article Editorial**: Content updates or date strategy for blog posts.
+
+---
+
+## Validation Checklist
+
+### 📍 Event Facts
+- [ ] Source URL provided in comments/description.
+- [ ] Verified venue, city, and event dates match the source.
+- [ ] Hero labels and event URLs are correct.
+
+### 🖼 Gear/Assets
+- [ ] Broken assets identified and updated.
+- [ ] Missing assets marked as `draft: true` (do not use placeholder paths).
+- [ ] No changes to event facts or merch catalog copy.
+
+### 🛍 Merch Catalog
+- [ ] Product removals (if any) are listed explicitly in the description.
+- [ ] Copy and layout updates verified against brand guidelines.
+- [ ] No changes to event facts or gear asset paths.
+
+### ✍️ Article Editorial
+- [ ] Rationale provided for any post date changes.
+- [ ] Old content does not appear "newly published" without intent.
+- [ ] No changes to factual event data or product catalogs.
+
+---
+
+## Technical Checks
+- [ ] `pnpm build` passes.
+- [ ] `pnpm run audit` shows no new UI anti-patterns.
+- [ ] PR touches only files relevant to the selected scope.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,6 +171,11 @@ When multiple agents work simultaneously:
   ```
 - **Pre-submit check**: Always run `python3 dev-tools/td_cli.py gh pre-submit` before pushing
 - **No monolithic PRs**: Keep PRs focused. Ideally modify no more than 3 files in `src/layouts/` or `src/components/`
+- **Split Content PRs**: Do not mix content domains. Create separate PRs for:
+  - **Event Facts**: Factual corrections (venue, city, dates, URL). Must include source URL.
+  - **Gear Assets**: Broken image/path fixes. Mark missing assets as `draft: true`.
+  - **Merch Catalog**: Copy or layout updates. List product removals explicitly.
+  - **Articles**: Editorial updates. Provide rationale for date changes.
 - **Code review standards**: Evaluate dead abstractions, unnecessary indirection, responsibility creep, and token compliance
 
 ### Baseline Maintenance

--- a/dev-tools/project_config.json
+++ b/dev-tools/project_config.json
@@ -6,5 +6,11 @@
   "monolithic_pr_threshold": 3,
   "base_branch": "origin/main",
   "use_gemini_fallback": false,
-  "ollama_synthesis_model": "llama3.2"
+  "ollama_synthesis_model": "llama3.2",
+  "content_scopes": {
+    "events": "content/events/",
+    "resources": "content/resources/",
+    "posts": "content/posts/",
+    "studies": "content/studies/"
+  }
 }

--- a/dev-tools/scope_check.py
+++ b/dev-tools/scope_check.py
@@ -1,7 +1,7 @@
 import json
 import os
 import sys
-from typing import List, Optional
+from typing import List, Optional, Set
 
 # Import run_command from utils
 from utils import run_command
@@ -12,7 +12,13 @@ def get_project_config():
         return {
             "core_dirs": ["src/layouts/", "src/components/"],
             "monolithic_pr_threshold": 3,
-            "base_branch": "origin/main"
+            "base_branch": "origin/main",
+            "content_scopes": {
+                "events": "content/events/",
+                "resources": "content/resources/",
+                "posts": "content/posts/",
+                "studies": "content/studies/"
+            }
         }
     with open(config_path) as f:
         return json.load(f)
@@ -33,7 +39,7 @@ def get_changed_files():
     return []
 
 def verify_pr_scope(file_list=None):
-    """Checks if a PR touches too many core layout/component files."""
+    """Checks if a PR touches too many core layout/component files or mixes content scopes."""
     if file_list is None:
         file_list = get_changed_files()
 
@@ -44,6 +50,31 @@ def verify_pr_scope(file_list=None):
     core_files = [f for f in file_list if any(f.startswith(d) for d in core_dirs)]
     if len(core_files) > threshold:
         return f"PR scope warning: Touching {len(core_files)} core files in {core_dirs}. Consider splitting this monolithic PR to avoid merge conflicts (AGENTS.md §23)."
+
+    # Content Scope Check
+    content_scopes = config.get("content_scopes", {
+        "events": "content/events/",
+        "resources": "content/resources/",
+        "posts": "content/posts/",
+        "studies": "content/studies/"
+    })
+
+    active_scopes: Set[str] = set()
+    for f in file_list:
+        for scope_name, prefix in content_scopes.items():
+            if f.startswith(prefix):
+                active_scopes.add(scope_name)
+
+    if len(active_scopes) > 1:
+        return f"Content scope warning: Mixed content domains detected ({', '.join(active_scopes)}). PRs should be split by scope: Event Facts, Gear Assets, Merch Catalog, or Articles (AGENTS.md §21)."
+
+    # Mixed Content and Code Check
+    has_content = len(active_scopes) > 0
+    code_files = [f for f in file_list if f.startswith("src/") and not any(f.startswith(d) for d in core_dirs)]
+
+    if has_content and len(code_files) > 2:
+        return "PR scope warning: Mixing significant code changes with content updates. Consider splitting content corrections from feature development."
+
     return None
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR introduces infrastructure to enforce the "Split Content PR" policy, ensuring that factual corrections, asset fixes, merch catalog updates, and blog post changes are kept in separate, focused PRs.

Key changes:
- **PR Template**: Added `.github/PULL_REQUEST_TEMPLATE.md` with checklists for Event Facts, Gear Assets, Merch Catalog, and Articles.
- **Automated Validation**: Updated `dev-tools/scope_check.py` to warn when a PR touches multiple content domains or mixes significant code changes with content corrections.
- **Documentation**: Updated `AGENTS.md` to reflect the new policy and guide contributors on how to structure their PRs.
- **Configuration**: Centralized content scope definitions in `dev-tools/project_config.json`.

Fixes #1737

---
*PR created automatically by Jules for task [4988335591704485170](https://jules.google.com/task/4988335591704485170) started by @arii*