### PR TITLE
Conservative SEO and Product JSON-LD implementation

### DIFF
--- a/src/features/lab/Toolbox.tsx
+++ b/src/features/lab/Toolbox.tsx
@@ -27,7 +27,7 @@ export default function Toolbox() {
     <Box as="section" paddingY={4}>
       <SEO
         title="Toolbox"
-        description="Rigorous testing and honest takes on the gear that keeps you moving. Gear reviews for West Coast Swing dancers."
+        description="Dance gear notes and product resources for West Coast Swing weekends, practice, travel, recovery, and social dance comfort."
         jsonLd={generateGearCatalogSchema(allFilteredItems)}
       />
       <Box as="header" marginBottom={8}>

--- a/src/lib/__tests__/schema.test.ts
+++ b/src/lib/__tests__/schema.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { generateMerchSchema, generateGearCatalogSchema } from '../../utils/schema';
+import { generateMerchSchema, generateGearCatalogSchema, getImageUrl } from '../../utils/schema';
 import type { ProductCatalogItem } from '@/data/products/catalog';
 import type { Resource } from '@/lib/types/content';
+import { BASE_URL, ASSET_PREFIX } from '@/config/constants';
 
 describe('Schema generation', () => {
   describe('generateMerchSchema', () => {
-    it('should only include stable fields by default for non-printful merch', () => {
+    it('should only include stable fields and no risky fields', () => {
       const mockProducts: ProductCatalogItem[] = [
         {
           id: 'test-id',
@@ -14,33 +15,6 @@ describe('Schema generation', () => {
           description: 'Test Description',
           imageUrl: '/test-image.jpg',
           href: '/test-product',
-          collections: ['test'],
-          tags: ['test'],
-          disclosure: 'none'
-        }
-      ];
-
-      const schema = generateMerchSchema(mockProducts);
-      const product = schema.itemListElement[0].item;
-
-      expect(product.name).toBe('Test Product');
-      expect(product.sku).toBe('test-id');
-      expect(product.aggregateRating).toBeUndefined();
-      expect(product.review).toBeUndefined();
-      expect(product.offers.shippingDetails).toBeUndefined();
-      expect(product.offers.hasMerchantReturnPolicy).toBeUndefined();
-      expect(product.offers.availability).toBeUndefined();
-    });
-
-    it('should include price and policies for printful merch', () => {
-      const mockProducts: ProductCatalogItem[] = [
-        {
-          id: 'printful-id',
-          source: 'owned-merch',
-          title: 'Printful Product',
-          description: 'Printful Description',
-          imageUrl: '/printful-image.jpg',
-          href: '/printful-product',
           price: '$25.00',
           collections: ['test'],
           tags: ['test'],
@@ -51,38 +25,24 @@ describe('Schema generation', () => {
       const schema = generateMerchSchema(mockProducts);
       const product = schema.itemListElement[0].item;
 
-      expect(product.offers.price).toBe('25.00');
-      expect(product.offers.priceCurrency).toBe('USD');
-      expect(product.offers.shippingDetails).toBeDefined();
-      expect(product.offers.hasMerchantReturnPolicy).toBeDefined();
-      expect(product.offers.availability).toBe('https://schema.org/InStock');
+      expect(product.name).toBe('Test Product');
+      expect(product.sku).toBe('test-id');
+
+      // Risky fields should be undefined (and should not even be in the type)
+      const json = JSON.stringify(product);
+      expect(json).not.toContain('price');
+      expect(json).not.toContain('availability');
+      expect(json).not.toContain('shippingDetails');
+      expect(json).not.toContain('hasMerchantReturnPolicy');
+      expect(json).not.toContain('aggregateRating');
+      expect(json).not.toContain('review');
+
+      expect(product.offers.url).toBe('/test-product');
     });
   });
 
   describe('generateGearCatalogSchema', () => {
-    it('should not include ratings or policies if not provided', () => {
-      const mockResources: Resource[] = [
-        {
-          type: 'resource',
-          slug: 'test-gear',
-          title: 'Test Gear',
-          date: '2023-01-01',
-          author: 'Ariel Anders, PhD',
-          category: 'Gear',
-          excerpt: 'Test Excerpt',
-          content: 'Test Content'
-        }
-      ];
-
-      const schema = generateGearCatalogSchema(mockResources);
-      const product = schema.itemListElement[0].item;
-
-      expect(product.aggregateRating).toBeUndefined();
-      expect(product.review).toBeUndefined();
-      expect(product.offers.shippingDetails).toBeUndefined();
-    });
-
-    it('should include ratings and reviews when verified source data exists', () => {
+    it('should not include ratings, reviews, or risky offer claims for gear', () => {
       const mockResources: Resource[] = [
         {
           type: 'resource',
@@ -94,63 +54,53 @@ describe('Schema generation', () => {
           excerpt: 'Test Excerpt',
           content: 'Test Content',
           rating: 4.5,
-          verdict: 'Excellent gear'
-        }
-      ];
-
-      const schema = generateGearCatalogSchema(mockResources);
-      const product = schema.itemListElement[0].item;
-
-      expect(product.aggregateRating).toBeDefined();
-      expect(product.aggregateRating?.ratingValue).toBe(4.5);
-      expect(product.review).toBeDefined();
-      expect(product.review?.[0].reviewRating.ratingValue).toBe(4.5);
-      expect(product.review?.[0].author.name).toBe('Test Author');
-    });
-
-    it('should NOT include review if verdict is present but rating is missing', () => {
-      const mockResources: Resource[] = [
-        {
-          type: 'resource',
-          slug: 'test-gear',
-          title: 'Test Gear',
-          date: '2023-01-01',
-          author: 'Ariel Anders, PhD',
-          category: 'Gear',
-          excerpt: 'Test Excerpt',
-          content: 'Test Content',
-          verdict: 'Excellent gear'
-        }
-      ];
-
-      const schema = generateGearCatalogSchema(mockResources);
-      const product = schema.itemListElement[0].item;
-
-      expect(product.review).toBeUndefined();
-    });
-
-    it('should include policies for owned merch in gear catalog', () => {
-      const mockResources: Resource[] = [
-        {
-          type: 'resource',
-          slug: 'merch-gear',
-          title: 'Merch Gear',
-          date: '2023-01-01',
-          author: 'Ariel Anders, PhD',
-          category: 'Gear',
-          excerpt: 'Test Excerpt',
-          content: 'Test Content',
-          shopUrl: 'https://printful.com/test',
+          verdict: 'Excellent gear',
+          shopUrl: 'https://example.com/test',
           provider: 'printful'
         }
       ];
 
       const schema = generateGearCatalogSchema(mockResources);
       const product = schema.itemListElement[0].item;
+      const json = JSON.stringify(product);
 
-      expect(product.offers.shippingDetails).toBeDefined();
-      expect(product.offers.hasMerchantReturnPolicy).toBeDefined();
-      expect(product.offers.availability).toBe('https://schema.org/InStock');
+      expect(product.name).toBe('Test Gear');
+      expect(json).not.toContain('aggregateRating');
+      expect(json).not.toContain('review');
+      expect(json).not.toContain('price');
+      expect(json).not.toContain('availability');
+      expect(json).not.toContain('shippingDetails');
+      expect(json).not.toContain('hasMerchantReturnPolicy');
+
+      expect(product.offers.url).toBe('https://example.com/test');
+    });
+  });
+
+  describe('getImageUrl', () => {
+    it('should handle various URL formats without duplication', () => {
+      const baseUrl = BASE_URL;
+      const assetPrefix = ASSET_PREFIX;
+
+      // Relative path
+      expect(getImageUrl('/assets/foo.webp')).toBe(`${baseUrl}${assetPrefix}/assets/foo.webp`);
+
+      // Path without leading slash
+      expect(getImageUrl('assets/foo.webp')).toBe(`${baseUrl}${assetPrefix}/assets/foo.webp`);
+
+      // External URL
+      expect(getImageUrl('https://example.com/foo.webp')).toBe('https://example.com/foo.webp');
+
+      // Already contains base URL
+      expect(getImageUrl(`${baseUrl}/assets/foo.webp`)).toBe(`${baseUrl}${assetPrefix}/assets/foo.webp`);
+
+      // Already contains asset prefix (if prefix is not '/')
+      if (assetPrefix !== '' && assetPrefix !== '/') {
+         expect(getImageUrl(`${assetPrefix}/assets/foo.webp`)).toBe(`${baseUrl}${assetPrefix}/assets/foo.webp`);
+      }
+    });
+
+    it('should fallback to defaultUrl if url is missing', () => {
+      expect(getImageUrl(undefined, '/default.jpg')).toBe(`${BASE_URL}${ASSET_PREFIX}/default.jpg`);
     });
   });
 });

--- a/src/pages/Merch.tsx
+++ b/src/pages/Merch.tsx
@@ -22,7 +22,7 @@ export default function Merch() {
     <Box>
       <SEO
         title="West Coast Swing Dance Merch"
-        description="Shop official BoomTick apparel for West Coast Swing dancers, social dancers, and NorCal locals. Curated collections for leads, follows, and switch dancers."
+        description="Shop BoomTick merch for West Coast Swing dancers, including role-pride tees, NorCal designs, rainbow pride apparel, and dance-weekend layers."
         jsonLd={generateMerchSchema(getAllMerchProducts())}
       />
 

--- a/src/utils/schema.ts
+++ b/src/utils/schema.ts
@@ -4,10 +4,31 @@ import { ASSET_PREFIX, BASE_URL } from '@/config/constants';
 
 /**
  * SCHEMA POLICY: Conservative Product JSON-LD
- * 1. Merch: Only include ratings or reviews when site has real source data.
- * 2. Gear: Only include price, stock, rating, review, or shipping when from a verified source.
- * 3. Merchant Listing: Added only when exact policy, price, and shipping data is confirmed.
- * 4. Stable fields (name, description, image, URL, brand, SKU) are always included when known.
+ *
+ * Only publish stable, site-controlled facts in Product structured data.
+ *
+ * Allowed now:
+ * - name
+ * - description
+ * - image
+ * - URL
+ * - brand
+ * - internal SKU/id
+ *
+ * Do NOT publish at this time:
+ * - price
+ * - currency
+ * - availability / stock status
+ * - shipping details
+ * - return policy
+ * - ratings
+ * - reviews
+ * - review counts
+ * - delivery dates
+ *
+ * Rationale:
+ * Printful/Amazon/product availability, pricing, shipping, returns, and ratings can change
+ * outside the site. Publishing guessed or stale values in JSON-LD creates SEO and trust risk.
  */
 
 export interface SchemaBrand {
@@ -15,50 +36,9 @@ export interface SchemaBrand {
   "name": string;
 }
 
-export interface SchemaShippingDetails {
-  "@type": "OfferShippingDetails";
-  "description": string;
-  "shippingDestination": {
-    "@type": "DefinedRegion";
-    "addressCountry": string;
-  };
-}
-
-export interface SchemaReturnPolicy {
-  "@type": "MerchantReturnPolicy";
-  "applicableCountry": string;
-  "returnPolicyCategory": string;
-  "description": string;
-}
-
-export interface SchemaAggregateRating {
-  "@type": "AggregateRating";
-  "ratingValue": number;
-  "reviewCount"?: number;
-  "bestRating"?: number;
-  "worstRating"?: number;
-}
-
-export interface SchemaReview {
-  "@type": "Review";
-  "reviewRating": {
-    "@type": "Rating";
-    "ratingValue": number;
-  };
-  "author": {
-    "@type": "Person";
-    "name": string;
-  };
-}
-
 export interface SchemaOffer {
   "@type": "Offer";
   "url": string;
-  "price"?: string;
-  "priceCurrency"?: string;
-  "availability"?: string;
-  "shippingDetails"?: SchemaShippingDetails;
-  "hasMerchantReturnPolicy"?: SchemaReturnPolicy;
 }
 
 export interface SchemaProduct {
@@ -70,8 +50,6 @@ export interface SchemaProduct {
   "brand": SchemaBrand;
   "sku": string;
   "offers": SchemaOffer;
-  "aggregateRating"?: SchemaAggregateRating;
-  "review"?: SchemaReview[];
 }
 
 export interface SchemaListItem {
@@ -86,27 +64,32 @@ export interface SchemaItemList {
   "itemListElement": SchemaListItem[];
 }
 
-export const POD_SHIPPING_POLICY: SchemaShippingDetails = {
-  "@type": "OfferShippingDetails",
-  "description": "Made to order. Production and shipping times vary by product and destination. Final delivery estimates are shown at checkout.",
-  "shippingDestination": {
-    "@type": "DefinedRegion",
-    "addressCountry": "US"
-  }
-} as const;
-
-export const POD_RETURN_POLICY: SchemaReturnPolicy = {
-  "@type": "MerchantReturnPolicy",
-  "applicableCountry": "US",
-  "returnPolicyCategory": "https://schema.org/UnsupportedReturnPolicy",
-  "description": "Each item is made to order. We cannot accept returns or exchanges for size, color, or change of mind. If your item arrives misprinted, damaged, defective, or incorrect, contact us promptly so we can help resolve it."
-} as const;
-
 export const AMAZON_AFFILIATE_DISCLOSURE = "As an Amazon Associate, BoomTick may earn from qualifying purchases.";
 
-function getImageUrl(url?: string, defaultUrl?: string): string {
-  if (!url) return defaultUrl || "";
-  return url.startsWith('http') ? url : `${BASE_URL}${ASSET_PREFIX}${url}`;
+/**
+ * Ensures a valid image URL without duplicate prefixes.
+ * Handles:
+ * - /assets/foo.webp -> BASE_URL + ASSET_PREFIX + /assets/foo.webp (avoiding duplication)
+ * - https://example.com/foo.webp -> unchanged
+ */
+export function getImageUrl(url?: string, defaultUrl?: string): string {
+  const target = url || defaultUrl || "";
+  if (!target) return "";
+  if (target.startsWith('http')) return target;
+
+  // Normalize path by removing duplicate base/asset prefixes if they already exist in the string
+  let path = target;
+  if (BASE_URL && path.startsWith(BASE_URL)) {
+    path = path.replace(BASE_URL, '');
+  }
+  if (ASSET_PREFIX && path.startsWith(ASSET_PREFIX)) {
+    path = path.replace(ASSET_PREFIX, '');
+  }
+
+  // Ensure path starts with a single slash
+  path = '/' + path.replace(/^\/+/, '');
+
+  return `${BASE_URL}${ASSET_PREFIX}${path}`;
 }
 
 export function generateMerchSchema(products: ProductCatalogItem[]): SchemaItemList {
@@ -114,23 +97,6 @@ export function generateMerchSchema(products: ProductCatalogItem[]): SchemaItemL
     "@context": "https://schema.org",
     "@type": "ItemList",
     "itemListElement": products.map((product, index) => {
-      const offer: SchemaOffer = {
-        "@type": "Offer",
-        "url": product.href,
-      };
-
-      // Only add policies if it's owned merch (Printful)
-      if (product.disclosure === 'owned-printful') {
-        offer.shippingDetails = POD_SHIPPING_POLICY;
-        offer.hasMerchantReturnPolicy = POD_RETURN_POLICY;
-        offer.availability = "https://schema.org/InStock";
-      }
-
-      if (product.price) {
-        offer.price = product.price.replace(/[^0-9.]/g, '');
-        offer.priceCurrency = "USD";
-      }
-
       const item: SchemaProduct = {
         "@type": "Product",
         "name": product.title,
@@ -141,7 +107,10 @@ export function generateMerchSchema(products: ProductCatalogItem[]): SchemaItemL
           "name": "BoomTick"
         },
         "sku": product.id,
-        "offers": offer
+        "offers": {
+          "@type": "Offer",
+          "url": product.href,
+        }
       };
 
       return {
@@ -158,58 +127,23 @@ export function generateGearCatalogSchema(resources: Resource[]): SchemaItemList
     "@context": "https://schema.org",
     "@type": "ItemList",
     "itemListElement": resources.map((resource, index) => {
-      const isMerch = !!resource.shopUrl && resource.provider === 'printful';
       const isAmazon = resource.affiliateProvider === 'amazon';
-
-      const offer: SchemaOffer = {
-        "@type": "Offer",
-        "url": resource.shopUrl || `${BASE_URL}/gear/${resource.slug}`,
-      };
-
-      if (isMerch) {
-        offer.shippingDetails = POD_SHIPPING_POLICY;
-        offer.hasMerchantReturnPolicy = POD_RETURN_POLICY;
-        offer.availability = "https://schema.org/InStock";
-      }
 
       const productSchema: SchemaProduct = {
         "@type": "Product",
         "name": resource.title,
         "description": isAmazon ? `${resource.excerpt} ${AMAZON_AFFILIATE_DISCLOSURE}` : resource.excerpt,
-        "image": getImageUrl(resource.image, `${BASE_URL}/assets/comp_analysis_hero.webp`),
+        "image": getImageUrl(resource.image, `/assets/comp_analysis_hero.webp`),
         "brand": {
           "@type": "Brand",
           "name": "BoomTick"
         },
         "sku": resource.internalSku || resource.slug,
-        "offers": offer
+        "offers": {
+          "@type": "Offer",
+          "url": resource.shopUrl || `${BASE_URL}/gear/${resource.slug}`,
+        }
       };
-
-      // Only add rating if verified in resource data
-      if (typeof resource.rating === 'number') {
-        productSchema.aggregateRating = {
-          "@type": "AggregateRating",
-          "ratingValue": resource.rating,
-          "bestRating": 5,
-          "worstRating": 1
-        };
-      }
-
-      // Only add verdict as a review if both a verdict AND rating are present
-      // Avoid guesstimating ratings for verdicts without numeric scores.
-      if (resource.verdict && typeof resource.rating === 'number') {
-        productSchema.review = [{
-          "@type": "Review",
-          "reviewRating": {
-            "@type": "Rating",
-            "ratingValue": resource.rating,
-          },
-          "author": {
-            "@type": "Person",
-            "name": resource.author || "Ariel Anders, PhD"
-          }
-        }];
-      }
 
       return {
         "@type": "ListItem",


### PR DESCRIPTION
This PR implements a conservative policy for Product JSON-LD and SEO metadata to avoid publishing unsupported or "hallucinatory" claims. 

Key changes:
- Refactored `src/utils/schema.ts` to strictly emit only name, description, image, URL, brand, and SKU.
- Removed logic that inferred stock, shipping, returns, prices, and ratings for both Printful and Amazon products.
- Improved `getImageUrl` utility to handle path joining and normalization correctly, avoiding duplicate prefixes.
- Updated meta descriptions in `Merch.tsx` and `Toolbox.tsx` to use stable, evergreen copy.
- Added vitest unit tests to verify the absence of risky fields and the correctness of URL generation.
- Verified visual and metadata changes via Playwright.

This approach minimizes SEO and trust risks associated with stale or guessed product data until verified source data is available.

---
*PR created automatically by Jules for task [17259019803886754366](https://jules.google.com/task/17259019803886754366) started by @arii*