### PR TITLE
Fix syntax errors and duplicate imports causing CI failures

### DIFF
--- a/src/features/research/ResearchAnalytics.tsx
+++ b/src/features/research/ResearchAnalytics.tsx
@@ -1,9 +1,7 @@
 import { Icon } from '@/components/ui/Icon';
-import { useNavigate } from 'react-router-dom';
-import { Search, ArrowRight, Activity, FileText, Cpu, LucideIcon, ExternalLink, Github, Globe, Clock } from 'lucide-react';
 import { useNavigate, NavLink } from 'react-router-dom';
 import { routes } from '@/config/routes';
-import { Search, ArrowRight, Activity, FileText, Cpu, LucideIcon, ExternalLink, Github, Globe, Send, Terminal, Layout, Workflow, Code, Zap, Microscope, SearchCode, Database, Rocket } from 'lucide-react';
+import { Search, ArrowRight, Activity, FileText, Cpu, LucideIcon, ExternalLink, Github, Globe, Clock, Send, Terminal, Layout, Workflow, Code, Zap, Microscope, SearchCode, Database, Rocket } from 'lucide-react';
 import { Box, Stack, Text, Grid } from '@/layouts/Primitives';
 import { SEO } from '@/components/SEO';
 import { PageHeader } from '@/components/ui/PageHeader';

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -69,7 +69,6 @@ function normalizeReadTime(val: unknown): number | undefined {
   return undefined;
 }
 
-function transform<T extends { date?: string; draft?: boolean; type?: string; status?: string }>(
 export function normalizeAsset(val: unknown) {
   if (val === "" || val === undefined || val === null) return undefined;
   if (typeof val !== "string") return val;


### PR DESCRIPTION
Fixes CI build failures in the repo. 

This PR resolves duplicate variable declarations in `ResearchAnalytics.tsx` by consolidating duplicate imports from `lucide-react` and `react-router-dom`. It also fixes a malformed and incomplete `transform` function signature floating in `src/lib/content.ts` that was interrupting the export of `normalizeAsset`.

Tests, builds, and oxlint now run successfully.

---
*PR created automatically by Jules for task [8331990217887391867](https://jules.google.com/task/8331990217887391867) started by @arii*