### PR TITLE
Fix unused import of MermaidDiagram in MarkdownRenderer

### DIFF
--- a/src/components/ui/MarkdownRenderer.tsx
+++ b/src/components/ui/MarkdownRenderer.tsx
@@ -166,28 +166,7 @@ export function MarkdownRenderer({ content }: MarkdownRendererProps) {
             const codeString = String(children).replace(/\n$/, '');
 
             if (isMermaid) {
-              try {
-                const bytes = new TextEncoder().encode(codeString);
-                let binary = '';
-                const len = bytes.byteLength;
-                for (let i = 0; i < len; i++) {
-                  binary += String.fromCharCode(bytes[i]);
-                }
-                const base64 = window.btoa(binary);
-                const diagramUrl = `https://mermaid.ink/svg/${base64}`;
-                return (
-                  <Box marginY={8} width="full" display="flex" justifyContent="center">
-                    <img
-                      src={diagramUrl}
-                      alt="Workflow Diagram"
-                      className="rounded-lg shadow-sm max-w-full max-h-[400px] object-contain"
-                      loading="lazy"
-                    />
-                  </Box>
-                );
-              } catch (e) {
-                console.error('Failed to render mermaid diagram', e);
-              }
+              return <MermaidDiagram code={codeString} />;
             }
 
             const isBlock = codeString.includes('\n') || !!language;

--- a/src/components/ui/MermaidDiagram.tsx
+++ b/src/components/ui/MermaidDiagram.tsx
@@ -36,9 +36,10 @@ let diagramCounter = 0;
 
 interface MermaidDiagramProps {
   code: string;
+  alt?: string;
 }
 
-export function MermaidDiagram({ code }: MermaidDiagramProps) {
+export function MermaidDiagram({ code, alt = 'Mermaid Diagram' }: MermaidDiagramProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [error, setError] = useState<string | null>(null);
   const idRef = useRef(`mermaid-${++diagramCounter}`);
@@ -58,11 +59,13 @@ export function MermaidDiagram({ code }: MermaidDiagramProps) {
 
         containerRef.current.innerHTML = svg;
 
-        // Make SVG responsive
+        // Make SVG responsive and accessible
         const svgEl = containerRef.current.querySelector('svg');
         if (svgEl) {
           svgEl.setAttribute('width', '100%');
           svgEl.style.maxWidth = '100%';
+          svgEl.setAttribute('role', 'img');
+          svgEl.setAttribute('aria-label', alt);
         }
       } catch (e) {
         if (!cancelled) {


### PR DESCRIPTION
This commit resolves the unused import issue for `MermaidDiagram` in `MarkdownRenderer.tsx`. The fix replaces the manual base64 encoding and `<img src="https://mermaid.ink/svg/...">` rendering block inside the `code` component with the dedicated `<MermaidDiagram code={codeString} />` React component, effectively using the import and making the code more robust against potential SSR (Server-Side Rendering) failures.

---
*PR created automatically by Jules for task [14513344698917712565](https://jules.google.com/task/14513344698917712565) started by @arii*