### PR TITLE
chore: revert unrelated changes in boomtick-mcp/ directory

### DIFF
--- a/boomtick-mcp/src/lib/git.ts
+++ b/boomtick-mcp/src/lib/git.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { runCommand } from "./shell.js";
 import { config } from "../config.js";
 import path from "path";
@@ -25,7 +24,7 @@ export async function createWorktree(branch: string, prNumber: number): Promise<
   try {
     await fs.rm(worktreePath, { recursive: true, force: true });
     await runCommand("git", ["worktree", "prune"]);
-  } catch { }
+  } catch (e) {}
 
   const result = await runCommand("git", ["worktree", "add", "-b", `repair-pr-${prNumber}-${Date.now()}`, worktreePath, branch]);
 

--- a/boomtick-mcp/src/lib/result.ts
+++ b/boomtick-mcp/src/lib/result.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
 export interface ToolResult extends CallToolResult {

--- a/boomtick-mcp/src/lib/shell.ts
+++ b/boomtick-mcp/src/lib/shell.ts
@@ -1,5 +1,6 @@
 import { spawn } from "child_process";
 import { config } from "../config.js";
+import path from "path";
 
 export const ALLOWED_COMMANDS = {
   git: "git",

--- a/boomtick-mcp/src/mcp/server.ts
+++ b/boomtick-mcp/src/mcp/server.ts
@@ -16,8 +16,8 @@ import { getPrDiffHandler, GetPrDiffInputSchema } from "../tools/github.get_pr_d
 import { getMergeConflictFilesHandler, GetMergeConflictFilesInputSchema } from "../tools/github.get_merge_conflict_files.js";
 import { checkoutBranchHandler, CheckoutBranchInputSchema } from "../tools/github.checkout_branch.js";
 import { getChangedFilesHandler, GetChangedFilesInputSchema } from "../tools/repo.get_changed_files.js";
-import { getPackageScriptsHandler } from "../tools/repo.get_package_scripts.js";
-import { getRouteMapHandler } from "../tools/repo.get_route_map.js";
+import { getPackageScriptsHandler, GetPackageScriptsInputSchema } from "../tools/repo.get_package_scripts.js";
+import { getRouteMapHandler, GetRouteMapInputSchema } from "../tools/repo.get_route_map.js";
 import { readCiLogsHandler, ReadCiLogsInputSchema } from "../tools/repo.read_ci_logs.js";
 import { createRepairBranchHandler, CreateRepairBranchInputSchema } from "../tools/repo.create_repair_branch.js";
 import { runTestsHandler, RunTestsInputSchema } from "../tools/repo.run_tests.js";
@@ -101,7 +101,7 @@ export class BoomtickMCPServer {
             },
           ],
         };
-      } catch {
+      } catch (e) {
         throw new Error(`Prompt not found: ${name}`);
       }
     });

--- a/boomtick-mcp/src/tools/github.get_merge_conflict_files.ts
+++ b/boomtick-mcp/src/tools/github.get_merge_conflict_files.ts
@@ -1,7 +1,7 @@
-/* eslint-disable */
 import { z } from "zod";
 import { runCommand } from "../lib/shell.js";
 import { createWorktree, removeWorktree } from "../lib/git.js";
+import { config } from "../config.js";
 
 export const GetMergeConflictFilesInputSchema = z.object({
   prNumber: z.number(),

--- a/boomtick-mcp/src/tools/github.get_pr_diff.ts
+++ b/boomtick-mcp/src/tools/github.get_pr_diff.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { z } from "zod";
 import { runCommand } from "../lib/shell.js";
 

--- a/boomtick-mcp/src/tools/github.search_open_prs.ts
+++ b/boomtick-mcp/src/tools/github.search_open_prs.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { z } from "zod";
 import { runCommand } from "../lib/shell.js";
 

--- a/boomtick-mcp/src/tools/repo.get_package_scripts.test.ts
+++ b/boomtick-mcp/src/tools/repo.get_package_scripts.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { getPackageScriptsHandler } from "./repo.get_package_scripts.js";
 import fs from "fs/promises";
+import { config } from "../config.js";
 
 vi.mock("fs/promises");
 

--- a/boomtick-mcp/src/tools/repo.get_package_scripts.ts
+++ b/boomtick-mcp/src/tools/repo.get_package_scripts.ts
@@ -1,5 +1,5 @@
-/* eslint-disable */
 import { z } from "zod";
+import { runCommand } from "../lib/shell.js";
 import fs from "fs/promises";
 import path from "path";
 import { config } from "../config.js";

--- a/boomtick-mcp/src/tools/repo.get_route_map.ts
+++ b/boomtick-mcp/src/tools/repo.get_route_map.ts
@@ -1,15 +1,17 @@
 import { z } from "zod";
 import { runCommand } from "../lib/shell.js";
+import { config } from "../config.js";
 import path from "path";
 
 export const GetRouteMapInputSchema = z.object({});
 
 export async function getRouteMapHandler() {
   // Logic based on tech-dancer repo structure: src/config/routes.ts and content/
+  const routesPath = path.join(config.repoPath, "src/config/routes.ts");
 
   // For simplicity in MVP, we'll try to find routes by listing content files
   // and reading the main routes file if it exists.
-  const routeMap: Record<string, string> = {};
+  let routeMap: Record<string, string> = {};
 
   try {
     const gitFiles = await runCommand("git", ["ls-files", "content/"]);
@@ -25,7 +27,7 @@ export async function getRouteMapHandler() {
         }
       }
     }
-  } catch {
+  } catch (error) {
     // If no content files, that's fine
   }
 

--- a/boomtick-mcp/src/tools/repo.read_ci_logs.ts
+++ b/boomtick-mcp/src/tools/repo.read_ci_logs.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { z } from "zod";
 import { runCommand } from "../lib/shell.js";
 

--- a/boomtick-mcp/src/tools/repo.run_lighthouse.ts
+++ b/boomtick-mcp/src/tools/repo.run_lighthouse.ts
@@ -26,7 +26,7 @@ export async function runLighthouseHandler(args: z.infer<typeof RunLighthouseInp
          seo: 0
        };
     }
-  } catch {
+  } catch (e) {
     failures.push("Failed to parse Lighthouse report");
   }
 

--- a/boomtick-mcp/src/tools/repo.run_playwright.ts
+++ b/boomtick-mcp/src/tools/repo.run_playwright.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { z } from "zod";
 import { runCommand } from "../lib/shell.js";
 
@@ -27,7 +26,7 @@ export async function runPlaywrightHandler(args: z.infer<typeof RunPlaywrightInp
         }))
       );
     }
-  } catch { }
+  } catch (e) {}
 
   return {
     success: results.exitCode === 0,


### PR DESCRIPTION
This PR removes the unrelated modifications that were made to `boomtick-mcp/` in a previous commit by checking out the version from the origin/main branch, effectively reverting these specific files back to their original state on main.

---
*PR created automatically by Jules for task [4961412702381355804](https://jules.google.com/task/4961412702381355804) started by @arii*