### PR TITLE
Refactor ShareButton to use uppercase prop

### DIFF
--- a/src/components/article/ArticleLayout.tsx
+++ b/src/components/article/ArticleLayout.tsx
@@ -46,7 +46,8 @@ export function ArticleLayout({
               size="micro"
               weight="font-bold"
               tracking="widest"
-              className="uppercase"
+              uppercase
+
             >
               {backLabel}
             </Text>

--- a/src/components/ui/MarkdownRenderer.tsx
+++ b/src/components/ui/MarkdownRenderer.tsx
@@ -138,11 +138,11 @@ export function MarkdownRenderer({ content }: MarkdownRendererProps) {
           ),
           ...Object.entries(CUSTOM_COMPONENTS).reduce((acc, [_, config]) => {
             config.tags.forEach(tag => {
-              const Component = config.component as any;
-              acc[tag] = (props: any) => <Component {...props} />;
+              const Component = config.component as React.ElementType;
+              acc[tag] = (props: Record<string, unknown>) => <Component {...props} />;
             });
             return acc;
-          }, {} as any)
+          }, {} as Record<string, React.ElementType>)
         }}
       >
         {content}

--- a/src/components/ui/ShareButton.tsx
+++ b/src/components/ui/ShareButton.tsx
@@ -1,0 +1,27 @@
+import { Stack, Text } from '@/layouts/Primitives';
+import { Share2 } from 'lucide-react';
+import { useShare } from '@/hooks/useShare';
+
+interface ShareButtonProps {
+  title: string;
+  text?: string;
+  url?: string;
+}
+
+export function ShareButton({ title, text, url }: ShareButtonProps) {
+  const { share } = useShare();
+
+  return (
+    <Stack
+      as="button"
+      direction="row"
+      onClick={() => share({ title, text, url })}
+      align="center"
+      gap={1.5}
+      className="text-text-dim/60 hover:text-accent transition-colors group/share"
+    >
+      <Share2 className="w-3.5 h-3.5" />
+      <Text variant="mono" size="micro" weight="font-bold" uppercase tracking="wider">SHARE</Text>
+    </Stack>
+  );
+}

--- a/src/features/events/EventGuide.tsx
+++ b/src/features/events/EventGuide.tsx
@@ -1,5 +1,6 @@
+import { ShareButton } from "@/components/ui/ShareButton";
 
-import { Share2, Sparkles } from 'lucide-react';
+import { Sparkles } from 'lucide-react';
 import { Box, Stack, Text } from '@/layouts/Primitives';
 import { SEO } from '@/components/SEO';
 
@@ -61,22 +62,7 @@ export function EventGuide() {
     );
   }
 
-  const share = () => {
-    if (navigator.share) {
-      navigator.share({
-        title: event.title,
-        text: event.excerpt,
-        url: window.location.href,
-      }).catch(console.error);
-    }
-  };
 
-  const shareAction = (
-    <Stack as="button" direction="row" onClick={share} align="center" gap={1.5} className="text-text-dim/60 hover:text-accent transition-colors">
-      <Share2 className="w-3.5 h-3.5" />
-      <Text variant="mono" size="micro" weight="font-bold" className="uppercase tracking-wider">SHARE</Text>
-    </Stack>
-  );
 
   const rt = event.readingTime || `${getReadingTime(event.content)} min read`;
 
@@ -116,7 +102,7 @@ export function EventGuide() {
           dek={event.dek || event.excerpt}
           author={event.author}
           authorAvatar={event.authorAvatar}
-          shareAction={shareAction}
+          shareAction=<ShareButton title={event.title} text={event.excerpt} />
           visual={heroVisual}
           tags={event.tags}
         />

--- a/src/features/journal/components/BlogPostDetail.tsx
+++ b/src/features/journal/components/BlogPostDetail.tsx
@@ -1,6 +1,7 @@
+import { ShareButton } from "@/components/ui/ShareButton";
 
-import { Share2 } from 'lucide-react';
-import { Stack, Text } from '@/layouts/Primitives';
+
+import { Stack } from '@/layouts/Primitives';
 
 import { ArticleLayout } from '@/components/article/ArticleLayout';
 import { PostHeader } from '@/components/article/PostHeader';
@@ -18,15 +19,6 @@ interface BlogPostDetailProps {
 }
 
 export function BlogPostDetail({ post, onBack, backLabel }: BlogPostDetailProps) {
-  const share = () => {
-    if (navigator.share) {
-      navigator.share({
-        title: post.title,
-        text: post.excerpt,
-        url: window.location.href,
-      }).catch(console.error);
-    }
-  };
 
   const rt = post.readingTime || `${readingTime(post.content)} min read`;
 
@@ -42,19 +34,6 @@ export function BlogPostDetail({ post, onBack, backLabel }: BlogPostDetailProps)
     <ArticleFeatureCard image={post.image} />
   ) : null;
 
-  const shareAction = (
-    <Stack
-      as="button"
-      direction="row"
-      onClick={share}
-      align="center"
-      gap={1.5}
-      className="text-text-dim/60 hover:text-accent transition-colors group/share"
-    >
-      <Share2 className="w-3.5 h-3.5" />
-      <Text variant="mono" size="micro" weight="font-bold" className="uppercase tracking-wider">SHARE</Text>
-    </Stack>
-  );
 
   return (
     <ArticleLayout
@@ -70,7 +49,7 @@ export function BlogPostDetail({ post, onBack, backLabel }: BlogPostDetailProps)
           tags={post.tags}
           author={post.author}
           authorAvatar={post.authorAvatar}
-          shareAction={shareAction}
+          shareAction=<ShareButton title={post.title} text={post.excerpt} />
           visual={heroVisual}
         />
       }

--- a/src/features/lab/components/GearPostDetail.tsx
+++ b/src/features/lab/components/GearPostDetail.tsx
@@ -1,6 +1,7 @@
+import { ShareButton } from "@/components/ui/ShareButton";
 
-import { Share2 } from 'lucide-react';
-import { Stack, Text } from '@/layouts/Primitives';
+
+import { Stack } from '@/layouts/Primitives';
 import { ArticleLayout } from '@/components/article/ArticleLayout';
 import { PostHeader } from '@/components/article/PostHeader';
 import { ArticleFeatureCard } from '@/components/article/ArticleFeatureCard';
@@ -17,22 +18,7 @@ interface GearPostDetailProps {
 }
 
 export function GearPostDetail({ post, onBack, backLabel }: GearPostDetailProps) {
-  const share = () => {
-    if (navigator.share) {
-      navigator.share({
-        title: post.title,
-        text: post.excerpt,
-        url: window.location.href,
-      }).catch(console.error);
-    }
-  };
 
-  const shareAction = (
-    <Stack as="button" direction="row" onClick={share} align="center" gap={1.5} className="text-text-dim/60 hover:text-accent transition-colors">
-      <Share2 className="w-3.5 h-3.5" />
-      <Text variant="mono" size="micro" weight="font-bold" className="uppercase tracking-wider">SHARE</Text>
-    </Stack>
-  );
 
   const rt = post.readingTime || `${readingTime(post.content)} min read`;
 
@@ -49,7 +35,7 @@ export function GearPostDetail({ post, onBack, backLabel }: GearPostDetailProps)
           dek={post.dek || post.excerpt}
           author={post.author}
           authorAvatar={post.authorAvatar}
-          shareAction={shareAction}
+          shareAction=<ShareButton title={post.title} text={post.excerpt} />
           visual={post.image ? <ArticleFeatureCard image={post.image} /> : null}
           tags={post.tags}
         />

--- a/src/hooks/useShare.ts
+++ b/src/hooks/useShare.ts
@@ -1,0 +1,21 @@
+import { useCallback } from 'react';
+
+interface ShareData {
+  title: string;
+  text?: string;
+  url?: string;
+}
+
+export function useShare() {
+  const share = useCallback((data: ShareData) => {
+    if (navigator.share) {
+      navigator.share({
+        title: data.title,
+        text: data.text,
+        url: data.url || window.location.href,
+      }).catch(console.error);
+    }
+  }, []);
+
+  return { share };
+}


### PR DESCRIPTION
This applies the requested anti-pattern feedback from the latest PR comment to ensure that `ShareButton.tsx` uses the explicit `uppercase` prop on the `Text` primitive instead of supplying it as a raw `className`. Tests and linting verified locally.

---
*PR created automatically by Jules for task [14741124206488620966](https://jules.google.com/task/14741124206488620966) started by @arii*