### PR TITLE
fix(affiliate): Update amazon disclosure and product links

### DIFF
--- a/content/posts/2026-04-19-gear-essentials.md
+++ b/content/posts/2026-04-19-gear-essentials.md
@@ -12,7 +12,7 @@ author: "Ariel Anders, PhD"
 affiliateIds:
   - "loop-experience"
   - "portable-steamer"
-  - "portable-speaker"
+  - "jbl-flip-6"
   - "portable-charger"
 ---
 
@@ -60,6 +60,6 @@ Because social dancing often runs until 4:00 AM or 5:00 AM, many dancers find th
 
 ### Miscellaneous Tech & Tools
 - **High-capacity power bank:** Your phone battery can drain quickly from recording workshop recaps, taking videos of friends, and looking up late-night songs.
-<notice type="affiliate" id="portable-speaker" />
+<notice type="affiliate" id="jbl-flip-6" />
 <notice type="affiliate" id="portable-charger" />
 - **Emergency utility kit:** Pack a few safety pins, a travel sewing kit, and spare earring back stoppers in case of a wardrobe malfunction.

--- a/content/posts/2026-04-19-gear-essentials.md
+++ b/content/posts/2026-04-19-gear-essentials.md
@@ -19,47 +19,47 @@ affiliateIds:
 > Here is a practical packing checklist for a smoother West Coast Swing weekend, based on common dancer pain points: sore feet, loud ballrooms, sweaty workshops, cold hotel spaces, and late-night social dancing.
 
 ### Footwear & Shoe Care
-- [ ] **At least two pairs of dance shoes:** Rotating your shoes once or twice a day gives your feet a "change of scenery" and prevents intense soreness from pressure points. Suede-soled shoes (like Latin practice heels or practice sandals) are standard.
-- [ ] **Suede shoe brush:** Helpful for cleaning off dirt and restoring grip if the ballroom floor gets slick or dusty.
-- [ ] **Shoe glue:** For emergency repairs if a sole starts peeling mid-event.
-- [ ] **Friction protection:** Blister care pads, athletic tape, or friction-reducing sticks. If you wear open-toed dance sandals, bringing sock-length nylons can prevent strap friction and blisters.
-- [ ] **Baking soda or baby powder:** To dry out damp shoes and eliminate odor after hours of dancing.
+- **At least two pairs of dance shoes:** Rotating your shoes once or twice a day gives your feet a "change of scenery" and prevents intense soreness from pressure points. Suede-soled shoes (like Latin practice heels or practice sandals) are standard.
+- **Suede shoe brush:** Helpful for cleaning off dirt and restoring grip if the ballroom floor gets slick or dusty.
+- **Shoe glue:** For emergency repairs if a sole starts peeling mid-event.
+- **Friction protection:** Blister care pads, athletic tape, or friction-reducing sticks. If you wear open-toed dance sandals, bringing sock-length nylons can prevent strap friction and blisters.
+- **Baking soda or baby powder:** To dry out damp shoes and eliminate odor after hours of dancing.
 
 ### Apparel (The Sweat & Temperature Strategy)
-- [ ] **10 to 15 shirts:** Many dancers find they sweat much more than expected. Plan on bringing extra t-shirts for classes and workshops, and changing into fresh, nice shirts for social dancing. Darker or busy patterned shirts are often helpful because they hide underarm sweat patches.
-- [ ] **Synthetic pants/trousers:** Stretchy slacks or synthetic dress pants drape nicely, don't restrict your leg movement, and pack easily. Avoid heavy denim jeans—they can trap heat, restrict motion, and take too long to dry if you need to wash them.
-- [ ] **A warm hoodie or light jacket:** Ballrooms are often heavily air-conditioned and can be cold during workshops, competitions, or whenever you are sitting still.
-- [ ] **Double your socks and underwear:** Plan on showering and changing 2 to 3 times a day (after daytime workshops, before evening social dancing, etc.).
-- [ ] **Travel laundry detergent sheets:** Synthetic activewear can easily be washed in your hotel sink and will dry overnight if you run low on clean clothes.
+- **10 to 15 shirts:** Many dancers find they sweat much more than expected. Plan on bringing extra t-shirts for classes and workshops, and changing into fresh, nice shirts for social dancing. Darker or busy patterned shirts are often helpful because they hide underarm sweat patches.
+- **Synthetic pants/trousers:** Stretchy slacks or synthetic dress pants drape nicely, don't restrict your leg movement, and pack easily. Avoid heavy denim jeans—they can trap heat, restrict motion, and take too long to dry if you need to wash them.
+- **A warm hoodie or light jacket:** Ballrooms are often heavily air-conditioned and can be cold during workshops, competitions, or whenever you are sitting still.
+- **Double your socks and underwear:** Plan on showering and changing 2 to 3 times a day (after daytime workshops, before evening social dancing, etc.).
+- **Travel laundry detergent sheets:** Synthetic activewear can easily be washed in your hotel sink and will dry overnight if you run low on clean clothes.
 <notice type="affiliate" id="portable-steamer" />
 
 ### Ballroom Bag (On-the-Floor Essentials)
 Keep a small backpack or messenger bag with you in the ballroom so you don't have to keep walking back to your room for essentials:
-- [ ] **A small sweat towel:** Useful for wiping down your face and arms between dances.
-- [ ] **A handheld fan:** A battery-powered fan or a manual folding fan is helpful for cooling down on the sidelines.
-- [ ] **High-fidelity earplugs:** Ballroom sound systems can be loud. Dampening earplugs (like Loops) protect your hearing while still letting you hear the music and talk to your partners.
+- **A small sweat towel:** Useful for wiping down your face and arms between dances.
+- **A handheld fan:** A battery-powered fan or a manual folding fan is helpful for cooling down on the sidelines.
+- **High-fidelity earplugs:** Ballroom sound systems can be loud. Dampening earplugs (like Loop Experience 2) protect your hearing while still letting you hear the music and talk to your partners.
 <notice type="affiliate" id="loop-experience" />
-- [ ] **Reusable water bottle & electrolyte packets:** Powdered mixes (like Liquid I.V.) help prevent muscle cramps and dehydration from hours of active sweating.
+- **Reusable water bottle & electrolyte packets:** Powdered mixes (like Liquid I.V.) help prevent muscle cramps and dehydration from hours of active sweating.
 
 ### Hygiene & Close-Connection Etiquette
-- [ ] **Deodorant / Antiperspirant:** WCS is an intimate, close-proximity partner dance. Use a strong combination of both and reapply often.
-- [ ] **Breath mints or gum:** Keep your breath fresh throughout long nights.
-- [ ] **Hand sanitizer:** Keep a travel-sized bottle in your bag and sanitize your hands every few dances to avoid getting sick.
+- **Deodorant / Antiperspirant:** WCS is an intimate, close-proximity partner dance. Use a strong combination of both and reapply often.
+- **Breath mints or gum:** Keep your breath fresh throughout long nights.
+- **Hand sanitizer:** Keep a travel-sized bottle in your bag and sanitize your hands every few dances to avoid getting sick.
 
 ### Recovery & Downtime
-- [ ] **A swimsuit:** Early morning hot tub/jacuzzi hangouts are a common social tradition at swing events and can be a great way to soothe aching muscles.
-- [ ] **A lacrosse ball or hollow foam roller:** Useful for rolling out tight arches, calves, and lower back muscles.
-- [ ] **Pain relievers:** Standard over-the-counter anti-inflammatories (like ibuprofen or paracetamol) for sore joints and sleep-deprivation headaches.
-- [ ] **Protein bars & quick snacks:** Keep nuts, fruit, or protein bars in your room and bag. You may get hungry at 3:00 AM when hotel restaurants are closed.
+- **A swimsuit:** Early morning hot tub/jacuzzi hangouts are a common social tradition at swing events and can be a great way to soothe aching muscles.
+- **A lacrosse ball or hollow foam roller:** Useful for rolling out tight arches, calves, and lower back muscles.
+- **Pain relievers:** Standard over-the-counter anti-inflammatories (like ibuprofen or paracetamol) for sore joints and sleep-deprivation headaches.
+- **Protein bars & quick snacks:** Keep nuts, fruit, or protein bars in your room and bag. You may get hungry at 3:00 AM when hotel restaurants are closed.
 
 ### Daytime Sleep Gear (Circadian Sleep)
 Because social dancing often runs until 4:00 AM or 5:00 AM, many dancers find they need to sleep while the sun is up:
-- [ ] **A contoured sleep mask:** Often helpful to block out bright morning sunlight.
-- [ ] **Silencing earplugs:** To block out daytime hotel hallway noise and roommates moving around.
-- [ ] **Clothes pins or binder clips:** A great travel hack to clamp the hotel's blackout curtains completely shut and block annoying light leaks.
+- **A contoured sleep mask:** Often helpful to block out bright morning sunlight.
+- **Silencing earplugs:** To block out daytime hotel hallway noise and roommates moving around.
+- **Clothes pins or binder clips:** A great travel hack to clamp the hotel's blackout curtains completely shut and block annoying light leaks.
 
 ### Miscellaneous Tech & Tools
-- [ ] **High-capacity power bank:** Your phone battery can drain quickly from recording workshop recaps, taking videos of friends, and looking up late-night songs.
+- **High-capacity power bank:** Your phone battery can drain quickly from recording workshop recaps, taking videos of friends, and looking up late-night songs.
 <notice type="affiliate" id="portable-speaker" />
 <notice type="affiliate" id="portable-charger" />
-- [ ] **Emergency utility kit:** Pack a few safety pins, a travel sewing kit, and spare earring back stoppers in case of a wardrobe malfunction.
+- **Emergency utility kit:** Pack a few safety pins, a travel sewing kit, and spare earring back stoppers in case of a wardrobe malfunction.

--- a/src/components/ui/AffiliateDisclosure.tsx
+++ b/src/components/ui/AffiliateDisclosure.tsx
@@ -4,9 +4,9 @@ interface AffiliateDisclosureProps {
   compact?: boolean;
 }
 
-export const DISCLOSURE_TEXT = 'As an Amazon Associate, this page contains affiliate links. We earn a commission if you make a purchase.';
+export const DISCLOSURE_TEXT = 'As an Amazon Associate, I earn from qualifying purchases.';
 
-const COMPACT_TEXT = 'Amazon affiliate link';
+const COMPACT_TEXT = 'As an Amazon Associate, I earn from qualifying purchases.';
 
 export function AffiliateDisclosure({ compact = false }: AffiliateDisclosureProps) {
   const text = compact ? COMPACT_TEXT : DISCLOSURE_TEXT;

--- a/src/data/affiliates.json
+++ b/src/data/affiliates.json
@@ -19,7 +19,7 @@
   },
   "loop-experience": {
     "id": "loop-experience",
-    "name": "Loop Experience Ear Plugs",
+    "name": "Loop Experience 2 Ear Plugs",
     "url": "https://www.amazon.com/dp/B0D4DZDHZ1?tag=onasafari04-20",
     "category": "gear",
     "description": "Helps soften loud ballroom sound while still letting you hear the music.",
@@ -454,8 +454,8 @@
   },
   "portable-speaker": {
     "id": "portable-speaker",
-    "name": "Portable Bluetooth Speaker (UE Wonderboom 4)",
-    "url": "https://www.amazon.com/dp/B0BRXJVG1S?tag=onasafari04-20",
+    "name": "JBL Flip 6",
+    "url": "https://www.amazon.com/dp/B09GK544PP?tag=onasafari04-20",
     "category": "gear",
     "description": "Rugged, waterproof, and surprisingly loud. Perfect for hotel practice sessions or outdoor social gatherings.",
     "gearSlug": "2024-01-01-portable-speaker",

--- a/src/data/affiliates.json
+++ b/src/data/affiliates.json
@@ -454,6 +454,16 @@
   },
   "portable-speaker": {
     "id": "portable-speaker",
+    "name": "Portable Bluetooth Speaker (UE Wonderboom 4)",
+    "url": "https://www.amazon.com/dp/B0BRXJVG1S?tag=onasafari04-20",
+    "category": "gear",
+    "description": "Rugged, waterproof, and surprisingly loud. Perfect for hotel practice sessions or outdoor social gatherings.",
+    "gearSlug": "2024-01-01-portable-speaker",
+    "image": "/images/gear/amazon/portable-speaker.jpg",
+    "imageMode": "contain"
+  },
+  "jbl-flip-6": {
+    "id": "jbl-flip-6",
     "name": "JBL Flip 6",
     "url": "https://www.amazon.com/dp/B09GK544PP?tag=onasafari04-20",
     "category": "gear",

--- a/src/features/journal/components/BlogPostDetail.tsx
+++ b/src/features/journal/components/BlogPostDetail.tsx
@@ -83,6 +83,7 @@ export function BlogPostDetail({ post, onBack, backLabel }: BlogPostDetailProps)
       sidebar={
         affiliateLinks.length > 0 ? (
           <Stack gap={6}>
+            <AffiliateDisclosure compact={true} />
             <Text as="h2" variant="mono" size="xs" weight="font-bold" color="dim" uppercase tracking="widest">
               Shop selected items
             </Text>
@@ -91,7 +92,6 @@ export function BlogPostDetail({ post, onBack, backLabel }: BlogPostDetailProps)
                 <AffiliateCard key={link.id} link={link} />
               ))}
             </Stack>
-            <AffiliateDisclosure compact={true} />
           </Stack>
         ) : undefined
       }


### PR DESCRIPTION
This PR updates the Amazon affiliate integration to strictly adhere to compliance policies:
1. Replaces generic disclosure text with the exact mandated wording: "As an Amazon Associate, I earn from qualifying purchases."
2. Moves the disclosure directly above the affiliate shop section in the blog post sidebar for better visibility.
3. Corrects product mismatches in `affiliates.json` by updating the JBL speaker to "JBL Flip 6" and the Loop earplugs to "Loop Experience 2 Ear Plugs", providing accurate Amazon ASINs.
4. Cleans up redundant `- [ ]` checkboxes in `content/posts/2026-04-19-gear-essentials.md`, converting them to standard bullet points.

---
*PR created automatically by Jules for task [7894114168654928421](https://jules.google.com/task/7894114168654928421) started by @arii*