### PR TITLE
ci: Fix gh-pages deploy concurrency cancellation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -104,10 +104,9 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     concurrency:
-      # Use a global concurrency group for all gh-pages writes to prevent conflicts
-      # and ensure sequential deployment across all branches.
-      group: gh-pages-deploy
-      cancel-in-progress: false
+      # Use a branch-specific concurrency group to prevent cancelling deployments from other branches
+      group: deploy-${{ github.ref }}
+      cancel-in-progress: true
     steps:
       - name: Checkout Branch
         uses: actions/checkout@v4

--- a/.github/workflows/prune-stale-previews.yml
+++ b/.github/workflows/prune-stale-previews.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch: # Allows manual triggering
 
 concurrency:
-  group: gh-pages-deploy
+  group: prune-stale-previews
   cancel-in-progress: false
 
 


### PR DESCRIPTION
This commit addresses the issue where branch preview deployments were being automatically canceled due to the shared \`gh-pages-deploy\` concurrency group in \`.github/workflows/deploy.yml\`.

Changes:
1. Updated \`.github/workflows/deploy.yml\` to use \`group: deploy-\${{ github.ref }}\` so concurrent branch previews don't cancel each other. The bash deploy script already handles \`git push\` retry conflicts.
2. Updated \`.github/workflows/prune-stale-previews.yml\` to use its own concurrency group (\`prune-stale-previews\`) since the global one was removed.
3. Removed \`.github/workflows/deploy-pages.yml\` to avoid concurrent deployment issues and ensure \`deploy.yml\` is the single deployment pipeline.

---
*PR created automatically by Jules for task [12755055088100818807](https://jules.google.com/task/12755055088100818807) started by @arii*