### PR TITLE
fix: preview dashboard redirect loop

### DIFF
--- a/public/previews/index.html
+++ b/public/previews/index.html
@@ -107,7 +107,7 @@
         </footer>
     </div>
 <script>
-  if (!window.location.pathname.endsWith('/')) {
+  if (!window.location.pathname.endsWith('/') && !window.location.pathname.endsWith('.html')) {
     window.location.replace(`${window.location.pathname}/${window.location.search}${window.location.hash}`);
   }
 </script>


### PR DESCRIPTION
Fixes the infinite trailing slash redirect loop in `public/previews/index.html` which occurred when visiting `.html` files directly. This fixes the Playwright test timeouts on the Preview Dashboard.

---
*PR created automatically by Jules for task [8148298237971985730](https://jules.google.com/task/8148298237971985730) started by @arii*