### PR TITLE
Fix GitHub Actions deploy job for branch previews

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -195,11 +195,8 @@ jobs:
             fi
 
             # 5. Prune stale previews and update metadata
-            # We copy the script to the current directory to run it easily
-            cp "$GITHUB_WORKSPACE/scripts/manage-previews.sh" ./manage-previews.sh
-            chmod +x ./manage-previews.sh
-            ./manage-previews.sh ../open_prs.txt
-            rm ./manage-previews.sh
+            # We run the script directly from the workspace
+            bash "$GITHUB_WORKSPACE/scripts/manage-previews.sh" ../open_prs.txt
 
             # Use the latest dashboard UI from the current deployment
             cp ../dist-assets/previews/index.html previews/index.html


### PR DESCRIPTION
- Fixed the GitHub Actions deploy job (`deploy.yml`) to call `bash "$GITHUB_WORKSPACE/scripts/manage-previews.sh"` directly instead of copying, chmodding, and removing the script manually.
- Ensured the code is verified locally and passes lint, types, and unit tests.
- Re-confirmed that PR #1860 is the canonical approach as requested.

---
*PR created automatically by Jules for task [17219461281092627151](https://jules.google.com/task/17219461281092627151) started by @arii*