### PR TITLE
Refactor grid layouts to use primitives and enhance layout system capabilities

### DIFF
--- a/src/features/home/FeaturedEventGuide.tsx
+++ b/src/features/home/FeaturedEventGuide.tsx
@@ -2,7 +2,7 @@
 import { useRef, useState } from 'react';
 import { ChevronLeft, ChevronRight, MapPin } from 'lucide-react';
 import { NavLink } from 'react-router-dom';
-import { Box, Stack, Text } from '@/layouts/Primitives';
+import { Box, Grid, Stack, Text } from '@/layouts/Primitives';
 import { getEvents } from '@/lib/content';
 
 const SWIPE_CLICK_CANCEL_THRESHOLD = 5;
@@ -77,12 +77,13 @@ export function FeaturedEventGuide() {
       </Text>
 
       {/* Editorial card: image-led grid */}
-      <Box
+      <Grid
         as="article"
         border
         radius="xl"
         overflow="hidden"
-        className="relative z-10 grid w-full max-w-full min-w-0 bg-surface touch-pan-y overscroll-x-contain select-none md:grid-cols-[260px_1fr] md:min-h-[200px]"
+        cols={{ base: 1, md: "[260px_1fr]" }}
+        className="relative z-10 w-full max-w-full min-w-0 bg-surface touch-pan-y overscroll-x-contain select-none md:min-h-[200px]"
         aria-roledescription="carousel"
         aria-label="Featured event guides"
         data-gesture-handled="true"
@@ -168,7 +169,7 @@ export function FeaturedEventGuide() {
             )}
           </Box>
         </Stack>
-      </Box>
+      </Grid>
     </Box>
   );
 }

--- a/src/features/home/GearShelf.tsx
+++ b/src/features/home/GearShelf.tsx
@@ -1,6 +1,6 @@
 // impeccable-ignore-file
 import { NavLink } from 'react-router-dom';
-import { Box, Text } from '@/layouts/Primitives';
+import { Box, Grid, Text } from '@/layouts/Primitives';
 import { CategoryPlaceholder } from '@/components/ui/CategoryPlaceholder';
 import { ASSET_PREFIX } from '@/config/constants';
 
@@ -35,7 +35,7 @@ export function GearShelf() {
       </Text>
 
       {/* Desktop: square image tile grid — visual shelf, not list cards */}
-      <Box className="hidden lg:grid lg:grid-cols-3 lg:gap-4">
+      <Grid display={{ base: 'none', lg: 'grid' }} cols={3} gap={4}>
         {PICKS.map(({ label, image, imageText, href }) => (
           <Box key={label} as={NavLink} to={href} className="group">
             <Box
@@ -72,7 +72,7 @@ export function GearShelf() {
             </Text>
           </Box>
         ))}
-      </Box>
+      </Grid>
 
       {/* Mobile: horizontal scroll of compact tiles */}
       <Box className="w-full max-w-full overflow-x-auto overscroll-x-contain pb-3 lg:hidden">

--- a/src/layouts/Box.tsx
+++ b/src/layouts/Box.tsx
@@ -3,7 +3,7 @@ import { forwardRef, HTMLAttributes, ElementType } from "react"
 import { cn, composeStyles } from "@/lib/utils"
 import { spacing, layout as layoutTokens, shadows, zIndex as zIndexTokens } from "@/styles/design-tokens"
 import { variants } from "@/lib/variants"
-import { ResponsiveProp, getResponsiveClasses } from "./system-utils"
+import { ResponsiveProp, getResponsiveClasses, getVal } from "./system-utils"
 import { SPACING_MAP, RADIUS_MAP, SHADOW_MAP, SPAN_MAP } from "./layout-maps"
 
 export interface BaseProps {
@@ -105,25 +105,6 @@ export const Box = forwardRef<HTMLDivElement, BoxProps>(
       'viewport', 'layout', 'layoutId', 'onAnimationStart',
       'onAnimationComplete', 'onUpdate', 'custom'
     ];
-
-    // Define getVal before it's used
-    const getVal = (val: string | number | boolean | undefined | null, prefix: string) => {
-      if (!val) return ""
-      const pfx = prefix ? `${prefix}-` : ""
-
-      // Standard Tailwind tokens (numbers or specific strings without CSS units)
-      const isToken = typeof val === "number" ||
-        (typeof val === "string" && /^[a-z0-9-]+$/.test(val) && !/[0-9](px|vh|vw|%|rem|em)$/.test(val))
-
-      if (isToken) return `${pfx}${val}`
-
-      // Arbitrary values
-      const value = typeof val === "string" && val.startsWith("[") && val.endsWith("]")
-        ? val
-        : `[${val}]`
-
-      return `${pfx}${value}`
-    }
 
     const motionProps: Record<string, unknown> = {}
     if (isMotion) {

--- a/src/layouts/Grid.tsx
+++ b/src/layouts/Grid.tsx
@@ -12,7 +12,7 @@ interface GridProps extends BoxProps {
 }
 
 export const Grid = forwardRef<HTMLDivElement, GridProps>(
-  ({ className, cols = 12, rows, ...props }, ref) => {
+  ({ className, cols = 12, rows, display = "grid", ...props }, ref) => {
     const colMapper = (v: string | number | boolean | undefined | null) => {
       const token = COLS_MAP[v as keyof typeof COLS_MAP];
       if (token) return token;
@@ -28,8 +28,8 @@ export const Grid = forwardRef<HTMLDivElement, GridProps>(
     return (
       <Box
         ref={ref}
+        display={display}
         className={composeStyles(
-          "grid",
           getResponsiveClasses(cols, "", colMapper),
           getResponsiveClasses(rows, "", rowMapper),
           className

--- a/src/layouts/Grid.tsx
+++ b/src/layouts/Grid.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import { forwardRef } from "react"
 import { composeStyles } from "@/lib/utils"
 import { Box, BoxProps } from "./Box"
-import { ResponsiveProp, getResponsiveClasses } from "./system-utils"
+import { ResponsiveProp, getResponsiveClasses, getVal } from "./system-utils"
 
 import { COLS_MAP, ROWS_MAP } from "./layout-maps"
 
@@ -13,13 +13,25 @@ interface GridProps extends BoxProps {
 
 export const Grid = forwardRef<HTMLDivElement, GridProps>(
   ({ className, cols = 12, rows, ...props }, ref) => {
+    const colMapper = (v: string | number | boolean | undefined | null) => {
+      const token = COLS_MAP[v as keyof typeof COLS_MAP];
+      if (token) return token;
+      return getVal(v, "grid-cols");
+    }
+
+    const rowMapper = (v: string | number | boolean | undefined | null) => {
+      const token = ROWS_MAP[v as keyof typeof ROWS_MAP];
+      if (token) return token;
+      return getVal(v, "grid-rows");
+    }
+
     return (
       <Box
         ref={ref}
         className={composeStyles(
           "grid",
-          getResponsiveClasses(cols, "", (v) => COLS_MAP[v as keyof typeof COLS_MAP] || ""),
-          getResponsiveClasses(rows, "", (v) => ROWS_MAP[v as keyof typeof ROWS_MAP] || ""),
+          getResponsiveClasses(cols, "", colMapper),
+          getResponsiveClasses(rows, "", rowMapper),
           className
         )}
         {...props}

--- a/src/layouts/system-utils.ts
+++ b/src/layouts/system-utils.ts
@@ -24,3 +24,21 @@ export function getResponsiveClasses(
     xxl && `2xl:${classPrefix}${mapper ? mapper(xxl) : xxl}`
   )
 }
+
+export function getVal(val: string | number | boolean | undefined | null, prefix: string) {
+  if (!val) return ""
+  const pfx = prefix ? `${prefix}-` : ""
+
+  // Standard Tailwind tokens (numbers or specific strings without CSS units)
+  const isToken = typeof val === "number" ||
+    (typeof val === "string" && /^[a-z0-9-]+$/.test(val) && !/[0-9](px|vh|vw|%|rem|em)$/.test(val))
+
+  if (isToken) return `${pfx}${val}`
+
+  // Arbitrary values
+  const value = typeof val === "string" && val.startsWith("[") && val.endsWith("]")
+    ? val
+    : `[${val}]`
+
+  return `${pfx}${value}`
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -22,7 +22,7 @@ export default function Home() {
       {/* Hero + Featured Guide: editorial two-column on desktop, stacked on mobile */}
       <Grid
         as="section"
-        cols={{ base: 1, lg: 2 }}
+        cols={{ base: 1, lg: "[minmax(0,1fr)_420px]" }}
         gap={10}
         align="center"
         className="w-full max-w-full min-w-0"
@@ -36,7 +36,7 @@ export default function Home() {
         <TopicGrid />
 
         <Grid
-          cols={{ base: 1, lg: 2 }}
+          cols={{ base: 1, lg: "[minmax(0,1.6fr)_minmax(300px,0.8fr)]" }}
           gap={8}
           className="w-full max-w-full min-w-0"
         >
@@ -45,7 +45,7 @@ export default function Home() {
         </Grid>
 
         <Grid
-          cols={{ base: 1, lg: 2 }}
+          cols={{ base: 1, lg: "[minmax(0,1.6fr)_minmax(300px,0.8fr)]" }}
           gap={8}
           className="w-full max-w-full min-w-0"
         >

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -20,9 +20,13 @@ export default function Home() {
       />
 
       {/* Hero + Featured Guide: editorial two-column on desktop, stacked on mobile */}
+      {/* Safelist for arbitrary grid classes:
+          lg:grid-cols-[minmax(0,1fr)_420px]
+          lg:grid-cols-[minmax(0,1.6fr)_minmax(300px,0.8fr)]
+      */}
       <Grid
         as="section"
-        cols={{ base: 1, lg: "[minmax(0,1fr)_420px]" }}
+        cols={{ lg: "[minmax(0,1fr)_420px]" }}
         gap={10}
         align="center"
         className="w-full max-w-full min-w-0"
@@ -36,7 +40,7 @@ export default function Home() {
         <TopicGrid />
 
         <Grid
-          cols={{ base: 1, lg: "[minmax(0,1.6fr)_minmax(300px,0.8fr)]" }}
+          cols={{ lg: "[minmax(0,1.6fr)_minmax(300px,0.8fr)]" }}
           gap={8}
           className="w-full max-w-full min-w-0"
         >
@@ -45,7 +49,7 @@ export default function Home() {
         </Grid>
 
         <Grid
-          cols={{ base: 1, lg: "[minmax(0,1.6fr)_minmax(300px,0.8fr)]" }}
+          cols={{ lg: "[minmax(0,1.6fr)_minmax(300px,0.8fr)]" }}
           gap={8}
           className="w-full max-w-full min-w-0"
         >

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,6 +1,6 @@
 // impeccable-ignore-file
 import { SEO } from '@/components/SEO';
-import { Box, Stack } from '@/layouts/Primitives';
+import { Box, Stack, Grid } from '@/layouts/Primitives';
 import { STATIC_SCHEMAS } from '@/config/constants';
 import { FeaturedGuidePanel } from '@/features/home/FeaturedGuidePanel';
 import { TopicGrid } from '@/features/home/TopicGrid';
@@ -20,34 +20,38 @@ export default function Home() {
       />
 
       {/* Hero + Featured Guide: editorial two-column on desktop, stacked on mobile */}
-      <Box
+      <Grid
         as="section"
-        display="grid"
-        className="w-full max-w-full min-w-0 items-center gap-10 lg:grid-cols-[minmax(0,1fr)_420px]"
+        cols={{ base: 1, lg: 2 }}
+        gap={10}
+        align="center"
+        className="w-full max-w-full min-w-0"
       >
         <HeroSection />
         <FeaturedGuidePanel />
-      </Box>
+      </Grid>
 
       {/* Remaining sections — tighter vertical rhythm on mobile */}
       <Stack gap={{ base: 10, lg: 14 }} className="mt-12 w-full max-w-full min-w-0 lg:mt-16">
         <TopicGrid />
 
-        <Box
-          display="grid"
-          className="w-full max-w-full min-w-0 gap-8 lg:grid-cols-[minmax(0,1.6fr)_minmax(300px,0.8fr)]"
+        <Grid
+          cols={{ base: 1, lg: 2 }}
+          gap={8}
+          className="w-full max-w-full min-w-0"
         >
           <FeaturedEventGuide />
           <GearShelf />
-        </Box>
+        </Grid>
 
-        <Box
-          display="grid"
-          className="w-full max-w-full min-w-0 gap-8 lg:grid-cols-[minmax(0,1.6fr)_minmax(300px,0.8fr)]"
+        <Grid
+          cols={{ base: 1, lg: 2 }}
+          gap={8}
+          className="w-full max-w-full min-w-0"
         >
           <LatestPosts />
           <DevLabCallout />
-        </Box>
+        </Grid>
       </Stack>
     </Box>
   );


### PR DESCRIPTION
Replaced raw Tailwind grid implementations in the home page features with the standard Grid primitive. To support the existing designs, I enhanced the Grid primitive to handle arbitrary Tailwind values by centralizing the value resolution logic into a shared system utility. Verified that all layout policies are now met and that the application remains visually consistent and type-safe.

Fixes #1983

---
*PR created automatically by Jules for task [18427082986878128734](https://jules.google.com/task/18427082986878128734) started by @arii*