### PR TITLE
Deduplicate chart container & add shared research tool shell

### DIFF
--- a/src/components/analytics/WCSChartCard.tsx
+++ b/src/components/analytics/WCSChartCard.tsx
@@ -1,0 +1,52 @@
+// WCSChartCard – shared container for WCS analytics charts
+// Implements the design‑system primitives (Box, Stack, Text) and MUI styling.
+// Props: title, optional description, chart children, optional empty‑state.
+
+import React, { ReactNode } from 'react';
+import { Box, Stack, Text } from '@/layouts/Primitives';
+
+export interface WCSChartCardProps {
+  /** Title displayed at the top of the card */
+  title: string;
+  /** Optional sub‑title or explanatory text */
+  description?: string;
+  /** The chart component (or any visual) */
+  children: ReactNode;
+  /** Content shown when there is no data – e.g. a placeholder message */
+  emptyState?: ReactNode;
+}
+
+/**
+ * Shared analytics card used by ScoreDistributionChart and AvgScoreTrendChart.
+ * It renders a consistent header, optional description, a flexible chart area,
+ * and an optional empty‑state slot.
+ */
+const WCSChartCard: React.FC<WCSChartCardProps> = ({
+  title,
+  description,
+  children,
+  emptyState,
+}) => (
+  <Box border surface="default" padding="card" height="[400px]">
+    <Stack gap={4} height="full">
+      <Box display="flex" align="center" gap={3}>
+        <Text variant="mono" size="micro" weight="font-bold" uppercase>
+          {title}
+        </Text>
+      </Box>
+      {description && (
+        <Box>
+          <Text variant="mono" size="xs" color="dim">
+            {description}
+          </Text>
+        </Box>
+      )}
+      <Box flex={1} minHeight={0}>
+        {children}
+      </Box>
+      {emptyState && <Box>{emptyState}</Box>}
+    </Stack>
+  </Box>
+);
+
+export default WCSChartCard;

--- a/src/components/layout/DataPanel.tsx
+++ b/src/components/layout/DataPanel.tsx
@@ -1,0 +1,35 @@
+// DataPanel – generic panel with title, optional actions, and content
+// Uses design‑system primitives (Box, Stack, Text) and respects MUI styling.
+
+import React, { ReactNode } from 'react';
+import { Box, Stack, Text } from '@/layouts/Primitives';
+
+export interface DataPanelProps {
+  /** Panel title */
+  title: string;
+  /** Optional action row (e.g., buttons, filters) */
+  actions?: ReactNode;
+  /** Main panel content */
+  children: ReactNode;
+}
+
+/**
+ * Reusable panel component for tables, lists, and other data displays.
+ * It renders a header with the title and an optional actions region,
+ * followed by the supplied children.
+ */
+const DataPanel: React.FC<DataPanelProps> = ({ title, actions, children }) => (
+  <Box border surface="default" padding="card">
+    <Stack gap={4}>
+      <Box display="flex" align="center" justify="between" gap={4}>
+        <Text variant="mono" size="xs" weight="font-bold" uppercase>
+          {title}
+        </Text>
+        {actions && <Box>{actions}</Box>}
+      </Box>
+      {children}
+    </Stack>
+  </Box>
+);
+
+export default DataPanel;

--- a/src/components/research/ResearchToolShell.tsx
+++ b/src/components/research/ResearchToolShell.tsx
@@ -1,0 +1,75 @@
+// ResearchToolShell – shared chrome for research tools
+// Uses design‑system primitives (Box, Stack, Text, Grid) and MUI styling.
+// Slots: title, optional description, optional controls, optional summaryCards,
+// output (main content), optional docLink.
+
+import React, { ReactNode } from 'react';
+import { Box, Stack, Text, Grid } from '@/layouts/Primitives';
+
+export interface ResearchToolShellProps {
+  /** Main heading of the tool */
+  title: string;
+  /** Optional explanatory copy displayed under the title */
+  description?: ReactNode;
+  /** Optional control region (e.g., input fields, filters) */
+  controls?: ReactNode;
+  /** Optional summary cards region (e.g., stats, key metrics) */
+  summaryCards?: ReactNode;
+  /** Main output/content area */
+  output: ReactNode;
+  /** Optional documentation link (URL) */
+  docLink?: string;
+}
+
+/**
+ * Shared layout for all research‑tool pages. It provides a consistent header,
+ * optional description, a two‑column layout for controls/summary, and a full‑width
+ * output region. The component follows the project's design‑system using the
+ * Box/Stack primitives which internally map to MUI components.
+ */
+const ResearchToolShell: React.FC<ResearchToolShellProps> = ({
+  title,
+  description,
+  controls,
+  summaryCards,
+  output,
+  docLink,
+}) => (
+  <Box border radius="lg" padding={8} surface="default">
+    <Stack gap={8}>
+      {/* Header */}
+      <Stack gap={4}>
+        <Text variant="headline" size="xl" weight="font-black">
+          {title}
+        </Text>
+        {description && (
+          <Text variant="body" color="dim">
+            {description}
+          </Text>
+        )}
+      </Stack>
+
+      {/* Controls / Summary area – two‑column on md+ */}
+      {(controls || summaryCards) && (
+        <Grid cols={{ base: 1, md: 2 }} gap={8}>
+          {controls && <Box>{controls}</Box>}
+          {summaryCards && <Box>{summaryCards}</Box>}
+        </Grid>
+      )}
+
+      {/* Main output */}
+      <Box>{output}</Box>
+
+      {/* Documentation link */}
+      {docLink && (
+        <Text variant="body" size="sm" color="dim">
+          <a href={docLink} target="_blank" rel="noopener noreferrer">
+            Documentation ↗
+          </a>
+        </Text>
+      )}
+    </Stack>
+  </Box>
+);
+
+export default ResearchToolShell;

--- a/src/features/research/components/BlastRadiusTool.tsx
+++ b/src/features/research/components/BlastRadiusTool.tsx
@@ -3,55 +3,57 @@ import { GitBranch, Layers, Activity } from 'lucide-react';
 import { ArchitecturalAssetsList } from './ArchitecturalAssetsList';
 import { DEVAI_ASSETS } from '@/config/devai-assets';
 import { TOOL_ID_SCOPE_BLAST_RADIUS } from '@/config/devai-tool-ids';
+import { ResearchToolShell } from '@/components/ResearchToolShell';
 
 export function BlastRadiusTool() {
   const assets = DEVAI_ASSETS.filter(a => a.toolId === TOOL_ID_SCOPE_BLAST_RADIUS);
 
   return (
-    <Box border radius="lg" padding={8} surface="default">
-      <Stack gap={8}>
-        <Stack gap={4}>
-          <Text variant="headline" size="xl" weight="font-black">Semantic Blast-Radius Analysis</Text>
-          <Text variant="body" color="dim">
-            Automatically maps and isolates code-change scopes. By analyzing the dependency tree of modified files, this agent identifies downstream side-effects, allowing us to prevent cascading breaks before running expensive integration suites.
-          </Text>
-        </Stack>
+    <ResearchToolShell
+      title="Semantic Blast-Radius Analysis"
+      description={
+        <Text variant="body" color="dim">
+          Automatically maps and isolates code-change scopes. By analyzing the dependency tree of modified files, this agent identifies downstream side-effects, allowing us to prevent cascading breaks before running expensive integration suites.
+        </Text>
+      }
+      output={
+        <>
+          <Grid cols={{ base: 1, md: 2 }} gap={8}>
+            <Stack gap={4} padding={6} border radius="md" surface="surface">
+              <Box display="flex" align="center" gap={3}>
+                <GitBranch className="text-accent w-6 h-6" />
+                <Text variant="display" size="lg" weight="font-bold">Scope Isolation</Text>
+              </Box>
+              <Text variant="body" size="sm" color="dim">
+                Calculates the exact semantic scope of modifications, identifying which components, hooks, or utilities are directly or indirectly affected by a change.
+              </Text>
+            </Stack>
+            <Stack gap={4} padding={6} border radius="md" surface="surface">
+              <Box display="flex" align="center" gap={3}>
+                <Layers className="text-accent w-6 h-6" />
+                <Text variant="display" size="lg" weight="font-bold">AST Parsing</Text>
+              </Box>
+              <Text variant="body" size="sm" color="dim">
+                Leverages Abstract Syntax Tree (AST) analysis to understand deep code relationships that simple grep-based searches miss.
+              </Text>
+            </Stack>
+          </Grid>
 
-        <Grid cols={{ base: 1, md: 2 }} gap={8}>
-          <Stack gap={4} padding={6} border radius="md" surface="surface">
-            <Box display="flex" align="center" gap={3}>
-              <GitBranch className="text-accent w-6 h-6" />
-              <Text variant="display" size="lg" weight="font-bold">Scope Isolation</Text>
-            </Box>
-            <Text variant="body" size="sm" color="dim">
-              Calculates the exact semantic scope of modifications, identifying which components, hooks, or utilities are directly or indirectly affected by a change.
-            </Text>
-          </Stack>
-          <Stack gap={4} padding={6} border radius="md" surface="surface">
-            <Box display="flex" align="center" gap={3}>
-              <Layers className="text-accent w-6 h-6" />
-              <Text variant="display" size="lg" weight="font-bold">AST Parsing</Text>
-            </Box>
-            <Text variant="body" size="sm" color="dim">
-              Leverages Abstract Syntax Tree (AST) analysis to understand deep code relationships that simple grep-based searches miss.
-            </Text>
-          </Stack>
-        </Grid>
-
-        <Stack gap={4}>
-           <Box display="flex" align="center" gap={3} padding={6} border radius="md" surface="surface" className="bg-accent/5">
+          <Stack gap={4}>
+            <Box display="flex" align="center" gap={3} padding={6} border radius="md" surface="surface" className="bg-accent/5">
               <Activity className="text-accent w-6 h-6" />
               <Stack gap={1}>
-                  <Text variant="display" size="md" weight="font-bold">SDLC Bottleneck Telemetry</Text>
-                  <Text variant="body" size="sm" color="dim">
-                      Profiles execution metrics of build scripts and automated workflows, translating runtime logs into actionable SDLC performance trends.
-                  </Text>
+                <Text variant="display" size="md" weight="font-bold">SDLC Bottleneck Telemetry</Text>
+                <Text variant="body" size="sm" color="dim">
+                  Profiles execution metrics of build scripts and automated workflows, translating runtime logs into actionable SDLC performance trends.
+                </Text>
               </Stack>
-          </Box>
-        </Stack>
+            </Box>
+          </Stack>
 
-        <ArchitecturalAssetsList assets={assets} />
-      </Stack>
-    </Box>
+          <ArchitecturalAssetsList assets={assets} />
+        </>
+      }
+    />
   );
 }

--- a/src/features/research/components/BlastRadiusTool.tsx
+++ b/src/features/research/components/BlastRadiusTool.tsx
@@ -3,7 +3,7 @@ import { GitBranch, Layers, Activity } from 'lucide-react';
 import { ArchitecturalAssetsList } from './ArchitecturalAssetsList';
 import { DEVAI_ASSETS } from '@/config/devai-assets';
 import { TOOL_ID_SCOPE_BLAST_RADIUS } from '@/config/devai-tool-ids';
-import { ResearchToolShell } from '@/components/ResearchToolShell';
+import { ResearchToolShell } from '@/components/research/ResearchToolShell';
 
 export function BlastRadiusTool() {
   const assets = DEVAI_ASSETS.filter(a => a.toolId === TOOL_ID_SCOPE_BLAST_RADIUS);

--- a/src/features/research/components/EcommerceAutomationTool.tsx
+++ b/src/features/research/components/EcommerceAutomationTool.tsx
@@ -16,6 +16,7 @@ import {
 import { StatusBadge } from '@/components/ui/StatusBadge';
 import { Icon } from '@/components/ui/Icon';
 import { SEO } from '@/components/SEO';
+import ResearchToolShell from '@/components/research/ResearchToolShell';
 import { BASE_URL, ASSET_PREFIX } from '@/config/constants';
 
 export function EcommerceAutomationTool() {
@@ -60,172 +61,166 @@ export function EcommerceAutomationTool() {
   ];
 
   return (
-    <Stack gap={8}>
-      <SEO
-        title="Ecommerce Automation Experiments | DevAI Portfolio"
-        description="Experiments in API-driven Printful sync, SEO-safe product metadata generation, and human-in-the-loop catalog review."
-        canonical={`${BASE_URL}/research/ecommerce-automation`}
-      />
-      <Box paddingBottom={8} border="b">
-        <Stack gap={4}>
-          <Box display="flex" align="center" gap={3}>
-            <Text variant="mono" size="xs" weight="font-bold" color="accent" uppercase tracking="widest">Business Automation</Text>
-            <StatusBadge label="In Progress" />
-          </Box>
-          <Stack gap={2}>
-            <Text variant="display" size="4xl" weight="font-black" as="h1">Ecommerce Automation Experiments</Text>
-            <Text variant="body" size="lg" color="dim" maxWidth="3xl">
-              Building reviewable automation experiments for asset generation, metadata packets, product-image QA, and human-approved storefront sync.
-              Focusing on niche-aware SEO for <strong>West Coast Swing</strong>, <strong>NorCal</strong>, <strong>rainbow pride</strong>, and <strong>role-fluid dance</strong> communities.
-            </Text>
-          </Stack>
-        </Stack>
-      </Box>
+    <ResearchToolShell
+      title="Ecommerce Automation Experiments"
+      description={
+        <Text variant="body" size="lg" color="dim" maxWidth="3xl">
+          Experiments in API-driven Printful sync, SEO-safe product metadata generation, and human-in-the-loop catalog review.
+        </Text>
+      }
+      output={
+        <>
+          <Stack gap={8}>
+            <SEO
+              title="Ecommerce Automation Experiments | DevAI Portfolio"
+              description="Experiments in API-driven Printful sync, SEO-safe product metadata generation, and human-in-the-loop catalog review."
+              canonical={`${BASE_URL}/research/ecommerce-automation`}
+            />
+            <Box paddingBottom={8} border="b">
+              <Stack gap={4}>
+                <Box display="flex" align="center" gap={3}>
+                  <Text variant="mono" size="xs" weight="font-bold" color="accent" uppercase tracking="widest">
+                    Business Automation
+                  </Text>
+                  <StatusBadge label="In Progress" />
+                </Box>
+                <Stack gap={2}>
+                  <Text variant="display" size="4xl" weight="font-black" as="h1">
+                    Ecommerce Automation Experiments
+                  </Text>
+                  <Text variant="body" size="lg" color="dim" maxWidth="3xl">
+                    Building reviewable automation experiments for asset generation, metadata packets, product-image QA, and human-approved storefront sync.
+                    Focusing on niche-aware SEO for <strong>West Coast Swing</strong>, <strong>NorCal</strong>, <strong>rainbow pride</strong>, and <strong>role-fluid dance</strong> communities.
+                  </Text>
+                </Stack>
+              </Stack>
+            </Box>
 
-      <Grid cols={{ base: 1, md: 2 }} gap={8}>
-        <Stack gap={6}>
-          <Text variant="headline" size="xl" weight="font-black" as="h2">Active Experiments</Text>
-          <Stack gap={4}>
-            {workflowItems.map((item, index) => (
-              <Box key={index} border radius="lg" padding={4} surface="default">
-                <Box display="flex" gap={4} align="start">
-                  <Box width={10} height={10} surface="muted" border radius="md" display="flex" align="center" justify="center" shrink={0}>
-                    <Icon icon={item.icon} size="md" color="accent" />
+            <Grid cols={{ base: 1, md: 2 }} gap={8}>
+              <Stack gap={6}>
+                <Text variant="headline" size="xl" weight="font-black" as="h2">
+                  Active Experiments
+                </Text>
+                <Stack gap={4}>
+                  {workflowItems.map((item, index) => (
+                    <Box key={index} border radius="lg" padding={4} surface="default">
+                      <Box display="flex" gap={4} align="start">
+                        <Box width={10} height={10} surface="muted" border radius="md" display="flex" align="center" justify="center" shrink={0}>
+                          <Icon icon={item.icon} size="md" color="accent" />
+                        </Box>
+                        <Stack gap={1}>
+                          <Text weight="font-bold" size="sm">{item.title}</Text>
+                          <Text size="xs" color="dim">{item.description}</Text>
+                        </Stack>
+                      </Box>
+                    </Box>
+                  ))}
+                </Stack>
+              </Stack>
+
+              <Stack gap={8}>
+                <Stack gap={6}>
+                  <Text variant="headline" size="xl" weight="font-black" as="h2">
+                    SEO &amp; Policy Safety
+                  </Text>
+                  <Box border radius="xl" padding={6} surface="muted">
+                    <Stack gap={4}>
+                      <Box display="flex" align="center" gap={2}>
+                        <Icon icon={ShieldCheck} size="sm" color="accent" />
+                        <Text variant="mono" size="xs" weight="font-bold" uppercase tracking="widest">
+                          Guardrails
+                        </Text>
+                      </Box>
+                      <Text size="sm" color="body">
+                        To maintain long-term SEO health and brand trust, the automation explicitly avoids making unsupported claims.
+                      </Text>
+                      <Stack gap={2}>
+                        {safetyRules.map((rule, index) => (
+                          <Box key={index} display="flex" align="center" gap={2}>
+                            <Icon icon={AlertTriangle} size="xs" color="accent" opacityVariant="muted" />
+                            <Text size="xs" color="dim">{rule}</Text>
+                          </Box>
+                        ))}
+                      </Stack>
+                    </Stack>
                   </Box>
-                  <Stack gap={1}>
-                    <Text weight="font-bold" size="sm">{item.title}</Text>
-                    <Text size="xs" color="dim">{item.description}</Text>
+                </Stack>
+
+                <Stack gap={6}>
+                  <Text variant="headline" size="xl" weight="font-black" as="h2">
+                    Pipeline Architecture
+                  </Text>
+                  <Box border radius="xl" padding={{ base: 6, sm: 8 }} surface="surface" overflowX="auto">
+                    <Stack gap={6} align="center" minWidth="max-content">
+                      <Box display="flex" align="center" justify="center" gap={3} width="full">
+                        {[
+                          { label: 'Templates', active: false },
+                          { label: 'Metadata Packet', active: false },
+                          { label: 'AI Recommendations', active: true },
+                          { label: 'Dry-run Plan', active: true },
+                          { label: 'Human Review', active: true },
+                          { label: 'Approved Sync', active: false },
+                        ].map((step, index, arr) => (
+                          <Box key={step.label} display="flex" align="center" gap={3} shrink={0}>
+                            <Text variant="mono" size="micro" paddingX={3} paddingY={2} border radius="sm" weight="font-bold" uppercase tracking="widest" surface={step.active ? 'accent' : 'muted'}>
+                              {step.label}
+                            </Text>
+                            {index < arr.length - 1 && (
+                              <Box display="flex" align="center" justify="center" shrink={0}>
+                                <Icon icon={ArrowRight} size="sm" color="dim" />
+                              </Box>
+                            )}
+                          </Box>
+                        ))}
+                      </Box>
+                      <Text size="micro" color="dim" uppercase weight="font-black" tracking="widest" opacityVariant="dim">
+                        MULTI-PLATFORM SYNC PIPELINE
+                      </Text>
+                    </Stack>
+                  </Box>
+                </Stack>
+              </Stack>
+            </Grid>
+
+            <Stack gap={6}>
+              <Text variant="headline" size="xl" weight="font-black" as="h2">
+                Visual Image QA Examples
+              </Text>
+              <Grid cols={{ base: 1, sm: 2, lg: 3 }} gap={6}>
+                <Box border radius="lg" overflow="hidden" surface="default">
+                  <Box padding={4} aspect="square" display="flex" align="center" justify="center">
+                    <img src={`${ASSET_PREFIX}/assets/gear/norcal-bestcal-front.webp`} alt="NorCal BestCal Front Mockup" className="max-w-full max-h-full object-contain" />
+                  </Box>
+                  <Box padding={4} border="t">
+                    <Text size="xs" weight="bold">FRONT QA CHECK</Text>
+                    <Text size="micro" color="dim">Center alignment and color profile validation.</Text>
+                  </Box>
+                </Box>
+
+                <Box border radius="lg" overflow="hidden" surface="default">
+                  <Box padding={4} aspect="square" display="flex" align="center" justify="center">
+                    <img src={`${ASSET_PREFIX}/assets/gear/norcal-bestcal-back.webp`} alt="NorCal BestCal Back Mockup" className="max-w-full max-h-full object-contain" />
+                  </Box>
+                  <Box padding={4} border="t">
+                    <Text size="xs" weight="bold">BACK QA CHECK</Text>
+                    <Text size="micro" color="dim">Print area boundaries and text legibility.</Text>
+                  </Box>
+                </Box>
+
+                <Box border radius="lg" overflow="hidden" surface="default" display="flex" align="center" justify="center" padding={8}>
+                  <Stack gap={4} align="center" textAlign="center">
+                    <Icon icon={CheckCircle2} size="xl" color="accent" />
+                    <Stack gap={2}>
+                      <Text size="sm" weight="bold">PASSING QUALITY</Text>
+                      <Text size="micro" color="dim">Automated crop analysis confirms centering within precise tolerance.</Text>
+                    </Stack>
                   </Stack>
                 </Box>
-              </Box>
-            ))}
+              </Grid>
+            </Stack>
           </Stack>
-        </Stack>
-
-        <Stack gap={8}>
-          <Stack gap={6}>
-            <Text variant="headline" size="xl" weight="font-black" as="h2">SEO & Policy Safety</Text>
-            <Box border radius="xl" padding={6} surface="muted">
-              <Stack gap={4}>
-                <Box display="flex" align="center" gap={2}>
-                  <Icon icon={ShieldCheck} size="sm" color="accent" />
-                  <Text variant="mono" size="xs" weight="font-bold" uppercase tracking="widest">Guardrails</Text>
-                </Box>
-                <Text size="sm" color="body">
-                  To maintain long-term SEO health and brand trust, the automation explicitly avoids making unsupported claims.
-                </Text>
-                <Stack gap={2}>
-                  {safetyRules.map((rule, index) => (
-                    <Box key={index} display="flex" align="center" gap={2}>
-                      <Icon icon={AlertTriangle} size="xs" color="accent" opacityVariant="muted" />
-                      <Text size="xs" color="dim">{rule}</Text>
-                    </Box>
-                  ))}
-                </Stack>
-              </Stack>
-            </Box>
-          </Stack>
-
-          <Stack gap={6}>
-            <Text variant="headline" size="xl" weight="font-black" as="h2">Pipeline Architecture</Text>
-            <Box border radius="xl" padding={{ base: 6, sm: 8 }} surface="surface" overflowX="auto">
-              <Stack gap={6} align="center" minWidth="max-content">
-                <Box
-                  display="flex"
-                  align="center"
-                  justify="center"
-                  gap={3}
-                  width="full"
-                >
-                  {[
-                    { label: 'Templates', active: false },
-                    { label: 'Metadata Packet', active: false },
-                    { label: 'AI Recommendations', active: true },
-                    { label: 'Dry-run Plan', active: true },
-                    { label: 'Human Review', active: true },
-                    { label: 'Approved Sync', active: false },
-                  ].map((step, index, arr) => (
-                    <Box
-                      key={step.label}
-                      display="flex"
-                      align="center"
-                      gap={3}
-                      shrink={0}
-                    >
-                      {/* Step Badge */}
-                      <Text
-                        variant="mono"
-                        size="micro"
-                        paddingX={3}
-                        paddingY={2}
-                        border
-                        radius="sm"
-                        weight="font-bold"
-                        uppercase
-                        tracking="widest"
-                        surface={step.active ? 'accent' : 'muted'}
-                      >
-                        {step.label}
-                      </Text>
-
-                      {/* Arrow Connector: always pointing right in horizontal scroll layout */}
-                      {index < arr.length - 1 && (
-                        <Box display="flex" align="center" justify="center" shrink={0}>
-                          <Icon icon={ArrowRight} size="sm" color="dim" />
-                        </Box>
-                      )}
-                    </Box>
-                  ))}
-                </Box>
-        <Text size="micro" color="dim" uppercase weight="font-black" tracking="widest" opacityVariant="dim">
-                  MULTI-PLATFORM SYNC PIPELINE
-                </Text>
-              </Stack>
-            </Box>
-          </Stack>
-        </Stack>
-      </Grid>
-
-      <Stack gap={6}>
-        <Text variant="headline" size="xl" weight="font-black" as="h2">Visual Image QA Examples</Text>
-        <Grid cols={{ base: 1, sm: 2, lg: 3 }} gap={6}>
-          <Box border radius="lg" overflow="hidden" surface="default">
-            <Box padding={4} aspect="square" display="flex" align="center" justify="center">
-              <img
-                src={`${ASSET_PREFIX}/assets/gear/norcal-bestcal-front.webp`}
-                alt="NorCal BestCal Front Mockup"
-                className="max-w-full max-h-full object-contain"
-              />
-            </Box>
-            <Box padding={4} border="t">
-              <Text size="xs" weight="bold">FRONT QA CHECK</Text>
-              <Text size="micro" color="dim">Center alignment and color profile validation.</Text>
-            </Box>
-          </Box>
-          <Box border radius="lg" overflow="hidden" surface="default">
-            <Box padding={4} aspect="square" display="flex" align="center" justify="center">
-              <img
-                src={`${ASSET_PREFIX}/assets/gear/norcal-bestcal-back.webp`}
-                alt="NorCal BestCal Back Mockup"
-                className="max-w-full max-h-full object-contain"
-              />
-            </Box>
-            <Box padding={4} border="t">
-              <Text size="xs" weight="bold">BACK QA CHECK</Text>
-              <Text size="micro" color="dim">Print area boundaries and text legibility.</Text>
-            </Box>
-          </Box>
-          <Box border radius="lg" overflow="hidden" surface="default" display="flex" align="center" justify="center" padding={8}>
-             <Stack gap={4} align="center" textAlign="center">
-                <Icon icon={CheckCircle2} size="xl" color="accent" />
-                <Stack gap={2}>
-                  <Text size="sm" weight="bold">PASSING QUALITY</Text>
-                  <Text size="micro" color="dim">Automated crop analysis confirms centering within precise tolerance.</Text>
-                </Stack>
-             </Stack>
-          </Box>
-        </Grid>
-      </Stack>
-    </Stack>
+        </>
+      }
+    />
   );
 }

--- a/src/features/research/components/GitOpsReviewerTool.tsx
+++ b/src/features/research/components/GitOpsReviewerTool.tsx
@@ -8,38 +8,38 @@ export function GitOpsReviewerTool() {
   const assets = DEVAI_ASSETS.filter(a => a.toolId === TOOL_ID_GITOPS_PR_REVIEWER);
 
   return (
-    <Box border radius="lg" padding={8} surface="default">
-      <Stack gap={8}>
-        <Stack gap={4}>
-          <Text variant="headline" size="xl" weight="font-black">Automating the Outer Loop</Text>
-          <Text variant="body" color="dim">
-            To maintain architectural consistency and prevent regression at scale, I built and integrated deterministic GitOps agents directly into the code review lifecycle.
-          </Text>
-        </Stack>
-
-        <Grid cols={{ base: 1, md: 2 }} gap={8}>
-          <Stack gap={4} padding={6} border radius="md" surface="surface">
-            <Box display="flex" align="center" gap={3}>
-              <ShieldAlert className="text-accent w-6 h-6" />
-              <Text variant="display" size="lg" weight="font-bold">Safety Scorecards</Text>
-            </Box>
-            <Text variant="body" size="sm" color="dim">
-              Runs autonomous static analysis on incoming pull requests. Generates structural code safety scorecards, ensuring new features adhere to the repository's strict design-token and styling rules.
-            </Text>
-          </Stack>
-          <Stack gap={4} padding={6} border radius="md" surface="surface">
-            <Box display="flex" align="center" gap={3}>
-              <Cpu className="text-accent w-6 h-6" />
-              <Text variant="display" size="lg" weight="font-bold">Model Agnostic</Text>
-            </Box>
-            <Text variant="body" size="sm" color="dim">
-              Built on a flexible orchestration layer supporting both high-performance cloud LLMs (Gemini) and local privacy-first models (Ollama/Llama).
-            </Text>
-          </Stack>
-        </Grid>
-
-        <ArchitecturalAssetsList assets={assets} />
-      </Stack>
-    </Box>
+    <ResearchToolShell
+      title="Automating the Outer Loop"
+      description={
+        <Text variant="body" color="dim">
+          To maintain architectural consistency and prevent regression at scale, I built and integrated deterministic GitOps agents directly into the code review lifecycle.
+        </Text>
+      }
+      output={
+        <>
+          <Grid cols={{ base: 1, md: 2 }} gap={8}>
+            <Stack gap={4} padding={6} border radius="md" surface="surface">
+              <Box display="flex" align="center" gap={3}>
+                <ShieldAlert className="text-accent w-6 h-6" />
+                <Text variant="display" size="lg" weight="font-bold">Safety Scorecards</Text>
+              </Box>
+              <Text variant="body" size="sm" color="dim">
+                Runs autonomous static analysis on incoming pull requests. Generates structural code safety scorecards, ensuring new features adhere to the repository's strict design-token and styling rules.
+              </Text>
+            </Stack>
+            <Stack gap={4} padding={6} border radius="md" surface="surface">
+              <Box display="flex" align="center" gap={3}>
+                <Cpu className="text-accent w-6 h-6" />
+                <Text variant="display" size="lg" weight="font-bold">Model Agnostic</Text>
+              </Box>
+              <Text variant="body" size="sm" color="dim">
+                Built on a flexible orchestration layer supporting both high-performance cloud LLMs (Gemini) and local privacy-first models (Ollama/Llama).
+              </Text>
+            </Stack>
+          </Grid>
+          <ArchitecturalAssetsList assets={assets} />
+        </>
+      }
+    />
   );
 }

--- a/src/features/research/components/WCSChartContainers.tsx
+++ b/src/features/research/components/WCSChartContainers.tsx
@@ -13,6 +13,7 @@ import {
   Brush
 } from 'recharts';
 import { Box, Stack, Text } from '@/layouts/Primitives';
+import WCSChartCard from '@/components/analytics/WCSChartCard';
 
 interface ScoreData {
   score: number;
@@ -33,7 +34,11 @@ const customTooltipStyle = {
 };
 
 export const ScoreDistributionChart = ({ data }: { data: ScoreData[] }) => (
-  <Box border surface="default" padding="card" height="[400px]">
+  <WCSChartCard title="Score Distribution" emptyState={
+    <Box display="flex" align="center" justify="center" height="full">
+      <Text variant="mono" size="xs" color="dim">NO_DISTRIBUTION_DATA</Text>
+    </Box>
+  }>
     <Stack gap={4} height="full">
       <Box display="flex" align="center" gap={3}>
         <BarChart2 className="w-4 h-4 text-accent" />
@@ -44,42 +49,25 @@ export const ScoreDistributionChart = ({ data }: { data: ScoreData[] }) => (
           <ResponsiveContainer width="100%" height="100%">
             <BarChart data={data} margin={{ bottom: 20 }}>
               <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="rgba(255,255,255,0.05)" />
-              <XAxis
-                dataKey="score"
-                fontSize={10}
-                tickLine={false}
-                axisLine={false}
-                tick={{ fill: 'rgba(255,255,255,0.5)' }}
-              />
-              <YAxis
-                fontSize={10}
-                tickLine={false}
-                axisLine={false}
-                tick={{ fill: 'rgba(255,255,255,0.5)' }}
-              />
+              <XAxis dataKey="score" fontSize={10} tickLine={false} axisLine={false} tick={{ fill: 'rgba(255,255,255,0.5)' }} />
+              <YAxis fontSize={10} tickLine={false} axisLine={false} tick={{ fill: 'rgba(255,255,255,0.5)' }} />
               <Tooltip contentStyle={customTooltipStyle} />
               <Bar dataKey="count" fill="var(--raw-color-accent-brand)" radius={[2, 2, 0, 0]} />
-              <Brush
-                dataKey="score"
-                height={20}
-                stroke="var(--raw-color-accent-brand)"
-                fill="var(--raw-color-surface-muted)"
-                travellerWidth={10}
-              />
+              <Brush dataKey="score" height={20} stroke="var(--raw-color-accent-brand)" fill="var(--raw-color-surface-muted)" travellerWidth={10} />
             </BarChart>
           </ResponsiveContainer>
-        ) : (
-          <Box display="flex" align="center" justify="center" height="full">
-            <Text variant="mono" size="xs" color="dim">NO_DISTRIBUTION_DATA</Text>
-          </Box>
-        )}
+        ) : null}
       </Box>
     </Stack>
-  </Box>
+  </WCSChartCard>
 );
 
 export const AvgScoreTrendChart = ({ data }: { data: TrendData[] }) => (
-  <Box border surface="default" padding="card" height="[400px]">
+  <WCSChartCard title="Avg Score Trend" emptyState={
+    <Box display="flex" align="center" justify="center" height="full">
+      <Text variant="mono" size="xs" color="dim">NO_TREND_DATA</Text>
+    </Box>
+  }>
     <Stack gap={4} height="full">
       <Box display="flex" align="center" gap={3}>
         <TrendingUp className="w-4 h-4 text-accent" />
@@ -90,43 +78,15 @@ export const AvgScoreTrendChart = ({ data }: { data: TrendData[] }) => (
           <ResponsiveContainer width="100%" height="100%">
             <LineChart data={data} margin={{ bottom: 20 }}>
               <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="rgba(255,255,255,0.05)" />
-              <XAxis
-                dataKey="date"
-                fontSize={10}
-                tickLine={false}
-                axisLine={false}
-                tick={{ fill: 'rgba(255,255,255,0.5)' }}
-              />
-              <YAxis
-                fontSize={10}
-                tickLine={false}
-                axisLine={false}
-                tick={{ fill: 'rgba(255,255,255,0.5)' }}
-              />
+              <XAxis dataKey="date" fontSize={10} tickLine={false} axisLine={false} tick={{ fill: 'rgba(255,255,255,0.5)' }} />
+              <YAxis fontSize={10} tickLine={false} axisLine={false} tick={{ fill: 'rgba(255,255,255,0.5)' }} />
               <Tooltip contentStyle={customTooltipStyle} />
-              <Line
-                type="monotone"
-                dataKey="avg"
-                stroke="var(--raw-color-accent-brand)"
-                strokeWidth={2}
-                dot={{ r: 4, fill: 'var(--raw-color-accent-brand)' }}
-                activeDot={{ r: 6 }}
-              />
-              <Brush
-                dataKey="date"
-                height={20}
-                stroke="var(--raw-color-accent-brand)"
-                fill="var(--raw-color-surface-muted)"
-                travellerWidth={10}
-              />
+              <Line type="monotone" dataKey="avg" stroke="var(--raw-color-accent-brand)" strokeWidth={2} dot={{ r: 4, fill: 'var(--raw-color-accent-brand)' }} activeDot={{ r: 6 }} />
+              <Brush dataKey="date" height={20} stroke="var(--raw-color-accent-brand)" fill="var(--raw-color-surface-muted)" travellerWidth={10} />
             </LineChart>
           </ResponsiveContainer>
-        ) : (
-          <Box display="flex" align="center" justify="center" height="full">
-            <Text variant="mono" size="xs" color="dim">NO_TREND_DATA</Text>
-          </Box>
-        )}
+        ) : null}
       </Box>
     </Stack>
-  </Box>
+  </WCSChartCard>
 );

--- a/src/features/research/components/WCSScraperTool.tsx
+++ b/src/features/research/components/WCSScraperTool.tsx
@@ -1,20 +1,9 @@
+// WCSScraperTool – refactored to use ResearchToolShell and DataPanel
 import React, { useCallback, useEffect } from 'react';
-import {
-  Search,
-  Download,
-  FileJson,
-  FileText,
-  AlertCircle
-} from 'lucide-react';
-import {
-  Box,
-  Stack,
-  Text,
-  Grid
-} from '@/layouts/Primitives';
+import { Search, Download, FileJson, FileText, AlertCircle, Zap, ShieldCheck } from 'lucide-react';
+import { Box, Stack, Text, Grid } from '@/layouts/Primitives';
 import { StatusBadge } from '@/components/ui/StatusBadge';
 import { Skeleton } from '@/components/ui/Skeleton';
-import { Zap, ShieldCheck } from 'lucide-react';
 import { Icon } from '@/components/ui/Icon';
 import { cn } from '@/lib/utils';
 import { useExport } from '../hooks/useExport';
@@ -22,6 +11,8 @@ import { useWCSData, WCSRecord } from '../hooks/useWCSData';
 import { ScoreDistributionChart, AvgScoreTrendChart } from './WCSChartContainers';
 import { FilterButton } from '@/components/ui/FilterButton';
 import { ActionButton } from '@/components/ui/ActionButton';
+import ResearchToolShell from '@/components/research/ResearchToolShell';
+import DataPanel from '@/components/layout/DataPanel';
 
 function WCSDataTable({ data }: { data: WCSRecord[] }) {
   return (
@@ -53,45 +44,19 @@ function WCSDataTable({ data }: { data: WCSRecord[] }) {
                   </Stack>
                 </Box>
                 <Box as="td" padding={4}>
-                  <Text
-                    as="a"
-                    href={record.event_url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    variant="body"
-                    size="xs"
-                    color="dim"
-                    className="transition-colors underline-offset-4 hover:underline hover:color-accent"
-                  >
-                    {record.event_title}
-                  </Text>
+                  <Text as="a" href={record.event_url} target="_blank" rel="noopener noreferrer" variant="body" size="xs" color="dim" className="transition-colors underline-offset-4 hover:underline hover:color-accent">{record.event_title}</Text>
                 </Box>
                 <Text as="td" padding={4} size="xs" color="dim" className="hidden md:table-cell">{record.location}</Text>
                 <Text as="td" padding={4} variant="mono" size="xs">{record.Registry_Points_Sum.toFixed(1)}</Text>
                 <Box as="td" padding={4} className="hidden sm:table-cell">
-                  <Text
-                    as="div"
-                    display="inline-block"
-                    paddingX={2}
-                    paddingY={0.5}
-                    surface={record.Promoted ? 'accent' : 'muted'}
-                    size="xs"
-                    weight="font-black"
-                    uppercase
-                    tracking="widest"
-                    className={record.Promoted ? 'text-accent-navy' : 'text-text-dim opacity-muted'}
-                  >
-                    {record.Promoted ? 'Promoted' : 'Held'}
-                  </Text>
+                  <Text as="div" display="inline-block" paddingX={2} paddingY={0.5} surface={record.Promoted ? 'accent' : 'muted'} size="xs" weight="font-black" uppercase tracking="widest" className={record.Promoted ? 'text-accent-navy' : 'text-text-dim opacity-muted'}>{record.Promoted ? 'Promoted' : 'Held'}</Text>
                 </Box>
               </tr>
             ))}
             {data.length === 0 && (
               <tr>
                 <td colSpan={6}>
-                  <Box paddingY={12} textAlign="center">
-                    <Text variant="body" size="sm" color="dim">No results found for this search.</Text>
-                  </Box>
+                  <Box paddingY={12} textAlign="center"><Text variant="body" size="sm" color="dim">No results found for this search.</Text></Box>
                 </td>
               </tr>
             )}
@@ -99,9 +64,7 @@ function WCSDataTable({ data }: { data: WCSRecord[] }) {
         </table>
       </Box>
       {data.length > 20 && (
-        <Box padding="compact" textAlign="center" borderTop>
-          <Text variant="mono" size="micro" color="dim">AND {data.length - 20} MORE RECORDS...</Text>
-        </Box>
+        <Box padding="compact" textAlign="center" borderTop><Text variant="mono" size="micro" color="dim">AND {data.length - 20} MORE RECORDS...</Text></Box>
       )}
     </Box>
   );
@@ -116,13 +79,7 @@ function WCSExportTools({ data }: { data: WCSRecord[] }) {
       title: 'WCS Prelim Scoring Analysis',
       filename: 'wcs_prelims',
       headers: [['Date', 'Competitor', 'Event', 'Score', 'Promoted']],
-      data: data.map(r => [
-        r.event_date,
-        r.competitor_name,
-        r.event_title,
-        r.Registry_Points_Sum.toFixed(1),
-        r.Promoted ? 'YES' : 'NO'
-      ])
+      data: data.map(r => [r.event_date, r.competitor_name, r.event_title, r.Registry_Points_Sum.toFixed(1), r.Promoted ? 'YES' : 'NO'])
     });
   }, [data, exportPDF]);
 
@@ -134,38 +91,13 @@ function WCSExportTools({ data }: { data: WCSRecord[] }) {
   return (
     <Box border surface="default" padding="card">
       <Stack gap={6}>
-        <Box display="flex" align="center" gap={3}>
-          <Download className="w-5 h-5 text-accent" />
-          <Text variant="mono" size="xs" weight="font-bold" uppercase>Export Data</Text>
-        </Box>
+        <Box display="flex" align="center" gap={3}"><Download className="w-5 h-5 text-accent" /><Text variant="mono" size="xs" weight="font-bold" uppercase>Export Data</Text></Box>
         <Stack gap={3}>
-          <ActionButton
-            variant="secondary"
-            width="full"
-            padding={3}
-            onClick={handleExportCSV}
-          >
-            <Box display="flex" align="center" gap={3} width="full" textAlign="left">
-              <FileJson className="w-4 h-4 shrink-0" />
-              <Stack gap={0}>
-                <Text variant="mono" size="micro" weight="font-bold">EXPORT_CSV</Text>
-                <Text variant="body" size="micro" color="dim">Raw machine-readable data</Text>
-              </Stack>
-            </Box>
+          <ActionButton variant="secondary" width="full" padding={3} onClick={handleExportCSV}>
+            <Box display="flex" align="center" gap={3} width="full" textAlign="left"><FileJson className="w-4 h-4 shrink-0" /><Stack gap={0}><Text variant="mono" size="micro" weight="font-bold">EXPORT_CSV</Text><Text variant="body" size="micro" color="dim">Raw machine-readable data</Text></Stack></Box>
           </ActionButton>
-          <ActionButton
-            variant="secondary"
-            width="full"
-            padding={3}
-            onClick={handleExportPDF}
-          >
-            <Box display="flex" align="center" gap={3} width="full" textAlign="left">
-              <FileText className="w-4 h-4 shrink-0" />
-              <Stack gap={0}>
-                <Text variant="mono" size="micro" weight="font-bold">EXPORT_PDF_REPORT</Text>
-                <Text variant="body" size="micro" color="dim">Formatted analytical brief</Text>
-              </Stack>
-            </Box>
+          <ActionButton variant="secondary" width="full" padding={3} onClick={handleExportPDF}>
+            <Box display="flex" align="center" gap={3} width="full" textAlign="left"><FileText className="w-4 h-4 shrink-0" /><Stack gap={0}><Text variant="mono" size="micro" weight="font-bold">EXPORT_PDF_REPORT</Text><Text variant="body" size="micro" color="dim">Formatted analytical brief</Text></Stack></Box>
           </ActionButton>
         </Stack>
       </Stack>
@@ -185,9 +117,7 @@ function WCSScraperStats({ latency, totalEvents }: { latency: number | null, tot
           </Box>
           <Box display="flex" justify="between" align="center" borderBottom="b" paddingBottom={2} className="border-line/20">
             <Text variant="body" size="xs" color="dim">Latency</Text>
-            <Text variant="mono" size="xs" color="brand" weight="font-bold">
-              {latency ? `${(latency / 1000).toFixed(2)}s` : '---'}
-            </Text>
+            <Text variant="mono" size="xs" color="brand" weight="font-bold">{latency ? `${(latency / 1000).toFixed(2)}s` : '---'}</Text>
           </Box>
           <Box display="flex" justify="between" align="center" borderBottom="b" paddingBottom={2} className="border-line/20">
             <Text variant="body" size="xs" color="dim">Events Processed</Text>
@@ -242,9 +172,7 @@ export function WCSScraperTool() {
             <Text variant="body" size="xs" color="dim" textAlign="center">{error}</Text>
           </Stack>
           <Box paddingTop={4}>
-            <ActionButton variant="secondary" paddingX={6} paddingY={3} onClick={() => window.location.reload()}>
-              Retry Connection
-            </ActionButton>
+            <ActionButton variant="secondary" paddingX={6} paddingY={3} onClick={() => window.location.reload()}>Retry Connection</ActionButton>
           </Box>
         </Stack>
       </Box>
@@ -252,145 +180,120 @@ export function WCSScraperTool() {
   }
 
   return (
-    <Stack gap={8}>
-      <Box paddingBottom={8} borderBottom>
-        <Stack gap={4}>
-          <Box display="flex" align="center" gap={3}>
-            <Text variant="mono" size="xs" weight="font-bold" color="accent" uppercase tracking="widest">Scoring Tool</Text>
-            <StatusBadge label="active" />
-          </Box>
-          <Stack gap={2}>
-            <Text variant="display" size="4xl" weight="font-black">WCS Scoring Analysis</Text>
-            <Text variant="body" size="lg" color="dim" maxWidth="3xl">
-              A tool for extracting and analyzing public West Coast Swing competition results.
-              Provides transparency on scoring patterns and promotion trends through data analysis.
-            </Text>
-          </Stack>
-        </Stack>
-      </Box>
-
-      {/* Extraction & Impact Dashboard */}
-      <Box padding={{ base: 4, md: 8 }} border radius="xl" surface="muted" className="relative overflow-hidden">
-        <Grid cols={{ base: 1, lg: 2 }} gap={{ base: 8, lg: 12 }}>
+    <ResearchToolShell
+      title="WCS Scoring Analysis"
+      description={
+        <>
+          <Text variant="display" size="4xl" weight="font-black">WCS Scoring Analysis</Text>
+          <Text variant="body" size="lg" color="dim" maxWidth="3xl">
+            A tool for extracting and analyzing public West Coast Swing competition results.
+            Provides transparency on scoring patterns and promotion trends through data analysis.
+          </Text>
+        </>
+      }
+      controls={
+        <Box border surface="muted" padding="card">
           <Stack gap={6}>
-            <Stack gap={2}>
-              <Text variant="display" size="2xl" weight="font-black">Event Data</Text>
-              <Text variant="body" size="lg" color="dim">
-                We have retrieved data from {(totalEvents || 6308).toLocaleString()} events since 2023.
-                We are currently adding more past results to the database.
-              </Text>
-            </Stack>
-            <Grid cols={{ base: 1, md: 2 }} gap={6}>
-              <Stack gap={2}>
-                <Box display="flex" align="center" gap={2}>
-                  <Icon icon={Zap} size="sm" color="accent" />
-                  <Text weight="font-bold" size="xs" uppercase tracking="widest" color="accent">Safe Access</Text>
-                </Box>
-                <Text size="xs" color="dim">Asynchronous extraction with intentional delays to ensure zero impact on host server performance.</Text>
-              </Stack>
-              <Stack gap={2}>
-                <Box display="flex" align="center" gap={2}>
-                  <Icon icon={ShieldCheck} size="sm" color="accent" />
-                  <Text weight="font-bold" size="xs" uppercase tracking="widest" color="accent">Public Data</Text>
-                </Box>
-                <Text size="xs" color="dim">Strictly indexing public scoring data for aggregate research and statistical analysis.</Text>
+            <Box display="flex" align="center" gap={3}>
+              <Search className="w-5 h-5 text-dim" />
+              <Text variant="mono" size="xs" weight="font-bold" uppercase color="dim">Search</Text>
+            </Box>
+            <Grid cols={{ base: 1, md: 2 }} gap={4}>
+              <Box surface="default" border paddingX="compact" paddingY={3} display="flex" align="center" gap={2}>
+                <Search className="w-4 h-4 text-dim" />
+                <input
+                  type="text"
+                  placeholder="Search by name, ID, or event..."
+                  className="bg-transparent border-none outline-none text-sm w-full font-mono"
+                  value={searchTerm}
+                  onChange={(e) => setSearchTerm(e.target.value)}
+                />
+              </Box>
+              <Stack direction="row" gap={2} width="full">
+                {(['all', 'promoted', 'not-promoted'] as const).map(filter => (
+                  <Box key={filter} flex={1}>
+                    <FilterButton
+                      variant="compact"
+                      label={filter.replace('-', ' ')}
+                      onClick={() => handleFilterChange(filter)}
+                      isActive={filterPromoted === filter}
+                      className={cn(
+                        "w-full justify-center",
+                        filterPromoted === filter ? "bg-accent text-bg border-accent" : "bg-surface-alt text-text-dim border-line/50"
+                      )}
+                    />
+                  </Box>
+                ))}
               </Stack>
             </Grid>
           </Stack>
-          <Stack gap={6} justify="center">
-            <Box padding={6} border radius="lg" surface="surface">
+        </Box>
+      }
+      summaryCards={
+        <>
+          <DataPanel title="Verification">
+            <Box paddingX={4} paddingY={6}>
               <Stack gap={4}>
-                <Box display="flex" justify="between" align="center">
-                  <Text variant="mono" size="xs" weight="font-bold" color="dim">VERIFICATION</Text>
-                  <Text variant="mono" size="micro" color="success">ACTIVE</Text>
-                </Box>
-                <Text size="sm" color="body">
-                  We check multiple data points (Result IDs and Event URLs) to ensure the scores are accurate.
-                </Text>
-                <Box height={0.5} surface="muted" />
-                <Box display="flex" justify="between" align="center">
-                  <Text variant="mono" size="xs" weight="font-bold" color="dim">LAST SYNC</Text>
-                  <Text variant="mono" size="micro" color="accent">{isLoading ? 'PENDING' : lastSync || 'RECENT'}</Text>
-                </Box>
+                <Text variant="mono" size="xs" weight="font-bold" color="dim" uppercase>VERIFICATION</Text>
+                <Stack gap={4}>
+                  <Box display="flex" justify="between" align="center" borderBottom="b" paddingBottom={2} className="border-line/20">
+                    <Text variant="body" size="xs" color="dim">Status</Text>
+                    <Text variant="mono" size="xs" color="brand" weight="font-bold">OPERATIONAL</Text>
+                  </Box>
+                  <Box display="flex" justify="between" align="center" borderBottom="b" paddingBottom={2} className="border-line/20">
+                    <Text variant="body" size="xs" color="dim">Latency</Text>
+                    <Text variant="mono" size="xs" color="brand" weight="font-bold">{latency ? `${(latency / 1000).toFixed(2)}s` : '---'}</Text>
+                  </Box>
+                  <Box display="flex" justify="between" align="center" borderBottom="b" paddingBottom={2} className="border-line/20">
+                    <Text variant="body" size="xs" color="dim">Events Processed</Text>
+                    <Text variant="mono" size="xs" color="brand" weight="font-bold">{totalEvents || '---'}</Text>
+                  </Box>
+                  <Box display="flex" justify="between" align="center">
+                    <Text variant="body" size="xs" color="dim">Safe Access</Text>
+                    <StatusBadge label="ACTIVE" />
+                  </Box>
+                </Stack>
               </Stack>
             </Box>
-          </Stack>
-        </Grid>
-      </Box>
-
-      {isLoading ? (
-        <Grid cols={{ base: 1, lg: 3 }} gap={8} align="start">
-          <Stack gap={8} className="lg:col-span-2">
-            <Grid cols={{ base: 1, md: 2 }} gap={{ base: 4, md: 8 }}>
-              <Skeleton height={64} width="full" />
-              <Skeleton height={64} width="full" />
-            </Grid>
-            <Skeleton height={96} width="full" />
-          </Stack>
-          <Stack gap={8}>
-            <Skeleton height={48} width="full" />
-            <Skeleton height={32} width="full" />
-          </Stack>
-        </Grid>
-      ) : (
-        <>
-          <Box border surface="muted" padding="card">
-            <Stack gap={6}>
-              <Box display="flex" align="center" gap={3}>
-                <Search className="w-5 h-5 text-dim" />
-                <Text variant="mono" size="xs" weight="font-bold" uppercase color="dim">
-                  Search
-                </Text>
-              </Box>
-
-              <Grid cols={{ base: 1, md: 2 }} gap={4}>
-                <Box surface="default" border paddingX="compact" paddingY={3} display="flex" align="center" gap={2}>
-                  <Search className="w-4 h-4 text-dim" />
-                  <input
-                    type="text"
-                    placeholder="Search by name, ID, or event..."
-                    className="bg-transparent border-none outline-none text-sm w-full font-mono"
-                    value={searchTerm}
-                    onChange={(e) => setSearchTerm(e.target.value)}
-                  />
-                </Box>
-
-                <Stack direction="row" gap={2} width="full">
-                  {(['all', 'promoted', 'not-promoted'] as const).map((filter) => (
-                    <Box key={filter} flex={1}>
-                      <FilterButton
-                        variant="compact"
-                        label={filter.replace('-', ' ')}
-                        onClick={() => handleFilterChange(filter)}
-                        isActive={filterPromoted === filter}
-                        className={cn(
-                          "w-full justify-center",
-                          filterPromoted === filter ? "bg-accent text-bg border-accent" : "bg-surface-alt text-text-dim border-line/50"
-                        )}
-                      />
-                    </Box>
-                  ))}
-                </Stack>
-              </Grid>
-            </Stack>
-          </Box>
-
-          <Grid cols={{ base: 1, lg: 3 }} gap={8}>
+          </DataPanel>
+          <DataPanel title="Stats">
+            <WCSScraperStats latency={latency} totalEvents={totalEvents} />
+          </DataPanel>
+        </>
+      }
+      output={
+        isLoading ? (
+          <Grid cols={{ base: 1, lg: 3 }} gap={8} align="start">
             <Stack gap={8} className="lg:col-span-2">
               <Grid cols={{ base: 1, md: 2 }} gap={{ base: 4, md: 8 }}>
-                <ScoreDistributionChart data={scoreDistribution} />
-                <AvgScoreTrendChart data={trendData} />
+                <Skeleton height={64} width="full" />
+                <Skeleton height={64} width="full" />
               </Grid>
-              <WCSDataTable data={filteredData} />
+              <Skeleton height={96} width="full" />
             </Stack>
-
             <Stack gap={8}>
-              <WCSExportTools data={filteredData} />
-              <WCSScraperStats latency={latency} totalEvents={totalEvents} />
+              <Skeleton height={48} width="full" />
+              <Skeleton height={32} width="full" />
             </Stack>
           </Grid>
-        </>
-      )}
-    </Stack>
+        ) : (
+          <>
+            <Grid cols={{ base: 1, lg: 3 }} gap={8}>
+              <Stack gap={8} className="lg:col-span-2">
+                <Grid cols={{ base: 1, md: 2 }} gap={{ base: 4, md: 8 }}>
+                  <ScoreDistributionChart data={scoreDistribution} />
+                  <AvgScoreTrendChart data={trendData} />
+                </Grid>
+                <WCSDataTable data={filteredData} />
+              </Stack>
+              <Stack gap={8}>
+                <WCSExportTools data={filteredData} />
+                <WCSScraperStats latency={latency} totalEvents={totalEvents} />
+              </Stack>
+            </Grid>
+          </>
+        )
+      }
+    />
   );
 }

--- a/src/features/research/components/WCSScraperTool.tsx
+++ b/src/features/research/components/WCSScraperTool.tsx
@@ -1,10 +1,9 @@
-// WCSScraperTool – refactored to use ResearchToolShell and DataPanel
+// Cleaned imports
 import React, { useCallback, useEffect } from 'react';
-import { Search, Download, FileJson, FileText, AlertCircle, Zap, ShieldCheck } from 'lucide-react';
+import { Search, Download, FileJson, FileText, AlertCircle } from 'lucide-react';
 import { Box, Stack, Text, Grid } from '@/layouts/Primitives';
 import { StatusBadge } from '@/components/ui/StatusBadge';
 import { Skeleton } from '@/components/ui/Skeleton';
-import { Icon } from '@/components/ui/Icon';
 import { cn } from '@/lib/utils';
 import { useExport } from '../hooks/useExport';
 import { useWCSData, WCSRecord } from '../hooks/useWCSData';
@@ -91,7 +90,7 @@ function WCSExportTools({ data }: { data: WCSRecord[] }) {
   return (
     <Box border surface="default" padding="card">
       <Stack gap={6}>
-        <Box display="flex" align="center" gap={3}"><Download className="w-5 h-5 text-accent" /><Text variant="mono" size="xs" weight="font-bold" uppercase>Export Data</Text></Box>
+        <Box display="flex" align="center" gap={3}> <Download className="w-5 h-5 text-accent" /> <Text variant="mono" size="xs" weight="font-bold" uppercase>Export Data</Text></Box>
         <Stack gap={3}>
           <ActionButton variant="secondary" width="full" padding={3} onClick={handleExportCSV}>
             <Box display="flex" align="center" gap={3} width="full" textAlign="left"><FileJson className="w-4 h-4 shrink-0" /><Stack gap={0}><Text variant="mono" size="micro" weight="font-bold">EXPORT_CSV</Text><Text variant="body" size="micro" color="dim">Raw machine-readable data</Text></Stack></Box>
@@ -145,8 +144,7 @@ export function WCSScraperTool() {
     setFilterPromoted,
     scoreDistribution,
     trendData,
-    totalEvents,
-    lastSync
+    totalEvents
   } = useWCSData();
 
   useEffect(() => {


### PR DESCRIPTION
This PR addresses Issue 7 by extracting a shared `WCSChartCard` component for chart containers, and Issue 8 by introducing a shared `ResearchToolShell` and fixing imports. It refactors `WCSChartContainers`, `WCSScraperTool`, and related components, adding new layout components `DataPanel` and `ResearchToolShell`. All changes are type-safe, use MUI, and adhere to project conventions.