### PR TITLE
Add lightweight RAG indexer and integrate retrieval into code review pipeline

### DIFF
--- a/dev-tools/tdw_services/cli.py
+++ b/dev-tools/tdw_services/cli.py
@@ -323,6 +323,19 @@ def review(ctx, pr_number, no_cache):
 
     out(ctx, f"✅ Generated review for PR #{pr_number}", data=res)
 
+@ai.command(name='index-rag')
+@click.option('--limit', type=int, default=30, help='Number of recently closed PRs to index')
+@click.option('--index-path', default=None, help='Path to the JSON vector index')
+@click.pass_context
+def index_rag(ctx, limit, index_path):
+    """Build the RepoAuditor RAG index from standards, closed PRs, and review comments."""
+    orch = ctx.obj['ORCHESTRATOR']
+    res = orch.build_review_rag_index(limit=limit, index_path=index_path)
+    msg = f"✅ RAG index built: {res['chunks']} chunks from {res['documents']} documents at {res['index_path']}"
+    if res.get('warning'):
+        msg += f" (partial: {res['warning']})"
+    out(ctx, msg, data=res)
+
 @ai.command()
 @click.argument('file')
 @click.pass_context

--- a/dev-tools/tdw_services/orchestrator.py
+++ b/dev-tools/tdw_services/orchestrator.py
@@ -11,6 +11,7 @@ from collections import defaultdict
 from tdw_services.services.github import GitHubClient
 from tdw_services.services.gemini import LocalAIClient
 from tdw_services.services.jules import JulesClient
+from tdw_services.services.rag import ReviewRAGStore, collect_spec_documents
 from tdw_services.handlers.command_handler import CommandHandler
 from utils import (
     get_github_token,
@@ -90,9 +91,110 @@ class Orchestrator:
         cache_file = f"/tmp/review_cache_{pr_number}_{diff_hash}.json"
         if os.path.exists(cache_file):
             with open(cache_file, 'r') as f: return json.load(f)
+
+        # Retrieval-augmented review context: use a local JSON vector index when
+        # present, and always make current CODEX/AGENTS standards available even
+        # before the first historical index has been built.
+        pr_details['ragContext'] = self.get_review_rag_context(pr_diff)
         review_result = self.ai.generate_code_review(pr_details, pr_diff)
         with open(cache_file, 'w') as f: json.dump(review_result, f)
         return review_result
+
+    def build_review_rag_index(self, limit: int = 30, index_path: str | None = None) -> Dict[str, Any]:
+        """Build a JSON-backed RAG index from standards, closed PRs, and review comments."""
+        store = ReviewRAGStore(index_path=index_path or os.environ.get("REVIEW_RAG_INDEX_PATH", ".agent/review-rag-index.json"))
+        documents = collect_spec_documents()
+        indexed_prs = 0
+        indexed_comments = 0
+        indexed_ci_failures = 0
+
+        try:
+            closed_pulls = self.github.fetch_closed_pulls(limit=limit) if limit > 0 else []
+            for pr in closed_pulls:
+                number = pr.get('number')
+                title = pr.get('title') or f"PR #{number}"
+                body = pr.get('body') or ""
+                merged = pr.get('merged_at') or ""
+                if body.strip():
+                    documents.append({
+                        "source_type": "pull_request",
+                        "title": f"PR #{number}: {title}",
+                        "text": body,
+                        "metadata": {"number": number, "url": pr.get('html_url'), "merged_at": merged},
+                    })
+                    indexed_prs += 1
+
+                for comment in self.github.fetch_pr_review_comments(number):
+                    body = comment.get('body') or ""
+                    if body.strip():
+                        documents.append({
+                            "source_type": "review_comment",
+                            "title": f"PR #{number} review comment: {title}",
+                            "text": body,
+                            "metadata": {"number": number, "url": comment.get('html_url'), "path": comment.get('path')},
+                        })
+                        indexed_comments += 1
+
+                for comment in self.github.fetch_pr_issue_comments(number):
+                    body = comment.get('body') or ""
+                    if body.strip():
+                        documents.append({
+                            "source_type": "pr_discussion",
+                            "title": f"PR #{number} discussion: {title}",
+                            "text": body,
+                            "metadata": {"number": number, "url": comment.get('html_url')},
+                        })
+                        indexed_comments += 1
+
+                head_sha = (pr.get('head') or {}).get('sha')
+                fix_commit = pr.get('merge_commit_sha') or head_sha
+                if head_sha:
+                    for run in self.github.fetch_check_runs(head_sha):
+                        if run.get('conclusion') != 'failure':
+                            continue
+                        logs = self.github.fetch_check_run_logs(run.get('id'), external_id=run.get('external_id'))
+                        findings = extract_failing_info(logs)
+                        if findings:
+                            failure_text = "\n".join(
+                                f"{item.get('type')}: {item.get('file')}:{item.get('line')} {item.get('message')}"
+                                for item in findings[:20]
+                            )
+                        else:
+                            failure_text = logs[-5000:]
+                        if failure_text.strip():
+                            documents.append({
+                                "source_type": "ci_failure",
+                                "title": f"PR #{number} CI failure: {run.get('name')}",
+                                "text": f"Failure observed on {head_sha}. Fix/merge commit after this failure: {fix_commit}.\n{failure_text}",
+                                "metadata": {"number": number, "check": run.get('name'), "fix_commit": fix_commit, "url": run.get('url')},
+                            })
+                            indexed_ci_failures += 1
+        except Exception as exc:
+            # Standards-only indexes are still valuable in token- or network-limited environments.
+            warning = str(exc)
+        else:
+            warning = None
+
+        chunk_count = store.replace(documents)
+        return {
+            "status": "success" if warning is None else "partial",
+            "index_path": store.index_path,
+            "documents": len(documents),
+            "chunks": chunk_count,
+            "pull_requests": indexed_prs,
+            "comments": indexed_comments,
+            "ci_failures": indexed_ci_failures,
+            "warning": warning,
+        }
+
+    def get_review_rag_context(self, diff: str, index_path: str | None = None) -> Dict[str, Any]:
+        """Retrieve historical and standards context for a PR diff."""
+        store = ReviewRAGStore(index_path=index_path or os.environ.get("REVIEW_RAG_INDEX_PATH", ".agent/review-rag-index.json"))
+        if not store.chunks:
+            # Review retrieval must be side-effect free: make standards available
+            # in memory without creating an untracked .agent index during review.
+            store.replace(collect_spec_documents(), persist=False)
+        return store.build_prompt_context(diff)
 
     def resolve_conflict(self, file_path: str) -> bool:
         """

--- a/dev-tools/tdw_services/services/gemini.py
+++ b/dev-tools/tdw_services/services/gemini.py
@@ -5,6 +5,7 @@ import json
 import re
 import requests
 from typing import Optional, Dict, Any, List
+from tdw_services.services.rag import format_chunks_for_prompt
 from utils import (
     call_ollama,
     is_ollama_available,
@@ -194,6 +195,7 @@ class LocalAIClient:
             f"- {c.get('name')}: {c.get('status')} ({c.get('conclusion','Pending')})"
             for c in checks
         ) if checks else "No checks found."
+        rag_context = pr.get('ragContext') or {}
 
         ci_failures = [c for c in checks if c.get('conclusion') == 'failure']
         has_ci_failures = bool(ci_failures)
@@ -210,6 +212,7 @@ class LocalAIClient:
         print(f"  Gemini fallback  : {'enabled' if self.use_gemini_fallback else 'DISABLED'}")
         print(f"  Diff size        : {len(diff):,} chars")
         print(f"  CI failures      : {failing_names}")
+        print(f"  RAG queries      : {len(rag_context.get('queries', []))}")
         print(f"{'='*60}\n")
 
         if not ollama_ok and not self.use_gemini_fallback:
@@ -254,7 +257,7 @@ class LocalAIClient:
             t0 = time.time()
             print(f"  [{i:>2}/{len(reviewable)}] 🤖 {label} ({chunk['added_lines']} added lines{', truncated' if chunk['truncated'] else ''}) …", end="", flush=True)
 
-            prompt = self._build_chunk_prompt(chunk, pr_title, checks_summary)
+            prompt = self._build_chunk_prompt(chunk, pr_title, checks_summary, rag_context)
             raw = None
             try:
                 raw = call_ollama(prompt, model=_REVIEW_MODEL, schema=_CHUNK_SCHEMA, max_retries=2)
@@ -297,7 +300,7 @@ class LocalAIClient:
         # ── Phase B: synthesis ────────────────────────────────────────────────
         print(f"🔗 Synthesising {len(file_reviews)} chunk review(s) → final verdict …", end="", flush=True)
         t0 = time.time()
-        final = self._synthesize_review(file_reviews, pr_num, pr_title, has_ci_failures, ci_failures)
+        final = self._synthesize_review(file_reviews, pr_num, pr_title, has_ci_failures, ci_failures, rag_context)
         elapsed = time.time() - t0
         print(f" done ({elapsed:.1f}s)\n", flush=True)
 
@@ -312,14 +315,20 @@ class LocalAIClient:
         self._write_review_file(pr_num, pr, final, chunks, file_reviews)
         return final
 
-    def _build_chunk_prompt(self, chunk: Dict, pr_title: str, checks_summary: str) -> str:
+    def _build_chunk_prompt(self, chunk: Dict, pr_title: str, checks_summary: str, rag_context: Optional[Dict] = None) -> str:
         trunc_note = "\n(Note: diff was truncated to fit context window)" if chunk.get('truncated') else ""
+        rag_context = rag_context or {}
+        relevant_context = format_chunks_for_prompt(rag_context.get('historical_chunks', []), max_chars=4500)
+        codex_context = format_chunks_for_prompt(rag_context.get('codex_chunks', []), max_chars=3500)
         return (
             f'You are a strict code reviewer. Review ONLY the diff below for file "{chunk["file"]}".\n'
             f'PR title: {pr_title}\n'
             f'CI status: {checks_summary}\n\n'
+            f'RELEVANT HISTORICAL CONTEXT (retrieved from past PRs, review comments, and CI logs):\n{relevant_context}\n\n'
+            f'CODING STANDARDS (from CODEX.md / AGENTS.md):\n{codex_context}\n\n'
             f'Rules:\n'
             f'- Flag ONLY real problems: bugs, type unsafety, broken logic, design rule violations.\n'
+            f'- Flag contradictions with retrieved historical decisions or documented standards.\n'
             f'- Use severity "error" for blocking issues, "warn" for improvements, "info" for nits.\n'
             f'- Set verdict to "ok" (no issues), "needs_changes" (warn/info only), or "blocking" (any error).\n'
             f'- Output ONLY valid JSON. No prose, no markdown outside the JSON.\n\n'
@@ -403,6 +412,7 @@ class LocalAIClient:
         pr_title: str,
         has_ci_failures: bool,
         ci_failures: List[Dict],
+        rag_context: Optional[Dict] = None,
     ) -> Dict:
         """Call the lighter llama3.2 model to produce the final verdict from structured per-chunk data."""
         total_issues = sum(len(fr.get('issues', [])) for fr in file_reviews)
@@ -426,9 +436,15 @@ class LocalAIClient:
         if has_ci_failures:
             ci_note = f"\nCI FAILURES: {', '.join(c.get('name','?') for c in ci_failures)} – must NOT recommend Approved.\n"
 
+        rag_context = rag_context or {}
+        relevant_context = format_chunks_for_prompt(rag_context.get('historical_chunks', []), max_chars=3000)
+        codex_context = format_chunks_for_prompt(rag_context.get('codex_chunks', []), max_chars=2500)
+
         prompt = (
             f"You are summarising a code review for PR #{pr_num} – \"{pr_title}\".\n"
             f"{ci_note}\n"
+            f"RELEVANT HISTORICAL CONTEXT:\n{relevant_context}\n\n"
+            f"CODING STANDARDS:\n{codex_context}\n\n"
             f"Per-file results:\n"
             f"  Blocking : {blocking_files or 'none'}\n"
             f"  Needs changes: {needs_files or 'none'}\n"
@@ -437,6 +453,7 @@ class LocalAIClient:
             f"Total issues found: {total_issues}\n\n"
             f"Issue details:\n{findings_str if findings_str else '  (none)'}\n\n"
             f"Write a concise PR review body (reviewComment) summarising the above findings.\n"
+            f"Mention any contradictions with historical context or documented standards when present.\n"
             f"Choose recommendation: 'Approved', 'Approved with Minor Changes', or 'Not Approved'.\n"
             f"Suggest 1-3 labels (e.g. 'needs-changes', 'lgtm', 'ci-failing').\n"
             f"Output ONLY valid JSON, no prose outside it."

--- a/dev-tools/tdw_services/services/github.py
+++ b/dev-tools/tdw_services/services/github.py
@@ -61,6 +61,22 @@ class GitHubClient:
         except requests.exceptions.RequestException as e:
              raise Exception(f"GitHub API Error: {e}")
 
+
+    def fetch_closed_pulls(self, limit: int = 30) -> List[Dict[str, Any]]:
+        """Fetch recently closed pull requests for RAG indexing."""
+        pulls = self._request('GET', f'/repos/{self.repo}/pulls?state=closed&sort=updated&direction=desc&per_page={limit}')
+        return pulls if isinstance(pulls, list) else []
+
+    def fetch_pr_review_comments(self, number: int) -> List[Dict[str, Any]]:
+        """Fetch review comments left on a pull request."""
+        comments = self._request('GET', f'/repos/{self.repo}/pulls/{number}/comments?per_page=100')
+        return comments if isinstance(comments, list) else []
+
+    def fetch_pr_issue_comments(self, number: int) -> List[Dict[str, Any]]:
+        """Fetch conversation comments on a pull request issue thread."""
+        comments = self._request('GET', f'/repos/{self.repo}/issues/{number}/comments?per_page=100')
+        return comments if isinstance(comments, list) else []
+
     def fetch_pr_files(self, number: int) -> List[Dict[str, Any]]:
         """Fetches the list of files changed in a PR."""
         return self._request('GET', f'/repos/{self.repo}/pulls/{number}/files')

--- a/dev-tools/tdw_services/services/rag.py
+++ b/dev-tools/tdw_services/services/rag.py
@@ -1,0 +1,286 @@
+"""Lightweight retrieval-augmented context for RepoAuditor reviews.
+
+The implementation intentionally avoids a separate vector database server. It stores
+chunk metadata and embeddings in a JSON file, while supporting Google AI
+`text-embedding-004` when an API key is available and a deterministic local
+fallback for tests/offline development.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+import requests
+
+DEFAULT_INDEX_PATH = ".agent/review-rag-index.json"
+DEFAULT_CHUNK_TOKENS = 500
+DEFAULT_EMBEDDING_DIMENSIONS = 96
+GOOGLE_EMBEDDING_MODEL = "text-embedding-004"
+
+_TOKEN_RE = re.compile(r"[A-Za-z0-9_./#:-]+")
+_DIFF_FILE_RE = re.compile(r"^\+\+\+ b/(.+)$", re.MULTILINE)
+_ADDED_LINE_RE = re.compile(r"^\+(?!\+\+)(.*)$", re.MULTILINE)
+
+
+@dataclass(frozen=True)
+class RAGChunk:
+    """A stored chunk of historical or standards context."""
+
+    id: str
+    source_type: str
+    title: str
+    text: str
+    metadata: Dict[str, Any]
+    embedding: List[float]
+
+    def to_json(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "source_type": self.source_type,
+            "title": self.title,
+            "text": self.text,
+            "metadata": self.metadata,
+            "embedding": self.embedding,
+        }
+
+    @classmethod
+    def from_json(cls, data: Dict[str, Any]) -> "RAGChunk":
+        return cls(
+            id=str(data.get("id", "")),
+            source_type=str(data.get("source_type", "unknown")),
+            title=str(data.get("title", "Untitled")),
+            text=str(data.get("text", "")),
+            metadata=dict(data.get("metadata", {})),
+            embedding=[float(v) for v in data.get("embedding", [])],
+        )
+
+
+class HashEmbeddingProvider:
+    """Deterministic embedding fallback for local/offline operation."""
+
+    def __init__(self, dimensions: int = DEFAULT_EMBEDDING_DIMENSIONS):
+        self.dimensions = dimensions
+
+    def embed(self, text: str) -> List[float]:
+        vector = [0.0] * self.dimensions
+        for token in tokenize(text):
+            digest = hashlib.sha256(token.encode("utf-8")).digest()
+            idx = int.from_bytes(digest[:4], "big") % self.dimensions
+            sign = 1.0 if digest[4] % 2 == 0 else -1.0
+            vector[idx] += sign
+        return normalize(vector)
+
+
+class GoogleEmbeddingProvider:
+    """Google AI embedding provider using `text-embedding-004`."""
+
+    def __init__(self, api_key: str, model: str = GOOGLE_EMBEDDING_MODEL):
+        self.api_key = api_key
+        self.model = model
+
+    def embed(self, text: str) -> List[float]:
+        url = f"https://generativelanguage.googleapis.com/v1beta/models/{self.model}:embedContent?key={self.api_key}"
+        payload = {"content": {"parts": [{"text": text}]}}
+        response = requests.post(url, json=payload, timeout=30)
+        response.raise_for_status()
+        values = response.json().get("embedding", {}).get("values", [])
+        return normalize([float(v) for v in values])
+
+
+class ResilientEmbeddingProvider:
+    """Prefers Google embeddings and falls back to deterministic hashes on errors."""
+
+    def __init__(self, api_key: Optional[str] = None):
+        self._google = GoogleEmbeddingProvider(api_key) if api_key else None
+        self._fallback = HashEmbeddingProvider()
+
+    def embed(self, text: str) -> List[float]:
+        if self._google:
+            try:
+                return self._google.embed(text)
+            except Exception:
+                pass
+        return self._fallback.embed(text)
+
+
+def tokenize(text: str) -> List[str]:
+    return [match.group(0).lower() for match in _TOKEN_RE.finditer(text or "")]
+
+
+def normalize(vector: Sequence[float]) -> List[float]:
+    norm = math.sqrt(sum(value * value for value in vector))
+    if norm == 0:
+        return [0.0 for _ in vector]
+    return [value / norm for value in vector]
+
+
+def cosine_similarity(left: Sequence[float], right: Sequence[float]) -> float:
+    if not left or not right:
+        return 0.0
+    size = min(len(left), len(right))
+    return sum(left[i] * right[i] for i in range(size))
+
+
+def chunk_text(text: str, max_tokens: int = DEFAULT_CHUNK_TOKENS) -> List[str]:
+    """Chunk text into roughly `max_tokens` token segments preserving order."""
+    words = (text or "").split()
+    if not words:
+        return []
+    return [" ".join(words[i : i + max_tokens]) for i in range(0, len(words), max_tokens)]
+
+
+def build_review_queries(diff: str, limit: int = 5) -> List[str]:
+    """Generate deterministic retrieval queries from a PR diff."""
+    files = _DIFF_FILE_RE.findall(diff or "")
+    added_lines = [line.strip() for line in _ADDED_LINE_RE.findall(diff or "") if line.strip()]
+    keywords = " ".join(tokenize(" ".join(added_lines[:80]))[:120])
+
+    queries: List[str] = []
+    if files:
+        queries.append("changed files " + " ".join(files[:20]))
+    if keywords:
+        queries.append("new code patterns " + keywords)
+
+    for file_path in files[:3]:
+        related = [line for line in added_lines if Path(file_path).stem.lower() in line.lower()][:20]
+        query = f"historical decisions and CI failures for {file_path}"
+        if related:
+            query += " " + " ".join(related)
+        queries.append(query)
+
+    if not queries and diff:
+        queries.append(diff[:1200])
+
+    deduped: List[str] = []
+    for query in queries:
+        if query not in deduped:
+            deduped.append(query)
+    return deduped[:limit]
+
+
+class ReviewRAGStore:
+    """JSON-backed vector store for RepoAuditor review context."""
+
+    def __init__(self, index_path: str = DEFAULT_INDEX_PATH, embedding_provider: Optional[Any] = None):
+        self.index_path = index_path
+        api_key = os.environ.get("GOOGLE_API_KEY") or os.environ.get("GEMINI_API_KEY")
+        self.embedding_provider = embedding_provider or ResilientEmbeddingProvider(api_key=api_key)
+        self.chunks: List[RAGChunk] = []
+        self.load()
+
+    def load(self) -> None:
+        if not os.path.exists(self.index_path):
+            self.chunks = []
+            return
+        try:
+            with open(self.index_path, "r", encoding="utf-8") as handle:
+                payload = json.load(handle)
+            self.chunks = [RAGChunk.from_json(item) for item in payload.get("chunks", [])]
+        except Exception:
+            self.chunks = []
+
+    def save(self) -> None:
+        Path(self.index_path).parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "version": 1,
+            "embedding_model": GOOGLE_EMBEDDING_MODEL,
+            "chunk_tokens": DEFAULT_CHUNK_TOKENS,
+            "chunks": [chunk.to_json() for chunk in self.chunks],
+        }
+        with open(self.index_path, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+
+    def replace(self, documents: Iterable[Dict[str, Any]], persist: bool = True) -> int:
+        self.chunks = []
+        for document in documents:
+            self.add_document(**document)
+        if persist:
+            self.save()
+        return len(self.chunks)
+
+    def add_document(self, source_type: str, title: str, text: str, metadata: Optional[Dict[str, Any]] = None) -> None:
+        for idx, chunk in enumerate(chunk_text(text)):
+            chunk_id = hashlib.sha256(f"{source_type}\0{title}\0{idx}\0{chunk}".encode("utf-8")).hexdigest()[:20]
+            self.chunks.append(
+                RAGChunk(
+                    id=chunk_id,
+                    source_type=source_type,
+                    title=title,
+                    text=chunk,
+                    metadata={**(metadata or {}), "chunk_index": idx},
+                    embedding=self.embedding_provider.embed(chunk),
+                )
+            )
+
+    def retrieve(self, queries: Sequence[str], top_k: int = 8, source_type: Optional[str] = None) -> List[Dict[str, Any]]:
+        scored: Dict[str, Tuple[float, RAGChunk]] = {}
+        query_embeddings = [self.embedding_provider.embed(query) for query in queries if query.strip()]
+        for chunk in self.chunks:
+            if source_type and chunk.source_type != source_type:
+                continue
+            score = max((cosine_similarity(query_embedding, chunk.embedding) for query_embedding in query_embeddings), default=0.0)
+            if score <= 0:
+                continue
+            current = scored.get(chunk.id)
+            if current is None or score > current[0]:
+                scored[chunk.id] = (score, chunk)
+        return [
+            {**chunk.to_json(), "score": score}
+            for score, chunk in sorted(scored.values(), key=lambda item: item[0], reverse=True)[:top_k]
+        ]
+
+    def build_prompt_context(self, diff: str, top_k: int = 8, standards_k: int = 4) -> Dict[str, Any]:
+        queries = build_review_queries(diff)
+        historical = self.retrieve(queries, top_k=top_k)
+        standards = self.retrieve(queries or ["repository coding standards CODEX AGENTS"], top_k=standards_k, source_type="coding_standard")
+        if not standards:
+            standards = [
+                {**chunk.to_json(), "score": 0.0}
+                for chunk in self.chunks
+                if chunk.source_type == "coding_standard"
+            ][:standards_k]
+        return {
+            "queries": queries,
+            "historical_chunks": [chunk for chunk in historical if chunk.get("source_type") != "coding_standard"],
+            "codex_chunks": standards,
+        }
+
+
+def collect_spec_documents(repo_root: str = ".") -> List[Dict[str, Any]]:
+    """Collect CODEX/AGENTS standards documents from the repository."""
+    documents: List[Dict[str, Any]] = []
+    for filename in ("CODEX.md", "AGENTS.md"):
+        path = Path(repo_root) / filename
+        if path.exists():
+            documents.append(
+                {
+                    "source_type": "coding_standard",
+                    "title": filename,
+                    "text": path.read_text(encoding="utf-8", errors="ignore"),
+                    "metadata": {"path": filename},
+                }
+            )
+    return documents
+
+
+def format_chunks_for_prompt(chunks: Sequence[Dict[str, Any]], max_chars: int = 6000) -> str:
+    """Render retrieved chunks compactly for LLM prompts."""
+    rendered: List[str] = []
+    used = 0
+    for chunk in chunks:
+        header = f"[{chunk.get('source_type', 'unknown')}] {chunk.get('title', 'Untitled')} (score={chunk.get('score', 0):.3f})"
+        text = str(chunk.get("text", "")).strip()
+        entry = f"{header}\n{text}"
+        if used + len(entry) > max_chars:
+            break
+        rendered.append(entry)
+        used += len(entry)
+    return "\n\n---\n\n".join(rendered) if rendered else "(none retrieved)"

--- a/tests/dev-tools/test_review_rag.py
+++ b/tests/dev-tools/test_review_rag.py
@@ -1,0 +1,188 @@
+import os
+import sys
+import tempfile
+from pathlib import Path
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../dev-tools')))
+
+from tdw_services.orchestrator import Orchestrator
+from tdw_services.services.gemini import LocalAIClient
+from tdw_services.services.rag import HashEmbeddingProvider, ReviewRAGStore, build_review_queries, chunk_text
+from tdw_services.cli import cli
+from click.testing import CliRunner
+
+
+class TestReviewRAG(unittest.TestCase):
+    def test_chunk_text_uses_roughly_500_token_segments(self):
+        chunks = chunk_text(' '.join(f'token{i}' for i in range(1100)), max_tokens=500)
+
+        self.assertEqual(len(chunks), 3)
+        self.assertEqual(len(chunks[0].split()), 500)
+        self.assertEqual(len(chunks[1].split()), 500)
+        self.assertEqual(len(chunks[2].split()), 100)
+
+    def test_build_review_queries_uses_changed_files_and_added_code(self):
+        diff = '+++ b/src/App.tsx\n+import { Stack } from "@/layouts"\n+querySelector("#bad")\n'
+
+        queries = build_review_queries(diff)
+
+        self.assertTrue(any('src/App.tsx' in query for query in queries))
+        self.assertTrue(any('queryselector' in query for query in queries))
+        self.assertLessEqual(len(queries), 5)
+
+    def test_store_retrieves_similar_historical_chunk(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = ReviewRAGStore(
+                index_path=os.path.join(tmpdir, 'index.json'),
+                embedding_provider=HashEmbeddingProvider(),
+            )
+            store.replace([
+                {
+                    'source_type': 'pull_request',
+                    'title': 'PR #10: fix DOM access',
+                    'text': 'Avoid querySelector in TSX components; use controlled React state instead.',
+                    'metadata': {'number': 10},
+                },
+                {
+                    'source_type': 'coding_standard',
+                    'title': 'CODEX.md',
+                    'text': 'Run pnpm run doctor before builds.',
+                    'metadata': {'path': 'CODEX.md'},
+                },
+            ])
+
+            results = store.retrieve(['querySelector DOM access controlled state'], top_k=1)
+
+            self.assertEqual(results[0]['title'], 'PR #10: fix DOM access')
+
+    def test_chunk_prompt_includes_rag_context_and_standards(self):
+        client = LocalAIClient()
+        prompt = client._build_chunk_prompt(
+            {'file': 'src/App.tsx', 'diff_text': '+querySelector("#bad")', 'truncated': False},
+            'Test PR',
+            'No checks found.',
+            {
+                'historical_chunks': [
+                    {
+                        'source_type': 'pull_request',
+                        'title': 'PR #9: remove DOM access',
+                        'text': 'Past decision: no querySelector in UI components.',
+                        'score': 0.9,
+                    }
+                ],
+                'codex_chunks': [
+                    {
+                        'source_type': 'coding_standard',
+                        'title': 'AGENTS.md',
+                        'text': 'No direct DOM access.',
+                        'score': 0.8,
+                    }
+                ],
+            },
+        )
+
+        self.assertIn('RELEVANT HISTORICAL CONTEXT', prompt)
+        self.assertIn('Past decision: no querySelector', prompt)
+        self.assertIn('CODING STANDARDS', prompt)
+        self.assertIn('No direct DOM access', prompt)
+
+    def test_build_review_rag_index_includes_ci_failure_logs_with_fix_commit(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            orch = Orchestrator()
+            orch._github = MagicMock()
+            orch._github.fetch_closed_pulls.return_value = [
+                {
+                    'number': 7,
+                    'title': 'Fix lint',
+                    'body': 'Repair lint failure.',
+                    'html_url': 'https://example.test/pull/7',
+                    'head': {'sha': 'abc123'},
+                    'merge_commit_sha': 'def456',
+                }
+            ]
+            orch._github.fetch_pr_review_comments.return_value = []
+            orch._github.fetch_pr_issue_comments.return_value = []
+            orch._github.fetch_check_runs.return_value = [
+                {'id': 11, 'external_id': None, 'name': 'lint', 'conclusion': 'failure', 'url': 'https://example.test/check/11'}
+            ]
+            orch._github.fetch_check_run_logs.return_value = 'src/App.tsx:10:5: no querySelector [eslint/no-restricted-syntax]'
+
+            result = orch.build_review_rag_index(limit=1, index_path=os.path.join(tmpdir, 'index.json'))
+            store = ReviewRAGStore(os.path.join(tmpdir, 'index.json'), embedding_provider=HashEmbeddingProvider())
+            ci_chunks = [chunk for chunk in store.chunks if chunk.source_type == 'ci_failure']
+
+            self.assertEqual(result['status'], 'success')
+            self.assertEqual(result['ci_failures'], 1)
+            self.assertEqual(len(ci_chunks), 1)
+            self.assertIn('def456', ci_chunks[0].text)
+
+
+    def test_get_review_rag_context_does_not_write_default_index_as_side_effect(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            old_cwd = os.getcwd()
+            try:
+                os.chdir(tmpdir)
+                Path('CODEX.md').write_text('Run doctor before testing.', encoding='utf-8')
+                Path('AGENTS.md').write_text('No direct DOM access.', encoding='utf-8')
+
+                context = Orchestrator().get_review_rag_context('+++ b/src/App.tsx\n+querySelector("#bad")\n')
+
+                self.assertFalse(Path('.agent/review-rag-index.json').exists())
+                self.assertGreaterEqual(len(context['codex_chunks']), 1)
+            finally:
+                os.chdir(old_cwd)
+
+    def test_limit_zero_builds_standards_index_without_github_calls(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            old_cwd = os.getcwd()
+            try:
+                os.chdir(tmpdir)
+                Path('CODEX.md').write_text('Runtime standard.', encoding='utf-8')
+                Path('AGENTS.md').write_text('Agent standard.', encoding='utf-8')
+                orch = Orchestrator()
+                orch._github = MagicMock()
+
+                result = orch.build_review_rag_index(limit=0, index_path='index.json')
+
+                self.assertEqual(result['status'], 'success')
+                self.assertEqual(result['pull_requests'], 0)
+                self.assertEqual(result['comments'], 0)
+                orch._github.fetch_closed_pulls.assert_not_called()
+                self.assertTrue(Path('index.json').exists())
+            finally:
+                os.chdir(old_cwd)
+
+
+    @patch('tdw_services.orchestrator.Orchestrator.build_review_rag_index')
+    def test_index_rag_cli_calls_orchestrator(self, mock_index):
+        mock_index.return_value = {
+            'status': 'success',
+            'index_path': '.agent/review-rag-index.json',
+            'documents': 2,
+            'chunks': 3,
+            'pull_requests': 0,
+            'comments': 0,
+            'warning': None,
+        }
+        result = CliRunner().invoke(cli, ['ai', 'index-rag', '--limit', '5'])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_index.assert_called_once_with(limit=5, index_path=None)
+
+    def test_build_review_rag_index_allows_standards_only_partial_index(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            orch = Orchestrator()
+            orch._github = MagicMock()
+            orch._github.fetch_closed_pulls.side_effect = RuntimeError('token unavailable')
+
+            result = orch.build_review_rag_index(limit=1, index_path=os.path.join(tmpdir, 'index.json'))
+
+            self.assertEqual(result['status'], 'partial')
+            self.assertGreaterEqual(result['documents'], 1)
+            self.assertIn('token unavailable', result['warning'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Motivation

- Provide retrieval-augmented context for automated PR reviews by indexing repository standards, recent closed PRs, review comments, and CI failure logs into a local JSON-backed vector store. 
- Surface historical decisions and coding standards to the LLM-based reviewer so reviews can reference prior context and detect contradictions.

### Description

- Add a new RAG service at `dev-tools/tdw_services/services/rag.py` implementing `ReviewRAGStore`, deterministic/local embedding fallback, query generation, chunking, retrieval, and prompt formatting. 
- Add orchestrator integration methods `build_review_rag_index` and `get_review_rag_context` to `Orchestrator` to build a standards+history index and to produce retrieval context for a PR diff. 
- Extend the GitHub client with `fetch_closed_pulls`, `fetch_pr_review_comments`, and `fetch_pr_issue_comments` to collect documents for indexing. 
- Wire the retrieval context into the review pipeline by passing `ragContext` from `Orchestrator.review_pr` to `LocalAIClient.generate_code_review` and updating chunk and synthesis prompt builders to include formatted historical and CODEX/AGENTS context via `format_chunks_for_prompt`. 
- Add CLI command `ai index-rag` in `dev-tools/tdw_services/cli.py` to build the index from the command line and report chunk/document counts.

### Testing

- Added unit tests in `tests/dev-tools/test_review_rag.py` covering chunking, query generation, store retrieval, CI-failure indexing, side-effect free context retrieval, CLI invocation, and partial (standards-only) index behavior, and these tests passed. 
- The CLI integration path was exercised via a `CliRunner` test that called `ai index-rag` and verified `Orchestrator.build_review_rag_index` was invoked successfully. 
- Embedding fallback behavior and retrieval were validated using the deterministic `HashEmbeddingProvider` in tests and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20d64364048325aabaae8f7219782b)