### PR TITLE
Refactor verbose comments from dev-tools

### DIFF
--- a/dev-tools/tdw_services/orchestrator.py
+++ b/dev-tools/tdw_services/orchestrator.py
@@ -129,12 +129,7 @@ class Orchestrator:
         replace: bool = False,
         dry_run: bool = True,
     ) -> Dict[str, Any]:
-        """Post top-level PR comments parsed from a markdown review snapshot.
-
-        The default is a local-only dry run. Executed runs add a stable marker to each
-        comment so rerunning the command is idempotent. Use ``replace`` to update a
-        previously posted comment instead of skipping it.
-        """
+        """Post top-level PR comments parsed from a markdown review snapshot."""
         parsed_comments = self.parse_pr_review_comments(file_path)
         selected_numbers = pr_numbers or list(parsed_comments)
         missing_numbers = sorted(set(selected_numbers) - set(parsed_comments))

--- a/dev-tools/tdw_services/services/github.py
+++ b/dev-tools/tdw_services/services/github.py
@@ -90,17 +90,13 @@ class GitHubClient:
             return []
 
     def fetch_check_run_logs(self, check_run_id: int, external_id: Optional[str] = None) -> str:
-        """Fetches logs for a specific check run, using external_id (job_id) if available. Gracefully fallback to check_run_id if external_id 404s."""
-        # Ensure we have a valid ID and it's a string for the URL path
+        """Fetches logs for a specific check run."""
         job_id = str(external_id) if external_id is not None else str(check_run_id)
         try:
-            # GitHub API returns a 302 redirect to a URL that expires after a few minutes
-            # We explicitly set Accept to None or a generic type to avoid the .diff default in _request
             return self._request('GET', f'/repos/{self.repo}/actions/jobs/{job_id}/logs', is_text=True, accept="application/vnd.github.v3+json", allow_redirects=True)
         except Exception as e:
             error_msg = str(e)
             if external_id is not None and "404" in error_msg:
-                # Fallback to query by raw check_run_id
                 job_id = str(check_run_id)
                 try:
                     return self._request('GET', f'/repos/{self.repo}/actions/jobs/{job_id}/logs', is_text=True, accept="application/vnd.github.v3+json")


### PR DESCRIPTION
Removed overly verbose comments that explained "how" code works, complying with strict PR feedback to only keep comments explaining "why". Modified `orchestrator.py` and `github.py` to remove detailed mechanical explanations from docstrings. Verified functionality to ensure zero side-effects.

---
*PR created automatically by Jules for task [1684357747656547240](https://jules.google.com/task/1684357747656547240) started by @arii*