### PR TITLE
fix: harden conflicts environment validation

### DIFF
--- a/dev-tools/tdw_services/orchestrator.py
+++ b/dev-tools/tdw_services/orchestrator.py
@@ -5,7 +5,7 @@ import json
 import sys
 from datetime import datetime, timezone
 from typing import Dict, Any, List, Optional, Tuple
-from urllib.parse import quote, urlparse
+from urllib.parse import quote, urlparse, urlunparse
 from collections import defaultdict
 
 from tdw_services.services.github import GitHubClient
@@ -28,6 +28,8 @@ from scope_check import verify_pr_scope, get_project_config
 
 PROJECT_CONFIG = get_project_config()
 AUDIT_CHECK_DIRS = ['src/features', 'src/pages', 'src/components', 'src/layouts', 'src/App.tsx']
+CONFLICTS_REMOTE_FIX_URL = "https://github.com/arii/tech-dancer.git"
+CONFLICTS_TOKEN_ENV_VARS = ("CODEX_GH_TOKEN", "GITHUB_TOKEN")
 
 class Orchestrator:
     def __init__(self):
@@ -234,11 +236,28 @@ class Orchestrator:
         return formatted
 
     def _get_conflicts_github_token(self) -> Tuple[Optional[str], Optional[str]]:
-        if os.environ.get("CODEX_GH_TOKEN"):
-            return os.environ["CODEX_GH_TOKEN"], "CODEX_GH_TOKEN"
-        if os.environ.get("GITHUB_TOKEN"):
-            return os.environ["GITHUB_TOKEN"], "GITHUB_TOKEN"
+        for env_var in CONFLICTS_TOKEN_ENV_VARS:
+            token = os.environ.get(env_var)
+            if token:
+                return token, env_var
         return None, None
+
+    def _sanitize_remote_url_for_message(self, remote_url: str) -> str:
+        try:
+            parsed = urlparse(remote_url)
+        except ValueError:
+            return remote_url
+
+        if parsed.scheme in {"http", "https"} and parsed.netloc and "@" in parsed.netloc:
+            sanitized_netloc = f"<credentials>@{parsed.hostname or 'unknown-host'}"
+            try:
+                parsed_port = parsed.port
+            except ValueError:
+                parsed_port = None
+            if parsed_port:
+                sanitized_netloc = f"{sanitized_netloc}:{parsed_port}"
+            return urlunparse(parsed._replace(netloc=sanitized_netloc))
+        return remote_url
 
     def _validate_github_token_for_conflicts(self, repo_slug: str) -> Optional[Dict[str, str]]:
         token, token_source = self._get_conflicts_github_token()
@@ -255,7 +274,14 @@ class Orchestrator:
             }
 
         token_url = f"https://x-access-token:{quote(token, safe='')}@github.com/{repo_slug}.git"
-        parsed = urlparse(token_url)
+        try:
+            parsed = urlparse(token_url)
+        except ValueError:
+            return {
+                "status": "environment_error",
+                "message": f"Invalid GitHub token-derived URL from {token_source}. Set CODEX_GH_TOKEN or GITHUB_TOKEN to a valid GitHub token.",
+            }
+
         if parsed.scheme != "https" or parsed.hostname != "github.com" or not parsed.username or not parsed.password:
             return {
                 "status": "environment_error",
@@ -265,18 +291,20 @@ class Orchestrator:
 
     def _validate_origin_remote_for_conflicts(self) -> Tuple[Optional[str], Optional[Dict[str, str]]]:
         res = run_command(["git", "remote", "get-url", "origin"], check=False, log_on_error=False)
+        remote_fix = f"git remote set-url origin {CONFLICTS_REMOTE_FIX_URL}"
         if res.returncode != 0 or not res.stdout.strip():
             return None, {
                 "status": "environment_error",
-                "message": "Missing GitHub origin remote. Fix with: git remote add origin https://github.com/arii/tech-dancer.git",
+                "message": f"Missing GitHub origin remote. Fix with: git remote add origin {CONFLICTS_REMOTE_FIX_URL}",
             }
 
         remote_url = res.stdout.strip()
         match = re.match(r"^(?:https://(?:[^/@]+(?::[^/@]*)?@)?github\.com/|git@github\.com:)([^/\s]+/[^/\s]+?)(?:\.git)?/?$", remote_url)
         if not match or any(char in remote_url for char in "[]{}<>|\\^`") or any(char.isspace() for char in remote_url):
+            safe_remote_url = self._sanitize_remote_url_for_message(remote_url)
             return None, {
                 "status": "environment_error",
-                "message": f"Malformed GitHub origin remote: {remote_url}. Fix with: git remote set-url origin https://github.com/arii/tech-dancer.git",
+                "message": f"Malformed GitHub origin remote: {safe_remote_url}. Fix with: {remote_fix}",
             }
 
         repo_slug = match.group(1)

--- a/tests/dev-tools/test_conflicts_env.py
+++ b/tests/dev-tools/test_conflicts_env.py
@@ -63,6 +63,30 @@ class TestConflictsEnvironmentValidation(unittest.TestCase):
         self.assertIn('Invalid GitHub token from CODEX_GH_TOKEN', result['message'])
         self.assertIn('token-derived URL would be malformed', result['message'])
 
+    @patch.dict(os.environ, {'GITHUB_TOKEN': 'github-token'}, clear=True)
+    def test_github_token_used_when_codex_token_missing(self):
+        self.assertEqual(self.orch._get_conflicts_github_token(), ('github-token', 'GITHUB_TOKEN'))
+
+    @patch.dict(os.environ, {'CODEX_GH_TOKEN': 'codex-token', 'GITHUB_TOKEN': 'github-token'}, clear=True)
+    def test_codex_token_preferred_over_github_token(self):
+        self.assertEqual(self.orch._get_conflicts_github_token(), ('codex-token', 'CODEX_GH_TOKEN'))
+
+    @patch.dict(os.environ, {'CODEX_GH_TOKEN': 'valid-token'}, clear=True)
+    @patch('tdw_services.orchestrator.run_command')
+    def test_malformed_remote_message_sanitizes_embedded_credentials(self, mock_run):
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout='https://x-access-token:secret with space@github.com/arii/tech-dancer.git\n',
+            stderr='',
+        )
+
+        result = self.orch.handle_conflicts()
+
+        self.assertEqual(result['status'], 'environment_error')
+        self.assertIn('Malformed GitHub origin remote', result['message'])
+        self.assertIn('<credentials>@github.com', result['message'])
+        self.assertNotIn('secret with space', result['message'])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/dev-tools/test_modern_cli.py
+++ b/tests/dev-tools/test_modern_cli.py
@@ -40,5 +40,19 @@ class TestModernCLI(unittest.TestCase):
         self.assertEqual(result.exit_code, 0)
         mock_analyze.assert_called_once_with('README.md')
 
+    @patch('tdw_services.orchestrator.Orchestrator.handle_conflicts')
+    def test_conflicts_environment_error_reports_setup_without_registration_failure(self, mock_conflicts):
+        mock_conflicts.return_value = {
+            "status": "environment_error",
+            "message": "Missing GitHub token. Set CODEX_GH_TOKEN or GITHUB_TOKEN",
+        }
+
+        result = self.runner.invoke(cli, ['gh', 'conflicts'])
+
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn('Missing GitHub token', result.output)
+        self.assertNotIn('No such command', result.output)
+        mock_conflicts.assert_called_once_with(base_branch='main')
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### Motivation

- Improve robustness of the `gh conflicts` flow by detecting and reporting common environment misconfigurations before performing merge/conflict logic.  
- Avoid leaking embedded credentials or noisy low-level URL errors when the local `origin` remote or token-derived URL is malformed.  
- Prefer the explicit `CODEX_GH_TOKEN` environment variable but fall back to `GITHUB_TOKEN` for compatibility.  

### Description

- Centralized remediation constants by adding `CONFLICTS_REMOTE_FIX_URL` and `CONFLICTS_TOKEN_ENV_VARS` in `dev-tools/tdw_services/orchestrator.py`.  
- Made `_get_conflicts_github_token` iterate `CONFLICTS_TOKEN_ENV_VARS` so `CODEX_GH_TOKEN` is preferred and `GITHUB_TOKEN` is a fallback.  
- Added `_sanitize_remote_url_for_message` to redact embedded credentials from reported remote URLs and updated `_validate_origin_remote_for_conflicts` to return a clear remediation hint using the centralized `CONFLICTS_REMOTE_FIX_URL`.  
- Hardened `_validate_github_token_for_conflicts` to defensively parse token-derived URLs and return readable environment-error messages for missing/invalid tokens.  
- Expanded unit and CLI tests in `tests/dev-tools/test_conflicts_env.py` and `tests/dev-tools/test_modern_cli.py` to cover token selection, malformed-origin reporting with credential sanitization, and CLI behavior when environment errors occur.  

### Testing

- Ran unit tests with `python -m pytest tests/dev-tools/test_conflicts_env.py tests/dev-tools/test_modern_cli.py` and all tests passed.  
- Executed the repo audit with `pnpm run audit` which reported no UI anti-patterns.  
- Verified the pre-submit and build pipeline with `python3 dev-tools/td_cli.py gh pre-submit` and `pnpm build`, both completed successfully.  
- Ran `python3 dev-tools/td_cli.py gh conflicts` in the current environment and observed the expected `environment_error` with the new, user-facing remediation message for the malformed local `origin` remote.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b4724191c8325987710fee0d36d51)