### PR TITLE
Add semantic duplicate detection audit script, docs, and ignore artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules/
 .pnpm-store/
 
 # Build and Analysis
+artifacts/
 dist/
 dist-ssr/
 build/

--- a/docs/semantic-duplicate-detection.md
+++ b/docs/semantic-duplicate-detection.md
@@ -1,0 +1,55 @@
+# Semantic Duplicate Detection
+
+Boomtick can now generate an AST-based semantic duplicate inventory and report without relying on string matching. The detector fingerprints source files by JSX shape, child hierarchy, repeated `className` patterns, imported symbols, React hook calls, and utility calls.
+
+## Run the Audit
+
+```bash
+pnpm run audit:semantic
+```
+
+The command writes:
+
+- `artifacts/semantic-duplicates/report.md` for human review.
+- `artifacts/semantic-duplicates/report.json` for CI, bots, or follow-up codemods.
+
+Generated `artifacts/` output is intentionally ignored by Git so reports can be regenerated locally or in CI without creating noisy diffs.
+
+## Similarity Rubric
+
+The report uses the following weighted scoring model:
+
+| Metric | Weight |
+| --- | ---: |
+| JSX structure | 40% |
+| Child hierarchy | 20% |
+| Class names | 15% |
+| Imported components | 10% |
+| Hook usage | 10% |
+| Utility usage | 5% |
+
+Scores are bucketed as:
+
+- `90-100%`: definitely duplicate.
+- `75-89%`: likely duplicate.
+- `60-74%`: review manually.
+- `<60%`: omitted from the candidate list.
+
+## What It Detects
+
+The detector reports:
+
+1. A component inventory across `src/**/*.tsx` and `src/**/*.jsx`.
+2. Semantic role groups such as hero, header, card, grid, sidebar, tool, form, and navigation components.
+3. Exact JSX structure groups and repeated JSX subtree patterns that expose shared UI motifs even when component names differ.
+4. Candidate duplicate component pairs that exceed the manual-review threshold.
+5. Repeated literal `className` patterns that may belong behind layout primitives or composed components.
+6. Duplicate date/formatting logic signals based on matching Date and formatter call signatures.
+
+## Recommended Review Flow
+
+1. Run `pnpm run audit:semantic` before a broad UI refactor.
+2. Start with `Definitely duplicate` component pairs and repeated class patterns.
+3. Prefer project primitives (`Box`, `Stack`, `Grid`, `Text`) or a focused composed component over one-off consolidation.
+4. Convert high-confidence clusters into dispatchable issues; `docs/semantic-duplicate-github-issues.md` contains the initial backlog.
+5. For high-confidence migrations, add a dedicated jscodeshift codemod in a separate PR after the report identifies the target API.

--- a/docs/semantic-duplicate-github-issues.md
+++ b/docs/semantic-duplicate-github-issues.md
@@ -1,0 +1,507 @@
+# Semantic Duplicate GitHub Issue Dispatch Plan
+
+Generated from the expanded semantic duplicate audit (`pnpm run audit:semantic`) on 2026-06-11. The audit now reports 1,293 candidate duplicate pairs, 22 semantic role groups, 11 exact structure groups, 18 repeated JSX subtree patterns, 18 repeated class patterns, and 2 duplicate date/formatting logic groups.
+
+Use these as dispatch-ready GitHub issues. Keep each PR focused and avoid mixing unrelated content domains.
+
+## Issue 1 — Consolidate hero and masthead components
+
+**Labels:** `refactor`, `design-system`, `semantic-duplicate`
+
+**Problem:** Hero-like page introductions are split across editorial, global UI, event detail, and canvas-specific components.
+
+**Duplicate candidates:**
+
+- `src/components/editorial/EditorialHero.tsx#EditorialHero`
+- `src/components/ui/HeroSection.tsx#HeroSection`
+- `src/components/ui/HeroParticleCanvas.tsx#HeroParticleCanvas`
+- `src/features/events/components/EventHero.tsx#EventHero`
+- `src/features/events/components/EventHero.tsx#MetadataPill`
+
+**Suggested fix:** Create a shared hero/masthead API with slot support for metadata pills, visual effects, CTA rows, and editorial/event variants.
+
+**Acceptance criteria:**
+
+- One shared hero primitive owns title, eyebrow, summary, metadata, and CTA placement.
+- Event and editorial pages configure variants rather than reimplementing layout.
+- Motion and spacing use existing tokens/primitives only.
+
+## Issue 2 — Merge page, section, editorial, and sidebar header patterns
+
+**Labels:** `refactor`, `ui-consistency`, `semantic-duplicate`
+
+**Problem:** Header components repeat title/subtitle/meta layout semantics in multiple feature areas.
+
+**Duplicate candidates:**
+
+- `src/components/editorial/EditorialHeader.tsx#EditorialHeader`
+- `src/components/ui/PageHeader.tsx#PageHeader`
+- `src/components/ui/SectionHeader.tsx#SectionHeader`
+- `src/components/ui/EventSidebar.tsx#EventHeaderExtras`
+- `src/features/lab/components/sidebar/ResourceSidebar.tsx#ResourceHeaderExtras`
+
+**Suggested fix:** Extract a shared `HeaderBlock`/`SectionHeading` with variants for page, section, editorial metadata, and compact sidebar contexts.
+
+**Acceptance criteria:**
+
+- Header typography, separators, metadata rows, and CTA placement come from one component family.
+- `EventHeaderExtras` and `ResourceHeaderExtras` no longer duplicate the same structure.
+
+## Issue 3 — Create a unified content/card variant system
+
+**Labels:** `refactor`, `cards`, `design-system`
+
+**Problem:** Card semantics are duplicated across product, affiliate, content, event, and gear card implementations.
+
+**Duplicate candidates:**
+
+- `src/components/ui/BaseCard.tsx#BaseCard`
+- `src/components/ui/ContentCard.tsx#ContentCard`
+- `src/components/ui/EventCard.tsx#EventCard`
+- `src/components/ui/GearCard.tsx#GearCard`
+- `src/components/ui/AffiliateCard.tsx#AffiliateCard`
+- `src/components/products/ProductCard.tsx#ProductCard`
+
+**Suggested fix:** Extend `BaseCard` into a variant-driven composed card API with slots for image, badge, metadata, excerpt, price, rating, and actions.
+
+**Acceptance criteria:**
+
+- Shared card structure handles repeated image/title/excerpt/metadata/action patterns.
+- Feature cards only provide data and variant-specific slot content.
+- Existing tests for product cards continue passing.
+
+## Issue 4 — Consolidate blog and gear post route shells
+
+**Labels:** `refactor`, `routing`, `content`
+
+**Problem:** `BlogPost` and `GearPost` scored 96% similar and independently implement the same route state, fallback, SEO, and detail rendering shell.
+
+**Duplicate candidates:**
+
+- `src/features/journal/BlogPost.tsx#BlogPost`
+- `src/features/lab/GearPost.tsx#GearPost`
+
+**Suggested fix:** Introduce a shared `ContentPostRoute`/`ArticleRouteShell` that accepts content type, resolver, SEO mapping, and detail renderer.
+
+**Acceptance criteria:**
+
+- Both routes use a shared route shell.
+- No article filename/date prefixes are changed.
+- Missing-content and SEO behavior remain identical.
+
+## Issue 5 — Unify article/detail content renderers
+
+**Labels:** `refactor`, `markdown`, `content`
+
+**Problem:** Detail and markdown content rendering repeats between journal, gear, research, and preview surfaces.
+
+**Duplicate candidates:**
+
+- `src/features/journal/components/BlogPostDetail.tsx#BlogPostDetail`
+- `src/features/lab/components/GearPostDetail.tsx#GearPostDetail`
+- `src/features/research/ResearchDetail.tsx#ResearchDetail`
+- `src/features/lab/components/FullPreview.tsx#FullPreview`
+- Repeated class pattern: `prose-editorial`
+
+**Suggested fix:** Create one `EditorialContentRenderer` with slots for affiliate disclosures, related links, resource metadata, and preview-only controls.
+
+**Acceptance criteria:**
+
+- `prose-editorial` usage is centralized.
+- Markdown rendering and sanitization rules are shared.
+- Preview mode remains available without duplicating renderer markup.
+
+## Issue 6 — Consolidate event and resource sidebars
+
+**Labels:** `refactor`, `sidebar`, `semantic-duplicate`
+
+**Problem:** Event/resource sidebar components repeat header extras, body extras, metadata chips, and supporting card structure. `EventHeaderExtras` and `ResourceHeaderExtras` scored 98% similar.
+
+**Duplicate candidates:**
+
+- `src/components/ui/EventSidebar.tsx#EventSidebar`
+- `src/components/ui/EventSidebar.tsx#EventHeaderExtras`
+- `src/features/lab/components/sidebar/ResourceSidebar.tsx#ResourceSidebar`
+- `src/features/lab/components/sidebar/ResourceSidebar.tsx#ResourceHeaderExtras`
+- `src/features/lab/components/sidebar/ResourceSidebar.tsx#ResourceBodyExtras`
+
+**Suggested fix:** Create a shared `DetailSidebar` with `headerExtras`, `bodyExtras`, `stats`, `links`, and `disclosure` slots.
+
+**Acceptance criteria:**
+
+- Sidebar shell, spacing, and metadata list semantics are shared.
+- Event and resource sidebars remain feature-owned through slot content only.
+
+## Issue 7 — Deduplicate chart container components
+
+**Labels:** `refactor`, `analytics`, `low-risk`
+
+**Problem:** The WCS chart containers scored 100% similar and duplicate chart wrapper semantics.
+
+**Duplicate candidates:**
+
+- `src/features/research/components/WCSChartContainers.tsx#ScoreDistributionChart`
+- `src/features/research/components/WCSChartContainers.tsx#AvgScoreTrendChart`
+
+**Suggested fix:** Extract `WCSChartCard`/`AnalyticsChartPanel` with title, description, chart, and empty-state slots.
+
+**Acceptance criteria:**
+
+- Both charts use the same container component.
+- Chart-specific data and chart children remain isolated.
+
+## Issue 8 — Build a shared research tool shell
+
+**Labels:** `refactor`, `research`, `semantic-duplicate`
+
+**Problem:** Research tool pages repeat tool framing, explanatory copy blocks, control regions, and results surfaces. `BlastRadiusTool` and `GitOpsReviewerTool` scored 91% similar.
+
+**Duplicate candidates:**
+
+- `src/features/research/components/BlastRadiusTool.tsx#BlastRadiusTool`
+- `src/features/research/components/GitOpsReviewerTool.tsx#GitOpsReviewerTool`
+- `src/features/research/components/EcommerceAutomationTool.tsx#EcommerceAutomationTool`
+- `src/features/research/components/WCSScraperTool.tsx#WCSScraperTool`
+
+**Suggested fix:** Introduce `ResearchToolShell` with slots for input controls, summary cards, output panels, and documentation links.
+
+**Acceptance criteria:**
+
+- Tool chrome and layout are shared.
+- Individual tools own only domain logic and result content.
+
+## Issue 9 — Normalize WCS scraper stats/export/table subpanels
+
+**Labels:** `refactor`, `research`, `analytics`
+
+**Problem:** WCS scraper subcomponents duplicate panel title, action row, table/list, and stats card semantics.
+
+**Duplicate candidates:**
+
+- `src/features/research/components/WCSScraperTool.tsx#WCSScraperStats`
+- `src/features/research/components/WCSScraperTool.tsx#WCSExportTools`
+- `src/features/research/components/WCSScraperTool.tsx#WCSDataTable`
+- `src/components/layout/DetailElements.tsx#SpecsTable`
+
+**Suggested fix:** Extract reusable `DataPanel`, `StatsPanel`, and `ExportActions` components.
+
+**Acceptance criteria:**
+
+- WCS table/panel chrome no longer duplicates specs/table semantics.
+- Export buttons and stats summaries use shared panel primitives.
+
+## Issue 10 — Collapse merch image display variants
+
+**Labels:** `refactor`, `merch`, `low-risk`
+
+**Problem:** Merch image variant components have exact or near-exact structural duplicates. `SingleImage` and `ProminentImages` scored 100% similar.
+
+**Duplicate candidates:**
+
+- `src/components/products/MerchImageDisplay.tsx#MerchImage`
+- `src/components/products/MerchImageDisplay.tsx#SingleImage`
+- `src/components/products/MerchImageDisplay.tsx#EqualImages`
+- `src/components/products/MerchImageDisplay.tsx#ProminentImages`
+- `src/components/products/MerchImageDisplay.tsx#MerchImageDisplay`
+- `src/components/ui/ProductImageFrame.tsx#ProductImageFrame`
+
+**Suggested fix:** Replace layout-specific image functions with a single `MerchImageLayout` that receives a variant (`single`, `equal`, `prominent`).
+
+**Acceptance criteria:**
+
+- Shared image loading, alt text, sizing, and frame semantics are centralized.
+- Existing visual variants are preserved through props, not separate duplicate functions.
+
+## Issue 11 — Consolidate grid/list container patterns
+
+**Labels:** `refactor`, `layout`, `design-system`
+
+**Problem:** Grid-like surfaces independently implement collection layout semantics.
+
+**Duplicate candidates:**
+
+- `src/components/ui/FolioGrid.tsx#FolioGrid`
+- `src/features/home/TopicGrid.tsx#TopicGrid`
+- `src/features/lab/components/ResourceGrid.tsx#ResourceGrid`
+- `src/components/layout/DetailElements.tsx#ScoreGrid`
+- `src/components/ui/PageSkeleton.tsx#GridSkeleton`
+
+**Suggested fix:** Create a shared collection layout API for card grids, dense stat grids, and skeleton grids.
+
+**Acceptance criteria:**
+
+- Responsive behavior is controlled through layout primitives, not one-off classes.
+- Feature grid components become thin adapters around shared layout.
+
+## Issue 12 — Rationalize skeleton and loading-state components
+
+**Labels:** `refactor`, `loading-states`, `design-system`
+
+**Problem:** Skeleton states are implemented as multiple components with repeated layout structure and variants.
+
+**Duplicate candidates:**
+
+- `src/components/ui/PageSkeleton.tsx#GridSkeleton`
+- `src/components/ui/PageSkeleton.tsx#PostSkeleton`
+- `src/components/ui/PageSkeleton.tsx#SimpleSkeleton`
+- `src/components/ui/PageSkeleton.tsx#PageSkeleton`
+- `src/components/ui/Skeleton.tsx#Skeleton`
+
+**Suggested fix:** Convert page skeletons to configuration over one primitive skeleton composition.
+
+**Acceptance criteria:**
+
+- The route-level fallback still uses the standardized page skeleton.
+- Grid/post/simple variants share a single skeleton builder.
+
+## Issue 13 — Merge newsletter and CTA/banner section patterns
+
+**Labels:** `refactor`, `cta`, `email-capture`
+
+**Problem:** Newsletter/CTA sections repeat card-like copy, tag rows, and action structure.
+
+**Duplicate candidates:**
+
+- `src/components/editorial/EditorialNewsletter.tsx#EditorialNewsletter`
+- `src/features/email-capture/NewsletterBanner.tsx#NewsletterBanner`
+- `src/features/email-capture/EmailForm.tsx#EmailForm`
+- `src/components/ReferralBanner.tsx#ReferralBanner`
+- `src/features/home/DevLabCallout.tsx#DevLabCallout`
+
+**Suggested fix:** Create a shared `CTASection` with optional email form, tag chips, referral link, and editorial variants.
+
+**Acceptance criteria:**
+
+- Newsletter copy and form state remain feature-specific.
+- Layout and typography are shared.
+
+## Issue 14 — Unify form field and form-shell semantics
+
+**Labels:** `refactor`, `forms`, `accessibility`
+
+**Problem:** Contact, email capture, and custom event forms duplicate label, input, validation, and action-region structure.
+
+**Duplicate candidates:**
+
+- `src/features/contact/components/ContactFormView.tsx#ContactFormView`
+- `src/features/contact/components/FormField.tsx#FormField`
+- `src/features/email-capture/EmailForm.tsx#EmailForm`
+- `src/features/lab/wsdc-reminders/CustomEventForm.tsx#CustomEventForm`
+
+**Suggested fix:** Introduce shared form primitives for field row, help/error text, actions, and success states.
+
+**Acceptance criteria:**
+
+- Inputs remain controlled.
+- Labels and validation messaging are accessible and consistent.
+
+## Issue 15 — Consolidate navigation item/link patterns
+
+**Labels:** `refactor`, `navigation`, `accessibility`
+
+**Problem:** Desktop, mobile, bottom nav, and event navigation repeat link item and active-state semantics.
+
+**Duplicate candidates:**
+
+- `src/components/Navigation.tsx#Navigation`
+- `src/components/MobileBottomNav.tsx#MobileBottomNav`
+- `src/components/navigation/MobileMenuOverlay.tsx#MobileMenuOverlay`
+- `src/components/navigation/NavItem.tsx#NavItem`
+- `src/features/events/components/EventNavigation.tsx#EventNavigation`
+
+**Suggested fix:** Extract `NavLinkItem` and `NavList` variants for header, bottom mobile, overlay, and local event navigation.
+
+**Acceptance criteria:**
+
+- Active/hover/focus states are consistent.
+- No route strings move outside route config patterns.
+
+## Issue 16 — Share search input/results shell
+
+**Labels:** `refactor`, `search`, `ui-consistency`
+
+**Problem:** Search surfaces duplicate input chrome, empty state, and result-row semantics.
+
+**Duplicate candidates:**
+
+- `src/components/GlobalSearch.tsx#GlobalSearch`
+- `src/components/ui/SearchBox.tsx#SearchBox`
+- `src/components/ui/EmptyState.tsx#EmptyState`
+- `src/components/ui/ListRow.tsx#ListRow`
+
+**Suggested fix:** Create shared `SearchField`, `SearchResultsPanel`, and result row variants.
+
+**Acceptance criteria:**
+
+- Search keyboard/focus behavior remains unchanged.
+- Empty/loading/result states are shared.
+
+## Issue 17 — Normalize table/list/detail stat displays
+
+**Labels:** `refactor`, `data-display`, `semantic-duplicate`
+
+**Problem:** Specs, architectural asset lists, score items, and WCS data rows repeat label/value/list display semantics.
+
+**Duplicate candidates:**
+
+- `src/components/layout/DetailElements.tsx#ScoreItem`
+- `src/components/layout/DetailElements.tsx#SpecsTable`
+- `src/features/research/components/ArchitecturalAssetsList.tsx#ArchitecturalAssetsList`
+- `src/features/research/components/WCSScraperTool.tsx#WCSDataTable`
+- `src/components/ui/ListRow.tsx#ListRow`
+
+**Suggested fix:** Add `KeyValueList`, `StatItem`, and `DataList` primitives.
+
+**Acceptance criteria:**
+
+- Detail pages and research tools share the same data-display building blocks.
+- Table/list accessibility semantics are preserved.
+
+## Issue 18 — Centralize profile/resource/sidebar item lists
+
+**Labels:** `refactor`, `profile`, `resources`
+
+**Problem:** Profile cards, sidebar link lists, and resource body extras repeat small-list and link-list layouts.
+
+**Duplicate candidates:**
+
+- `src/features/profile/components/ProfileComponents.tsx#ProfileItems`
+- `src/features/profile/components/ProfileComponents.tsx#ProfileLinks`
+- `src/features/profile/components/ProfileComponents.tsx#ExperienceCards`
+- `src/features/lab/components/sidebar/ResourceSidebar.tsx#ResourceBodyExtras`
+- `src/features/lab/components/sidebar/ResourceSidebar.tsx#ResourceSidebar`
+
+**Suggested fix:** Create a shared `InfoList`/`LinkList` with icon, label, value, and href slots.
+
+**Acceptance criteria:**
+
+- Profile and sidebar lists no longer duplicate item-row markup.
+- Icons and link affordances remain accessible.
+
+## Issue 19 — Tokenize repeated icon sizing and metadata chip classes
+
+**Labels:** `design-system`, `tokens`, `cleanup`
+
+**Problem:** The audit found repeated raw class patterns such as `w-4 h-4 text-accent`, `w-5 h-5`, `group-hover:text-accent transition-colors`, and `hover:text-accent transition-colors`.
+
+**Duplicate candidates:**
+
+- `src/components/ui/EventCard.tsx#EventCard`
+- `src/components/ui/EventSidebar.tsx#EventSidebar`
+- `src/components/ui/GearCard.tsx#GearCard`
+- `src/features/lab/BlogDrafter.tsx#BlogDrafter`
+- `src/features/profile/components/ProfileComponents.tsx#ProfileItems`
+
+**Suggested fix:** Route repeated icon/link/chip affordances through `Icon`, `StatusBadge`, `Text`, or a new metadata-chip primitive.
+
+**Acceptance criteria:**
+
+- Touched files introduce no new UI audit violations.
+- Repeated icon/link class combinations are replaced by tokenized variants.
+
+## Issue 20 — Centralize home section width/container wrappers
+
+**Labels:** `refactor`, `home`, `layout`
+
+**Problem:** Home feature modules repeat section wrapper/container semantics, including the repeated `w-full max-w-full min-w-0` class pattern.
+
+**Duplicate candidates:**
+
+- `src/features/home/DevLabCallout.tsx#DevLabCallout`
+- `src/features/home/FeaturedEventGuide.tsx#FeaturedEventGuide`
+- `src/features/home/FeaturedGuidePanel.tsx#FeaturedGuidePanel`
+- `src/features/home/GearShelf.tsx#GearShelf`
+- `src/features/home/LatestPosts.tsx#LatestPosts`
+- `src/features/home/TopicGrid.tsx#TopicGrid`
+
+**Suggested fix:** Add a home `SectionShell` or use existing layout primitives consistently for section sizing and overflow behavior.
+
+**Acceptance criteria:**
+
+- Home modules share container/sizing semantics.
+- Section-specific content remains split by feature file.
+
+## Issue 21 — Consolidate date/time and generated ID logic
+
+**Labels:** `refactor`, `utilities`, `date-time`
+
+**Problem:** Date/time logic appears in route effects, utilities, reminders, UX audit reports, content sorting, and generated IDs. The semantic audit found duplicate `new Date` and `Date.now` signals.
+
+**Duplicate candidates:**
+
+- `src/lib/utils.ts#parseDate`
+- `src/lib/utils.ts#formatRelativeTime`
+- `src/lib/content.ts` content sorting with `new Date(...).getTime()`
+- `src/features/events/components/EventReminders.tsx` reminder date formatting
+- `src/pages/UXAuditor.tsx` report timestamp rendering
+- `src/features/lab/useBlogDrafter.ts#generateId`
+
+**Suggested fix:** Introduce a `src/lib/date-time.ts` utility module for parse/format/sort/timestamp helpers and move generated draft IDs behind a single helper.
+
+**Acceptance criteria:**
+
+- Date parsing/formatting is centralized and tested.
+- No behavior changes for content order, reminder dates, or audit timestamps.
+
+## Issue 22 — Unify buttons, filters, copy actions, and floating actions
+
+**Labels:** `refactor`, `buttons`, `accessibility`
+
+**Problem:** Action components repeat button affordance semantics across filters, copy prompts, scroll controls, and general actions.
+
+**Duplicate candidates:**
+
+- `src/components/ui/FilterButton.tsx#FilterButton`
+- `src/components/ui/ActionButton.tsx#ActionButton`
+- `src/components/ui/ViewToggle.tsx#ViewToggle`
+- `src/components/ui/ScrollToTopButton.tsx#ScrollToTopButton`
+- `src/pages/UXAuditor.tsx#CopyPromptButton`
+
+**Suggested fix:** Extend the shared `Button` variant API and migrate feature actions to it.
+
+**Acceptance criteria:**
+
+- Focus, pressed, disabled, and aria states are consistent.
+- Floating and copy actions remain distinguishable through variants.
+
+## Issue 23 — Rationalize empty, notice, disclosure, and callout states
+
+**Labels:** `refactor`, `feedback`, `design-system`
+
+**Problem:** Informational states and callouts repeat card-like layout and icon/title/body semantics.
+
+**Duplicate candidates:**
+
+- `src/components/ui/EmptyState.tsx#EmptyState`
+- `src/components/ui/Notice.tsx#Notice`
+- `src/components/ui/AffiliateDisclosure.tsx#AffiliateDisclosure`
+- `src/components/layout/DetailElements.tsx#VerdictCallout`
+- `src/features/home/DevLabCallout.tsx#DevLabCallout`
+- `src/features/contact/components/SuccessState.tsx#SuccessState`
+
+**Suggested fix:** Create a `FeedbackBlock`/`Callout` primitive with tone, icon, title, body, and actions slots.
+
+**Acceptance criteria:**
+
+- Success, notice, affiliate disclosure, and editorial callout variants use one implementation.
+- Accessibility and disclosure wording remain intact.
+
+## Issue 24 — Create a codemod backlog after shared APIs land
+
+**Labels:** `codemod`, `follow-up`, `maintenance`
+
+**Problem:** The audit produces many high-confidence duplicate pairs and role groups; manual migrations will be repetitive once shared APIs exist.
+
+**Duplicate candidates:**
+
+- Card migrations from `ContentCard`, `EventCard`, `GearCard`, and `ProductCard` to the shared card API.
+- Hero/header migrations to the shared masthead/header APIs.
+- Markdown/detail renderer migrations to the shared editorial renderer.
+- Button/filter/copy action migrations to shared `Button` variants.
+
+**Suggested fix:** Add jscodeshift transforms after the shared APIs are merged.
+
+**Acceptance criteria:**
+
+- Codemods are isolated by domain and include dry-run instructions.
+- Each codemod has before/after examples and a focused test fixture.

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "drafter": "tsx scripts/affiliate/add-item.ts",
     "affiliate:add": "tsx scripts/affiliate/add-item.ts",
     "affiliate:image": "tsx scripts/affiliate/image-helper.ts",
-    "affiliate:audit": "tsx scripts/affiliate/audit.ts"
+    "affiliate:audit": "tsx scripts/affiliate/audit.ts",
+    "audit:semantic": "node scripts/detect-semantic-duplicates.mjs"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",

--- a/scripts/detect-semantic-duplicates.mjs
+++ b/scripts/detect-semantic-duplicates.mjs
@@ -1,0 +1,760 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import ts from 'typescript';
+
+const ROOT = process.cwd();
+const SRC_DIR = path.join(ROOT, 'src');
+const OUTPUT_DIR = path.join(ROOT, 'artifacts', 'semantic-duplicates');
+const REPORT_PATH = path.join(OUTPUT_DIR, 'report.md');
+const JSON_PATH = path.join(OUTPUT_DIR, 'report.json');
+const SCORE_THRESHOLD = 55;
+const MAX_REPORTED_PAIRS = 250;
+
+const IGNORED_SEGMENTS = new Set(['node_modules', 'dist', 'coverage', 'playwright-report', 'test-results']);
+const JSX_EXTENSIONS = new Set(['.tsx', '.jsx']);
+const ANALYZED_EXTENSIONS = new Set(['.tsx', '.ts', '.jsx', '.js']);
+const UTILITY_CALL_ALLOWLIST = new Set([
+  'Array', 'Boolean', 'Date', 'Error', 'Map', 'Number', 'Object', 'Promise', 'RegExp', 'Set', 'String',
+  'console', 'JSON', 'Math', 'Intl', 'parseFloat', 'parseInt', 'encodeURIComponent', 'decodeURIComponent',
+]);
+
+function walk(dir) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  return entries.flatMap((entry) => {
+    if (entry.name.startsWith('.') || IGNORED_SEGMENTS.has(entry.name)) {
+      return [];
+    }
+
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      return walk(fullPath);
+    }
+
+    if (!ANALYZED_EXTENSIONS.has(path.extname(entry.name))) {
+      return [];
+    }
+
+    return [fullPath];
+  });
+}
+
+function toRepoPath(filePath) {
+  return path.relative(ROOT, filePath).split(path.sep).join('/');
+}
+
+function getNameText(name) {
+  if (ts.isIdentifier(name)) {
+    return name.text;
+  }
+
+  if (ts.isJsxNamespacedName?.(name)) {
+    return `${name.namespace.text}:${name.name.text}`;
+  }
+
+  if (ts.isPropertyAccessExpression(name)) {
+    return `${getNameText(name.expression)}.${name.name.text}`;
+  }
+
+  return 'unknown';
+}
+
+function normalizeTagName(name) {
+  const tag = getNameText(name);
+  if (/^[a-z]/.test(tag)) {
+    return tag;
+  }
+
+  if (tag.includes('.')) {
+    return tag.split('.').map((segment) => (segment === 'motion' ? 'motion' : 'Component')).join('.');
+  }
+
+  return 'Component';
+}
+
+function getJsxChildren(node) {
+  if (ts.isJsxElement(node)) {
+    return node.children;
+  }
+
+  if (ts.isJsxFragment(node)) {
+    return node.children;
+  }
+
+  return [];
+}
+
+function buildJsxTree(node) {
+  if (ts.isJsxSelfClosingElement(node)) {
+    return { tag: normalizeTagName(node.tagName), rawTag: getNameText(node.tagName), children: [] };
+  }
+
+  if (ts.isJsxElement(node)) {
+    const children = Array.from(getJsxChildren(node))
+      .map(buildJsxTree)
+      .filter(Boolean);
+    return { tag: normalizeTagName(node.openingElement.tagName), rawTag: getNameText(node.openingElement.tagName), children };
+  }
+
+  if (ts.isJsxFragment(node)) {
+    const children = Array.from(getJsxChildren(node))
+      .map(buildJsxTree)
+      .filter(Boolean);
+    return { tag: 'Fragment', rawTag: 'Fragment', children };
+  }
+
+  if (ts.isJsxExpression(node) && node.expression) {
+    if (ts.isJsxElement(node.expression) || ts.isJsxSelfClosingElement(node.expression) || ts.isJsxFragment(node.expression)) {
+      return buildJsxTree(node.expression);
+    }
+
+    return { tag: 'expression', rawTag: 'expression', children: [] };
+  }
+
+  if (ts.isJsxText(node)) {
+    return node.text.trim() ? { tag: 'text', rawTag: 'text', children: [] } : null;
+  }
+
+  return null;
+}
+
+function collectTags(tree, predicate, results = new Set()) {
+  if (!tree) {
+    return results;
+  }
+
+  const tag = tree.rawTag ?? tree.tag;
+  if (predicate(tag)) {
+    results.add(tag);
+  }
+
+  tree.children.forEach((child) => collectTags(child, predicate, results));
+  return results;
+}
+
+function collectSubtreeSignatures(tree, signatures = new Map()) {
+  if (!tree) {
+    return signatures;
+  }
+
+  const signature = `${tree.tag}(${tree.children.map((child) => collectSubtreeSignatures(child, signatures).currentSignature).join(',')})`;
+  const display = `${tree.tag}${tree.children.length > 0 ? ` → ${tree.children.map((child) => child.tag).join(' → ')}` : ''}`;
+  const count = signatures.get(signature) ?? { signature, display, count: 0 };
+  count.count += 1;
+  signatures.set(signature, count);
+  signatures.currentSignature = signature;
+  return signatures;
+}
+
+function flattenTree(tree, includeDepth = false, depth = 0) {
+  if (!tree) {
+    return [];
+  }
+
+  const current = includeDepth ? `${depth}:${tree.tag}` : tree.tag;
+  return [current, ...tree.children.flatMap((child) => flattenTree(child, includeDepth, depth + 1))];
+}
+
+function treeDepth(tree) {
+  if (!tree || tree.children.length === 0) {
+    return tree ? 1 : 0;
+  }
+
+  return 1 + Math.max(...tree.children.map(treeDepth));
+}
+
+function extractStringLiteral(node) {
+  if (!node) {
+    return null;
+  }
+
+  if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
+    return node.text;
+  }
+
+  if (ts.isJsxExpression(node) && node.expression) {
+    return extractStringLiteral(node.expression);
+  }
+
+  return null;
+}
+
+function attributeName(attribute) {
+  return ts.isIdentifier(attribute.name) ? attribute.name.text : attribute.name.getText();
+}
+
+function collectImports(sourceFile) {
+  const imports = new Set();
+  sourceFile.statements.forEach((statement) => {
+    if (!ts.isImportDeclaration(statement) || !statement.importClause) {
+      return;
+    }
+
+    const specifier = statement.moduleSpecifier.getText(sourceFile).replaceAll(/["']/g, '');
+    if (statement.importClause.name) {
+      imports.add(statement.importClause.name.text);
+    }
+
+    const bindings = statement.importClause.namedBindings;
+    if (bindings && ts.isNamedImports(bindings)) {
+      bindings.elements.forEach((element) => imports.add(element.name.text));
+    }
+
+    if (bindings && ts.isNamespaceImport(bindings)) {
+      imports.add(bindings.name.text);
+    }
+
+    imports.add(`module:${specifier}`);
+  });
+  return imports;
+}
+
+function addClassValue(classValue, classTokens, classPatterns) {
+  const normalized = classValue.split(/\s+/).filter(Boolean).join(' ');
+  if (!normalized) {
+    return;
+  }
+
+  classPatterns.add(normalized);
+  normalized.split(' ').forEach((token) => classTokens.add(token));
+}
+
+function hasJsx(node) {
+  let found = false;
+  function visit(child) {
+    if (found) {
+      return;
+    }
+    if (ts.isJsxElement(child) || ts.isJsxSelfClosingElement(child) || ts.isJsxFragment(child)) {
+      found = true;
+      return;
+    }
+    ts.forEachChild(child, visit);
+  }
+  visit(node);
+  return found;
+}
+
+function findReturnJsx(node) {
+  if (ts.isJsxElement(node) || ts.isJsxSelfClosingElement(node) || ts.isJsxFragment(node)) {
+    return node;
+  }
+
+  if (ts.isParenthesizedExpression(node)) {
+    return findReturnJsx(node.expression);
+  }
+
+  if (ts.isReturnStatement(node) && node.expression) {
+    return findReturnJsx(node.expression);
+  }
+
+  let result = null;
+  function visit(child) {
+    if (result) {
+      return;
+    }
+    if (ts.isReturnStatement(child) && child.expression) {
+      result = findReturnJsx(child.expression);
+      return;
+    }
+    ts.forEachChild(child, visit);
+  }
+  ts.forEachChild(node, visit);
+  return result;
+}
+
+function isComponentLikeName(name) {
+  return /^[A-Z]/.test(name);
+}
+
+function componentNameFromStatement(statement) {
+  if (ts.isFunctionDeclaration(statement) && statement.name && isComponentLikeName(statement.name.text) && hasJsx(statement)) {
+    return statement.name.text;
+  }
+
+  if (ts.isVariableStatement(statement)) {
+    for (const declaration of statement.declarationList.declarations) {
+      if (!ts.isIdentifier(declaration.name) || !declaration.initializer || !isComponentLikeName(declaration.name.text)) {
+        continue;
+      }
+
+      if ((ts.isArrowFunction(declaration.initializer) || ts.isFunctionExpression(declaration.initializer)) && hasJsx(declaration.initializer)) {
+        return declaration.name.text;
+      }
+    }
+  }
+
+  return null;
+}
+
+function collectCallsAndClasses(node, sourceFile, classTokens, classPatterns, hooks, utilities) {
+  function visit(child) {
+    if (ts.isJsxAttribute(child) && attributeName(child) === 'className') {
+      const literal = extractStringLiteral(child.initializer);
+      if (literal) {
+        addClassValue(literal, classTokens, classPatterns);
+      }
+    }
+
+    if (ts.isCallExpression(child)) {
+      const expression = child.expression;
+      const callName = expression.getText(sourceFile).split('.')[0] ?? expression.getText(sourceFile);
+      if (/^use[A-Z0-9]/.test(callName)) {
+        hooks.add(callName);
+      } else if (/^[A-Za-z_$][\w$]*$/.test(callName) && !UTILITY_CALL_ALLOWLIST.has(callName)) {
+        utilities.add(callName);
+      } else if (expression.getText(sourceFile).includes('toLocaleDateString')) {
+        utilities.add('toLocaleDateString');
+      }
+    }
+
+    if (ts.isNewExpression(child)) {
+      const name = child.expression.getText(sourceFile);
+      if (name === 'Date') {
+        utilities.add('new Date');
+      }
+    }
+
+    ts.forEachChild(child, visit);
+  }
+
+  visit(node);
+}
+
+function analyzeFile(filePath) {
+  const code = fs.readFileSync(filePath, 'utf8');
+  const sourceFile = ts.createSourceFile(filePath, code, ts.ScriptTarget.Latest, true, filePath.endsWith('.tsx') || filePath.endsWith('.jsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS);
+  const repoPath = toRepoPath(filePath);
+  const imports = collectImports(sourceFile);
+  const components = [];
+  const functions = [];
+
+  sourceFile.statements.forEach((statement) => {
+    const name = componentNameFromStatement(statement);
+    if (name) {
+      const jsxRoot = findReturnJsx(statement);
+      const tree = jsxRoot ? buildJsxTree(jsxRoot) : null;
+      const classTokens = new Set();
+      const classPatterns = new Set();
+      const hooks = new Set();
+      const utilities = new Set();
+      collectCallsAndClasses(statement, sourceFile, classTokens, classPatterns, hooks, utilities);
+      const structure = flattenTree(tree, false);
+      const hierarchy = flattenTree(tree, true);
+      const componentTags = [...collectTags(tree, (tag) => /^[A-Z]/.test(tag) || tag.includes('.'))].sort();
+      const intrinsicTags = [...collectTags(tree, (tag) => /^[a-z]/.test(tag))].sort();
+      const subtreeEntries = tree ? [...collectSubtreeSignatures(tree).values()].filter((entry) => entry.signature) : [];
+      components.push({
+        name,
+        file: repoPath,
+        root: tree?.tag ?? 'unknown',
+        depth: treeDepth(tree),
+        structure,
+        hierarchy,
+        structureHash: structure.join('>'),
+        hierarchyHash: hierarchy.join('>'),
+        classTokens: [...classTokens].sort(),
+        classPatterns: [...classPatterns].sort(),
+        imports: [...imports].sort(),
+        componentTags,
+        intrinsicTags,
+        subtrees: subtreeEntries.map((entry) => ({ signature: entry.signature, display: entry.display, count: entry.count })),
+        hooks: [...hooks].sort(),
+        utilities: [...utilities].sort(),
+      });
+    }
+
+    const functionName = getFunctionName(statement);
+    if (functionName) {
+      const calls = new Set();
+      const dateSignals = new Set();
+      collectFunctionCalls(statement, sourceFile, calls, dateSignals);
+      if (calls.size > 0 || dateSignals.size > 0) {
+        functions.push({
+          name: functionName,
+          file: repoPath,
+          calls: [...calls].sort(),
+          dateSignals: [...dateSignals].sort(),
+        });
+      }
+    }
+  });
+
+  return { components, functions };
+}
+
+function getFunctionName(statement) {
+  if (ts.isFunctionDeclaration(statement) && statement.name) {
+    return statement.name.text;
+  }
+
+  if (ts.isVariableStatement(statement)) {
+    for (const declaration of statement.declarationList.declarations) {
+      if (ts.isIdentifier(declaration.name) && declaration.initializer) {
+        if (ts.isArrowFunction(declaration.initializer) || ts.isFunctionExpression(declaration.initializer)) {
+          return declaration.name.text;
+        }
+      }
+    }
+  }
+
+  return null;
+}
+
+function collectFunctionCalls(node, sourceFile, calls, dateSignals) {
+  function visit(child) {
+    if (ts.isCallExpression(child)) {
+      const text = child.expression.getText(sourceFile);
+      const base = text.split('.')[0] ?? text;
+      calls.add(text);
+      if (text.includes('toLocaleDateString') || text.includes('format') || text.includes('parseISO')) {
+        dateSignals.add(text);
+      }
+      if (base === 'Date' || text.includes('Date')) {
+        dateSignals.add(text);
+      }
+    }
+
+    if (ts.isNewExpression(child)) {
+      const text = child.expression.getText(sourceFile);
+      calls.add(`new ${text}`);
+      if (text === 'Date') {
+        dateSignals.add('new Date');
+      }
+    }
+
+    ts.forEachChild(child, visit);
+  }
+
+  visit(node);
+}
+
+function jaccard(left, right) {
+  const leftSet = new Set(left);
+  const rightSet = new Set(right);
+  if (leftSet.size === 0 && rightSet.size === 0) {
+    return 1;
+  }
+
+  const intersection = [...leftSet].filter((item) => rightSet.has(item)).length;
+  const union = new Set([...leftSet, ...rightSet]).size;
+  return union === 0 ? 0 : intersection / union;
+}
+
+function similarity(left, right) {
+  const structure = jaccard(left.structure, right.structure);
+  const hierarchy = jaccard(left.hierarchy, right.hierarchy);
+  const classes = jaccard(left.classTokens, right.classTokens);
+  const imports = jaccard(left.componentTags, right.componentTags);
+  const hooks = jaccard(left.hooks, right.hooks);
+  const utilities = jaccard(left.utilities, right.utilities);
+
+  const score = (structure * 40) + (hierarchy * 20) + (classes * 15) + (imports * 10) + (hooks * 10) + (utilities * 5);
+  return {
+    score: Math.round(score),
+    metrics: {
+      structure: Math.round(structure * 100),
+      hierarchy: Math.round(hierarchy * 100),
+      classNames: Math.round(classes * 100),
+      componentUsage: Math.round(imports * 100),
+      hooks: Math.round(hooks * 100),
+      utilities: Math.round(utilities * 100),
+    },
+  };
+}
+
+function bucketForScore(score) {
+  if (score >= 90) return 'Definitely duplicate';
+  if (score >= 75) return 'Likely duplicate';
+  if (score >= 60) return 'Review manually';
+  return 'Different component';
+}
+
+function pairComponents(components) {
+  const pairs = [];
+  for (let i = 0; i < components.length; i += 1) {
+    for (let j = i + 1; j < components.length; j += 1) {
+      const left = components[i];
+      const right = components[j];
+      if (left.file === right.file && left.name === right.name) {
+        continue;
+      }
+      const result = similarity(left, right);
+      if (result.score >= SCORE_THRESHOLD) {
+        pairs.push({
+          score: result.score,
+          bucket: bucketForScore(result.score),
+          metrics: result.metrics,
+          left: componentSummary(left),
+          right: componentSummary(right),
+        });
+      }
+    }
+  }
+
+  return pairs.sort((left, right) => right.score - left.score || left.left.file.localeCompare(right.left.file));
+}
+
+function componentSummary(component) {
+  return {
+    name: component.name,
+    file: component.file,
+    root: component.root,
+    depth: component.depth,
+    structureHash: component.structureHash,
+    classPatterns: component.classPatterns,
+    hooks: component.hooks,
+    utilities: component.utilities,
+  };
+}
+
+function repeatedClassPatterns(components) {
+  const patternFiles = new Map();
+  components.forEach((component) => {
+    component.classPatterns.forEach((pattern) => {
+      if (!patternFiles.has(pattern)) {
+        patternFiles.set(pattern, new Set());
+      }
+      patternFiles.get(pattern).add(`${component.file}#${component.name}`);
+    });
+  });
+
+  return [...patternFiles.entries()]
+    .map(([pattern, owners]) => ({ pattern, count: owners.size, owners: [...owners].sort() }))
+    .filter((entry) => entry.count >= 3 || (entry.count >= 2 && entry.pattern.split(' ').length >= 4))
+    .sort((left, right) => right.count - left.count || right.pattern.length - left.pattern.length);
+}
+
+function duplicateFunctionSignals(functions) {
+  const groups = new Map();
+  functions.forEach((fn) => {
+    if (fn.dateSignals.length === 0) {
+      return;
+    }
+    const key = fn.dateSignals.join('|');
+    if (!groups.has(key)) {
+      groups.set(key, []);
+    }
+    groups.get(key).push(fn);
+  });
+
+  return [...groups.entries()]
+    .map(([signature, items]) => ({ signature, items }))
+    .filter((group) => group.items.length > 1)
+    .sort((left, right) => right.items.length - left.items.length);
+}
+
+
+function splitWords(name) {
+  return name
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/[^A-Za-z0-9]+/g, ' ')
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean);
+}
+
+const ROLE_TOKENS = [
+  'Hero', 'Header', 'Card', 'Grid', 'Sidebar', 'Newsletter', 'CTA', 'Button', 'Badge', 'Skeleton',
+  'Layout', 'Tool', 'Page', 'Chart', 'Form', 'Navigation', 'Content', 'Preview', 'Image', 'Detail',
+  'Feed', 'List', 'Search', 'Disclosure', 'Callout', 'Selector', 'Table', 'Stats', 'Export',
+];
+
+function roleGroups(components) {
+  return ROLE_TOKENS.map((role) => {
+    const members = components.filter((component) => {
+      const words = splitWords(`${component.name} ${component.file}`);
+      return words.some((word) => word.toLowerCase() === role.toLowerCase());
+    });
+    return { role, members: members.map(componentSummary).sort((left, right) => left.file.localeCompare(right.file)) };
+  }).filter((group) => group.members.length >= 2);
+}
+
+function exactStructureGroups(components) {
+  const groups = new Map();
+  components.forEach((component) => {
+    if (!component.structureHash || component.structureHash === 'unknown' || component.structureHash.split('>').length < 2) {
+      return;
+    }
+    if (!groups.has(component.structureHash)) {
+      groups.set(component.structureHash, []);
+    }
+    groups.get(component.structureHash).push(componentSummary(component));
+  });
+
+  return [...groups.entries()]
+    .map(([signature, members]) => ({ signature, members }))
+    .filter((group) => group.members.length >= 2)
+    .sort((left, right) => right.members.length - left.members.length || left.signature.localeCompare(right.signature));
+}
+
+function repeatedSubtreePatterns(components) {
+  const groups = new Map();
+  components.forEach((component) => {
+    component.subtrees.forEach((subtree) => {
+      if (subtree.signature.length < 18 || !subtree.signature.includes(',')) {
+        return;
+      }
+      if (!groups.has(subtree.signature)) {
+        groups.set(subtree.signature, { signature: subtree.signature, display: subtree.display, owners: new Set(), occurrences: 0 });
+      }
+      const group = groups.get(subtree.signature);
+      group.owners.add(`${component.file}#${component.name}`);
+      group.occurrences += subtree.count;
+    });
+  });
+
+  return [...groups.values()]
+    .map((group) => ({ ...group, owners: [...group.owners].sort() }))
+    .filter((group) => group.owners.length >= 3 || group.occurrences >= 5)
+    .sort((left, right) => right.owners.length - left.owners.length || right.occurrences - left.occurrences);
+}
+
+function renderRoleGroups(groups) {
+  if (groups.length === 0) {
+    return 'No semantic role groups were detected.';
+  }
+
+  return groups.map((group) => [
+    `### ${group.role} components (${group.members.length})`,
+    '',
+    ...group.members.map((member) => `- ${member.file}#${member.name}`),
+    '',
+  ].join('\n')).join('\n');
+}
+
+function renderExactStructureGroups(groups) {
+  if (groups.length === 0) {
+    return 'No exact structural groups were detected.';
+  }
+
+  return groups.slice(0, 40).map((group) => [
+    `### ${group.members.length} components with \`${group.signature}\``,
+    '',
+    ...group.members.map((member) => `- ${member.file}#${member.name}`),
+    '',
+  ].join('\n')).join('\n');
+}
+
+function renderSubtreePatterns(patterns) {
+  if (patterns.length === 0) {
+    return 'No repeated JSX subtree patterns were detected.';
+  }
+
+  return patterns.slice(0, 40).map((pattern) => [
+    `### ${pattern.display}`,
+    '',
+    `- Owners: ${pattern.owners.length}`,
+    `- Occurrences: ${pattern.occurrences}`,
+    ...pattern.owners.slice(0, 12).map((owner) => `- ${owner}`),
+    '',
+  ].join('\n')).join('\n');
+}
+
+function renderInventory(files, components) {
+  const directories = [...new Set(files.map((file) => path.dirname(toRepoPath(file))))].sort();
+  const componentLines = components
+    .sort((left, right) => left.file.localeCompare(right.file) || left.name.localeCompare(right.name))
+    .map((component) => `- ${component.file}#${component.name}`);
+
+  return [
+    '## Component Inventory',
+    '',
+    '### Source Directories',
+    '',
+    ...directories.map((dir) => `- ${dir}`),
+    '',
+    '### TSX Components',
+    '',
+    ...componentLines,
+  ].join('\n');
+}
+
+function renderReport({ files, components, pairs, classPatterns, functionGroups, semanticRoleGroups, structuralGroups, subtreePatterns }) {
+  const generatedAt = new Date().toISOString();
+  const pairLines = pairs.slice(0, MAX_REPORTED_PAIRS).flatMap((pair, index) => [
+    `### ${index + 1}. ${pair.left.name} ↔ ${pair.right.name}`,
+    '',
+    `- Similarity: **${pair.score}%** (${pair.bucket})`,
+    `- Files: \`${pair.left.file}\` and \`${pair.right.file}\``,
+    `- Roots/depth: \`${pair.left.root}\`/${pair.left.depth} and \`${pair.right.root}\`/${pair.right.depth}`,
+    `- Metrics: structure ${pair.metrics.structure}%, hierarchy ${pair.metrics.hierarchy}%, class names ${pair.metrics.classNames}%, component usage ${pair.metrics.componentUsage}%, hooks ${pair.metrics.hooks}%, utilities ${pair.metrics.utilities}%`,
+    `- Recommendation: review whether these belong behind a shared primitive, composed component, or variant API.`,
+    '',
+  ]);
+
+  const classLines = classPatterns.slice(0, 30).flatMap((entry) => [
+    `### \`${entry.pattern}\``,
+    '',
+    `- Occurrences: ${entry.count}`,
+    ...entry.owners.slice(0, 10).map((owner) => `- ${owner}`),
+    '',
+  ]);
+
+  const functionLines = functionGroups.flatMap((group) => [
+    `### ${group.signature}`,
+    '',
+    ...group.items.map((item) => `- ${item.file}#${item.name}`),
+    '',
+  ]);
+
+  return [
+    '# Semantic Duplicate Report',
+    '',
+    `Generated: ${generatedAt}`,
+    '',
+    'This report uses TypeScript AST traversal to fingerprint JSX structure, child hierarchy, className patterns, imported symbols, hook usage, and utility calls. Scores follow the project semantic-duplicate rubric: 90-100% definitely duplicate, 75-89% likely duplicate, 60-74% manual review.',
+    '',
+    renderInventory(files.filter((file) => JSX_EXTENSIONS.has(path.extname(file))), components),
+    '',
+    '## Semantic Role Groups',
+    '',
+    renderRoleGroups(semanticRoleGroups),
+    '',
+    '## Exact Structure Groups',
+    '',
+    renderExactStructureGroups(structuralGroups),
+    '',
+    '## Repeated JSX Subtree Patterns',
+    '',
+    renderSubtreePatterns(subtreePatterns),
+    '',
+    '## Candidate Duplicate Components',
+    '',
+    pairLines.length > 0 ? pairLines.join('\n') : 'No component pairs met the review threshold.',
+    '',
+    '## Repeated Class Patterns',
+    '',
+    classLines.length > 0 ? classLines.join('\n') : 'No repeated className patterns met the reporting threshold.',
+    '',
+    '## Duplicate Date/Formatting Logic Signals',
+    '',
+    functionLines.length > 0 ? functionLines.join('\n') : 'No repeated date/formatting function signatures were detected.',
+    '',
+  ].join('\n');
+}
+
+const files = walk(SRC_DIR);
+const analyzed = files.map(analyzeFile);
+const components = analyzed.flatMap((result) => result.components);
+const functions = analyzed.flatMap((result) => result.functions);
+const pairs = pairComponents(components);
+const classPatterns = repeatedClassPatterns(components);
+const functionGroups = duplicateFunctionSignals(functions);
+const semanticRoleGroups = roleGroups(components);
+const structuralGroups = exactStructureGroups(components);
+const subtreePatterns = repeatedSubtreePatterns(components);
+const report = renderReport({ files, components, pairs, classPatterns, functionGroups, semanticRoleGroups, structuralGroups, subtreePatterns });
+
+fs.mkdirSync(OUTPUT_DIR, { recursive: true });
+fs.writeFileSync(REPORT_PATH, report);
+fs.writeFileSync(JSON_PATH, JSON.stringify({ components, pairs, classPatterns, functionGroups, semanticRoleGroups, structuralGroups, subtreePatterns }, null, 2));
+
+console.log(`Semantic duplicate report written to ${toRepoPath(REPORT_PATH)}`);
+console.log(`Components analyzed: ${components.length}`);
+console.log(`Candidate duplicate pairs: ${pairs.length}`);
+console.log(`Semantic role groups: ${semanticRoleGroups.length}`);
+console.log(`Exact structure groups: ${structuralGroups.length}`);
+console.log(`Repeated JSX subtree patterns: ${subtreePatterns.length}`);
+console.log(`Repeated class patterns: ${classPatterns.length}`);
+console.log(`Duplicate function signal groups: ${functionGroups.length}`);


### PR DESCRIPTION
### Motivation

- Introduce an automated AST-based audit to find semantically similar React components and repeated UI patterns to drive targeted refactors and codemods.
- Prevent noisy diffs from generated reports by excluding the artifacts output directory from version control.

### Description

- Add `scripts/detect-semantic-duplicates.mjs`, a TypeScript-using Node script that fingerprints JSX by structure, child hierarchy, className patterns, imports, hooks, and utility calls and emits a human-friendly Markdown report and a machine-readable JSON report to `artifacts/semantic-duplicates`.
- Add `audit:semantic` npm script to `package.json` to run the detector and update `.gitignore` to ignore the `artifacts/` directory.
- Add `docs/semantic-duplicate-detection.md` describing how to run the audit and the scoring rubric and `docs/semantic-duplicate-github-issues.md` containing a generated dispatch-ready backlog of refactor issues produced by the audit.
- JSON output is written for CI/codemod integration and the report generation is deterministic enough to be re-run locally or in CI without committing generated files.

### Testing

- Executed the new audit with `pnpm run audit:semantic`, which wrote `artifacts/semantic-duplicates/report.md` and `artifacts/semantic-duplicates/report.json` and produced the candidate counts summarized in the generated dispatch doc (1,293 candidate pairs and associated role/structure/group metrics).
- Ran the existing test suite with `pnpm test` (Vitest) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b215cdc488325bb56a8947e6f7148)