### PR TITLE
Fix React Router v7 hydration and enable future flags

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,7 @@ import { getSkeletonVariant } from './lib/utils';
 
 export function HydrateFallback() {
   return (
-    <Box as="main" id="main-content" width="full" minHeight="screen" surface="bg" display="flex" align="center" justify="center">
+    <Box id="loading-spinner" width="full" minHeight="screen" surface="bg" display="flex" align="center" justify="center">
       <Box
         width={8}
         height={8}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,19 @@ import { Box } from './layouts/Primitives';
 import { motionTokens } from './styles/motion';
 import { getSkeletonVariant } from './lib/utils';
 
+export function HydrateFallback() {
+  return (
+    <Box as="main" id="main-content" width="full" minHeight="screen" surface="bg" display="flex" align="center" justify="center">
+      <Box
+        width={8}
+        height={8}
+        radius="full"
+        className="border-4 border-accent border-t-transparent animate-spin"
+      />
+    </Box>
+  );
+}
+
 export function RootLayout() {
   const location = useLocation();
 
@@ -97,6 +110,7 @@ export const routes = [
   {
     path: '/',
     element: <RootLayout />,
+    HydrateFallback: HydrateFallback,
     errorElement: <GlobalErrorBoundary />,
     children: routeConfig.map((route) => ({
       ...route,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -76,6 +76,10 @@ const getBasename = (): string => {
 
 const router = createBrowserRouter(routes, {
   basename: getBasename(),
+  future: {
+    v7_startTransition: true,
+    v7_relativeSplatPath: true,
+  },
 });
 
 createRoot(document.getElementById('root')!).render(
@@ -85,6 +89,7 @@ createRoot(document.getElementById('root')!).render(
         <ThemeProvider>
           <RouterProvider
             router={router}
+            future={{ v7_startTransition: true }}
             fallbackElement={
               <Box as="main" id="main-content" width="full" minHeight="screen" surface="bg" display="flex" align="center" justify="center">
                 <Box

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -91,7 +91,7 @@ createRoot(document.getElementById('root')!).render(
             router={router}
             future={{ v7_startTransition: true }}
             fallbackElement={
-              <Box as="main" id="main-content" width="full" minHeight="screen" surface="bg" display="flex" align="center" justify="center">
+              <Box id="loading-spinner" width="full" minHeight="screen" surface="bg" display="flex" align="center" justify="center">
                 <Box
                   width={8}
                   height={8}


### PR DESCRIPTION
This PR fixes the "No HydrateFallback element provided" error and ensures proper hydration behavior for the React Router v7 SPA.

Key changes:
- Added a `HydrateFallback` component to `src/App.tsx` and registered it on the root route.
- Enabled `v7_startTransition` and `v7_relativeSplatPath` future flags in `src/main.tsx` for both `createBrowserRouter` and `RouterProvider`.
- Verified that hydration warnings are gone and the app renders correctly via Playwright.
- Confirmed that all existing tests pass.

Fixes #1807

---
*PR created automatically by Jules for task [3465295103503191560](https://jules.google.com/task/3465295103503191560) started by @arii*