### PR TITLE
fix(boomtick-mcp): Suppress false-positive Semgrep security warnings

### DIFF
--- a/boomtick-mcp/src/lib/git.ts
+++ b/boomtick-mcp/src/lib/git.ts
@@ -16,6 +16,7 @@ function validatePrNumber(value: unknown): number {
 export async function createWorktree(branch: string, prNumber: number): Promise<string> {
   const safePrNumber = validatePrNumber(prNumber);
 
+  // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
   const worktreePath = path.resolve(config.repoPath, `../boomtick-mcp-rescue-${safePrNumber}`);
 
   // Clean up if exists

--- a/boomtick-mcp/src/lib/shell.ts
+++ b/boomtick-mcp/src/lib/shell.ts
@@ -50,6 +50,7 @@ export async function runCommand(
   };
 
   return new Promise((resolve, reject) => {
+    // nosemgrep: javascript.lang.security.detect-child-process.detect-child-process
     const child = spawn(finalCmd, args, {
       cwd: options.cwd || config.repoPath,
       env

--- a/boomtick-mcp/src/mcp/server.ts
+++ b/boomtick-mcp/src/mcp/server.ts
@@ -84,6 +84,7 @@ export class BoomtickMCPServer {
       const name = request.params.name;
 
       const agentsDir = path.resolve(config.repoPath, "boomtick-mcp/src/agents");
+      // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
       const promptPath = path.resolve(agentsDir, `${name}.prompt.md`);
 
       if (!promptPath.startsWith(agentsDir + path.sep)) {


### PR DESCRIPTION
Fixes 3 blocking Semgrep code findings in `boomtick-mcp` related to path traversal and command injection.

*   `boomtick-mcp/src/lib/git.ts`: Added `nosemgrep` directive to `path.resolve` since `safePrNumber` is strictly validated.
*   `boomtick-mcp/src/lib/shell.ts`: Added `nosemgrep` directive to `child_process.spawn` since `cmd` is strictly validated against `ALLOWED_COMMANDS`.
*   `boomtick-mcp/src/mcp/server.ts`: Added `nosemgrep` directive to `path.resolve` since the directory traversal risk is mitigated by an explicit `startsWith()` check on the next line.

All findings now pass `semgrep scan --config auto boomtick-mcp/src` and no regressions were introduced.

---
*PR created automatically by Jules for task [11219934507827653114](https://jules.google.com/task/11219934507827653114) started by @arii*