### PR TITLE
fix: resolve data.json fetch issue on previews dashboard

### DIFF
--- a/public/previews/dashboard.js
+++ b/public/previews/dashboard.js
@@ -439,8 +439,17 @@ async function init() {
             grid.before(warning);
         }
 
-        const dataRes = await fetch('./data.json').catch(() => ({ json: () => ({}) }));
-        const metadata = await dataRes.json();
+        const dataUrl = new URL('data.json', window.location.href);
+        const dataRes = await fetch(dataUrl).catch(() => ({ text: () => ('{}'), url: 'fallback' }));
+        const text = await dataRes.text();
+        let metadata = {};
+        try {
+            metadata = JSON.parse(text);
+        } catch (err) {
+            console.error('data.json parse failed');
+            console.error('URL:', dataRes.url);
+            console.error('Response starts with:', text.slice(0, 500));
+        }
 
         const allFoldersRaw = Array.from(new Set(treeData.tree
             .filter(i => i.path.endsWith('/index.html') && !EXCLUDED.some(e => i.path.startsWith(e)) && i.path !== 'index.html' && i.path !== '404.html')


### PR DESCRIPTION
This change addresses a routing/path resolution issue in `public/previews/dashboard.js` where `fetch('./data.json')` was returning an HTML fallback instead of JSON under certain deployment conditions, leading to a parsing error (`Unexpected token '<'`).

The fix explicitly constructs an absolute URL using `new URL('data.json', window.location.href)` to prevent relative path breakage. Additionally, it implements a safe JSON parsing mechanism with a `try-catch` block that logs the URL and response start on failure and falls back gracefully to `{}`.

---
*PR created automatically by Jules for task [15133717185729630419](https://jules.google.com/task/15133717185729630419) started by @arii*