### PR TITLE
Add visual & DOM diff pipeline to deployment impact analysis

### DIFF
--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -20,7 +20,7 @@ runs:
       uses: pnpm/action-setup@v4
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         cache: 'pnpm'
         node-version-file: ${{ inputs.node-version-file }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,11 @@ on:
       - 'etl/**'
       - 'dev-tools/**'
       - 'tests/**'
+      - 'scripts/**'
       - 'package.json'
       - 'pnpm-lock.yaml'
       - '.github/workflows/ci.yml'
+      - '.github/actions/**'
       - 'AGENTS.md'
       - 'USAGE_NOTES.md'
       - 'WORKFLOW.md'
@@ -25,9 +27,11 @@ on:
       - 'etl/**'
       - 'dev-tools/**'
       - 'tests/**'
+      - 'scripts/**'
       - 'package.json'
       - 'pnpm-lock.yaml'
       - '.github/workflows/ci.yml'
+      - '.github/actions/**'
       - 'AGENTS.md'
       - 'USAGE_NOTES.md'
       - 'WORKFLOW.md'
@@ -57,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -114,7 +118,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Setup dependencies once and use caching for speedup.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: ./.github/actions/setup-node-pnpm
@@ -163,7 +167,7 @@ jobs:
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       # Setup dependencies once and use caching for speedup.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-node-pnpm
       - run: pnpm install --frozen-lockfile --prefer-offline
       - uses: actions/setup-python@v5
@@ -222,24 +226,38 @@ jobs:
     name: Deployment Impact Analysis
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: ./.github/actions/setup-node-pnpm
       - run: pnpm install --frozen-lockfile --prefer-offline
-      - name: Run Impact Analysis
+      - name: Install Playwright browser
+        run: pnpm run setup:playwright
+      - name: Deployment Impact Analysis
         run: pnpm run impact:analysis
+      - name: Build Main
+        run: pnpm run impact:build-main
+      - name: Build PR
+        env:
+          VITE_BASE_PATH: /
+        run: pnpm run build
+      - name: Visual Diff
+        run: pnpm run impact:visual-diff
+      - name: DOM Diff
+        run: pnpm run impact:dom-diff
       - name: Report Summary
         if: always()
         run: |
-          if [ -f artifacts/impact-analysis/impact.md ]; then
+          if [ -f artifacts/deployment-review.md ]; then
+            cat artifacts/deployment-review.md >> "$GITHUB_STEP_SUMMARY"
+          elif [ -f artifacts/impact-analysis/impact.md ]; then
             cat artifacts/impact-analysis/impact.md >> "$GITHUB_STEP_SUMMARY"
           else
             echo "## Deployment Impact Analysis" >> "$GITHUB_STEP_SUMMARY"
             echo "No impact report found." >> "$GITHUB_STEP_SUMMARY"
           fi
-      - name: Upload Impact Report
+      - name: Upload Deployment Review Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: deployment-impact-report
-          path: artifacts/impact-analysis/
+          name: deployment-review
+          path: artifacts/

--- a/package.json
+++ b/package.json
@@ -41,7 +41,10 @@
     "affiliate:image": "tsx scripts/affiliate/image-helper.ts",
     "affiliate:audit": "tsx scripts/affiliate/audit.ts",
     "audit:semantic": "node scripts/detect-semantic-duplicates.mjs",
-    "impact:analysis": "tsx scripts/impact-analysis.ts"
+    "impact:analysis": "tsx scripts/impact-analysis.ts",
+    "impact:build-main": "tsx scripts/impact-build-main.ts",
+    "impact:visual-diff": "tsx scripts/impact-visual-diff.ts",
+    "impact:dom-diff": "tsx scripts/impact-dom-diff.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
@@ -99,7 +102,10 @@
     "@testing-library/react": "^16.3.2",
     "@types/node": "^22.14.0",
     "@types/papaparse": "^5.5.2",
+    "@types/pixelmatch": "^5.2.6",
+    "@types/pngjs": "^6.0.5",
     "dependency-cruiser": "^17.4.3",
+    "diff": "^9.0.0",
     "eslint": "^10.2.1",
     "eslint-plugin-react-hooks": "^7.1.1",
     "globals": "^17.5.0",
@@ -107,7 +113,9 @@
     "knip": "^6.7.0",
     "npm-run-all": "^4.1.5",
     "oxlint": "^1.61.0",
+    "pixelmatch": "^7.2.0",
     "playwright": "1.49.0",
+    "pngjs": "^7.0.0",
     "rollup-plugin-visualizer": "^7.0.1",
     "sharp": "^0.34.5",
     "shx": "^0.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,9 +156,18 @@ importers:
       '@types/papaparse':
         specifier: ^5.5.2
         version: 5.5.2
+      '@types/pixelmatch':
+        specifier: ^5.2.6
+        version: 5.2.6
+      '@types/pngjs':
+        specifier: ^6.0.5
+        version: 6.0.5
       dependency-cruiser:
         specifier: ^17.4.3
         version: 17.4.3
+      diff:
+        specifier: ^9.0.0
+        version: 9.0.0
       eslint:
         specifier: ^10.2.1
         version: 10.2.1(jiti@2.6.1)
@@ -180,9 +189,15 @@ importers:
       oxlint:
         specifier: ^1.61.0
         version: 1.61.0
+      pixelmatch:
+        specifier: ^7.2.0
+        version: 7.2.0
       playwright:
         specifier: 1.49.0
         version: 1.49.0
+      pngjs:
+        specifier: ^7.0.0
+        version: 7.0.0
       rollup-plugin-visualizer:
         specifier: ^7.0.1
         version: 7.0.1(rolldown@1.0.0-rc.17)(rollup@2.80.0)
@@ -2583,6 +2598,12 @@ packages:
   '@types/papaparse@5.5.2':
     resolution: {integrity: sha512-gFnFp/JMzLHCwRf7tQHrNnfhN4eYBVYYI897CGX4MY1tzY9l2aLkVyx2IlKZ/SAqDbB3I1AOZW5gTMGGsqWliA==}
 
+  '@types/pixelmatch@5.2.6':
+    resolution: {integrity: sha512-wC83uexE5KGuUODn6zkm9gMzTwdY5L0chiK+VrKcDfEjzxh1uadlWTvOmAbCpnM9zx/Ww3f8uKlYQVnO/TrqVg==}
+
+  '@types/pngjs@6.0.5':
+    resolution: {integrity: sha512-0k5eKfrA83JOZPppLtS2C7OUtyNAl2wKNxfyYl9Q5g9lPkgBl/9hNyAu6HuEH2J4XmIv2znEpkDd0SaZVxW6iQ==}
+
   '@types/prismjs@1.26.6':
     resolution: {integrity: sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw==}
 
@@ -3397,6 +3418,10 @@ packages:
 
   devtools-protocol@0.0.1595872:
     resolution: {integrity: sha512-kRfgp8vWVjBu/fbYCiVFiOqsCk3CrMKEo3WbgGT2NXK2dG7vawWPBljixajVgGK9II8rDO9G0oD0zLt3I1daRg==}
+
+  diff@9.0.0:
+    resolution: {integrity: sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==}
+    engines: {node: '>=0.3.1'}
 
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
@@ -5040,6 +5065,10 @@ packages:
     resolution: {integrity: sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==}
     engines: {node: '>=4'}
 
+  pixelmatch@7.2.0:
+    resolution: {integrity: sha512-xhcb4yHu9sM/G7foGzoLtXYcC0zHEaOXXjRKhGup0fw78Nf2Tkiapv4EQyMzrbcmQPsllAI7DbFY2UT7PlI9Pg==}
+    hasBin: true
+
   playwright-core@1.49.0:
     resolution: {integrity: sha512-R+3KKTQF3npy5GTiKH/T+kdhoJfJojjHESR1YEWhYuEKRVfVaxH3+4+GvXE5xyCngCxhxnykk0Vlah9v8fs3jA==}
     engines: {node: '>=18'}
@@ -5054,6 +5083,10 @@ packages:
     resolution: {integrity: sha512-eKpmys0UFDnfNb3vfsf8Vx2LEOtflgRebl0Im2eQQnYMA4Aqd+Zw8bEOB+7ZKvN76901mRnqdsiOGKxzVTbi7A==}
     engines: {node: '>=18'}
     hasBin: true
+
+  pngjs@7.0.0:
+    resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
+    engines: {node: '>=14.19.0'}
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -8648,6 +8681,14 @@ snapshots:
     dependencies:
       '@types/node': 22.19.17
 
+  '@types/pixelmatch@5.2.6':
+    dependencies:
+      '@types/node': 22.19.17
+
+  '@types/pngjs@6.0.5':
+    dependencies:
+      '@types/node': 22.19.17
+
   '@types/prismjs@1.26.6': {}
 
   '@types/raf@3.4.3':
@@ -9456,6 +9497,8 @@ snapshots:
   devtools-protocol@0.0.1467305: {}
 
   devtools-protocol@0.0.1595872: {}
+
+  diff@9.0.0: {}
 
   dom-accessibility-api@0.5.16: {}
 
@@ -11587,6 +11630,10 @@ snapshots:
 
   pify@3.0.0: {}
 
+  pixelmatch@7.2.0:
+    dependencies:
+      pngjs: 7.0.0
+
   playwright-core@1.49.0: {}
 
   playwright-core@1.59.1: {}
@@ -11596,6 +11643,8 @@ snapshots:
       playwright-core: 1.49.0
     optionalDependencies:
       fsevents: 2.3.2
+
+  pngjs@7.0.0: {}
 
   possible-typed-array-names@1.1.0: {}
 

--- a/scripts/impact-analysis.ts
+++ b/scripts/impact-analysis.ts
@@ -202,6 +202,7 @@ async function main() {
     const report = {
       changedFiles,
       affectedPages,
+      routes: allUrls,
       visualReviewRequired: allUrls,
       impactLevel: severity
     };
@@ -232,6 +233,7 @@ async function main() {
     }
 
     fs.writeFileSync(path.join(outputDir, 'impact.json'), JSON.stringify(report, null, 2));
+    fs.writeFileSync(path.join(process.cwd(), 'artifacts', 'impact-analysis.json'), JSON.stringify(report, null, 2));
 
     const changedFilesList = changedFiles.map(f => `- ${f}`).join('\n');
 

--- a/scripts/impact-build-main.ts
+++ b/scripts/impact-build-main.ts
@@ -1,0 +1,36 @@
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+const worktreePath = path.join(process.cwd(), '.tmp-main');
+const baseRef = process.env.IMPACT_BASE_REF ?? 'origin/main';
+
+function run(command: string, args: string[], cwd = process.cwd()): void {
+  console.log(`$ ${command} ${args.join(' ')}`);
+  execFileSync(command, args, { cwd, stdio: 'inherit', env: { ...process.env, VITE_BASE_PATH: '/' } });
+}
+
+function removeExistingWorktree(): void {
+  if (!fs.existsSync(worktreePath)) return;
+
+  try {
+    run('git', ['worktree', 'remove', '--force', worktreePath]);
+  } catch {
+    fs.rmSync(worktreePath, { recursive: true, force: true });
+    run('git', ['worktree', 'prune']);
+  }
+}
+
+removeExistingWorktree();
+
+try {
+  run('git', ['rev-parse', '--verify', baseRef]);
+} catch {
+  run('git', ['fetch', 'origin', 'main']);
+}
+
+run('git', ['worktree', 'add', worktreePath, baseRef]);
+run('pnpm', ['install', '--frozen-lockfile', '--prefer-offline'], worktreePath);
+run('pnpm', ['run', 'build'], worktreePath);
+
+console.log(`✅ Built base branch worktree at ${worktreePath}`);

--- a/scripts/impact-dom-diff.ts
+++ b/scripts/impact-dom-diff.ts
@@ -1,0 +1,196 @@
+import { diffLines } from 'diff';
+import fs from 'fs';
+import path from 'path';
+import { JSDOM } from 'jsdom';
+import {
+  ARTIFACTS_DIR,
+  DOM_REVIEW_DIR,
+  DOM_SUMMARY_PATH,
+  VISUAL_SUMMARY_PATH,
+  combinedSeverity,
+  domSeverity,
+  ensureDirectory,
+  readImpactAnalysis,
+  routeToSlug,
+  type DomRouteSummary,
+  type VisualRouteSummary
+} from './impact-review-utils';
+
+const deploymentReviewPath = path.join(ARTIFACTS_DIR, 'deployment-review.md');
+
+function normalizeHtml(html: string): string {
+  const dom = new JSDOM(html);
+  const document = dom.window.document;
+
+  document.querySelectorAll('script, style, noscript').forEach(element => element.remove());
+  document.querySelectorAll('*').forEach(element => {
+    for (const attribute of Array.from(element.attributes) as Attr[]) {
+      if (
+        attribute.name === 'data-reactroot' ||
+        attribute.name === 'data-testid' ||
+        attribute.name === 'nonce' ||
+        attribute.name.startsWith('data-vite') ||
+        attribute.name.startsWith('data-radix') ||
+        attribute.name.startsWith('aria-busy') ||
+        /timestamp|hydration|^data-.*id$|^id$/.test(attribute.name)
+      ) {
+        element.removeAttribute(attribute.name);
+      }
+    }
+  });
+
+  return dom.serialize().replace(/\s+/g, ' ').replace(/>\s+</g, '><').trim();
+}
+
+function countElements(html: string, selector = '*'): number {
+  const dom = new JSDOM(html);
+  return dom.window.document.querySelectorAll(selector).length;
+}
+
+function summarizeDom(beforeHtml: string, afterHtml: string): DomRouteSummary['metrics'] {
+  const beforeNodes = countElements(beforeHtml);
+  const afterNodes = countElements(afterHtml);
+  const beforeImages = countElements(beforeHtml, 'img');
+  const afterImages = countElements(afterHtml, 'img');
+  const beforeLinks = countElements(beforeHtml, 'a');
+  const afterLinks = countElements(afterHtml, 'a');
+
+  return {
+    nodesAdded: Math.max(0, afterNodes - beforeNodes),
+    nodesRemoved: Math.max(0, beforeNodes - afterNodes),
+    imagesAdded: Math.max(0, afterImages - beforeImages),
+    imagesRemoved: Math.max(0, beforeImages - afterImages),
+    linksAdded: Math.max(0, afterLinks - beforeLinks),
+    linksRemoved: Math.max(0, beforeLinks - afterLinks)
+  };
+}
+
+function writeTextDiff(beforeHtml: string, afterHtml: string, outputPath: string): void {
+  const parts = diffLines(beforeHtml, afterHtml);
+  const lines = parts.flatMap(part => {
+    const prefix = part.added ? '+' : part.removed ? '-' : ' ';
+    return part.value
+      .split('\n')
+      .filter(Boolean)
+      .map(line => `${prefix} ${line}`);
+  });
+
+  fs.writeFileSync(outputPath, lines.join('\n'));
+}
+
+function readVisualSummaries(): VisualRouteSummary[] {
+  if (!fs.existsSync(VISUAL_SUMMARY_PATH)) return [];
+  const parsed = JSON.parse(fs.readFileSync(VISUAL_SUMMARY_PATH, 'utf8')) as { routes?: VisualRouteSummary[] };
+  return parsed.routes ?? [];
+}
+
+function formatDomMetrics(metrics: DomRouteSummary['metrics']): string[] {
+  const rows = [
+    ['Added nodes', metrics.nodesAdded],
+    ['Removed nodes', metrics.nodesRemoved],
+    ['Added images', metrics.imagesAdded],
+    ['Removed images', metrics.imagesRemoved],
+    ['Added links', metrics.linksAdded],
+    ['Removed links', metrics.linksRemoved]
+  ] as const;
+
+  const changed = rows.filter(([, value]) => value > 0);
+  return changed.length > 0 ? changed.map(([label, value]) => `- ${label}: ${value}`) : ['None'];
+}
+
+function generateDeploymentReport(domSummaries: DomRouteSummary[], visualSummaries: VisualRouteSummary[]): void {
+  const impact = readImpactAnalysis();
+  const visualByRoute = new Map(visualSummaries.map(summary => [summary.route, summary]));
+  const changedFiles = impact.changedFiles ?? [];
+
+  const routeSections = domSummaries.map(domSummary => {
+    const visual = visualByRoute.get(domSummary.route);
+    const severity = combinedSeverity(visual?.severity, domSummary.severity);
+    const reviewRequired = severity !== 'LOW';
+
+    return `### ${domSummary.route}
+
+Visual Difference: ${(visual?.differencePercent ?? 0).toFixed(2)}%
+
+DOM Changes:
+${formatDomMetrics(domSummary.metrics).join('\n')}
+
+Severity: ${severity}
+
+Review Required: ${reviewRequired ? 'Yes' : 'No'}
+
+Artifacts:
+- Before screenshot: ${visual?.beforePath ?? 'Not captured'}
+- After screenshot: ${visual?.afterPath ?? 'Not captured'}
+- Visual diff: ${visual?.diffPath ?? 'Not captured'}
+- DOM diff: ${domSummary.diffPath}
+`;
+  });
+
+  const report = `# Deployment Review
+
+## Summary
+
+Impact Level: ${impact.impactLevel ?? 'LOW'}
+
+Changed Files:
+${changedFiles.length > 0 ? changedFiles.map(file => `- ${file}`).join('\n') : '- None detected'}
+
+## Routes Reviewed
+
+${routeSections.length > 0 ? routeSections.join('\n---\n\n') : '_No concrete routes required review._'}
+`;
+
+  fs.writeFileSync(deploymentReviewPath, report);
+}
+
+function main(): void {
+  const impact = readImpactAnalysis();
+  const routes = impact.routes.filter(route => !route.includes(':'));
+  const summaries: DomRouteSummary[] = [];
+
+  ensureDirectory(DOM_REVIEW_DIR);
+
+  for (const route of routes) {
+    const slug = routeToSlug(route);
+    const routeDomDir = path.join(DOM_REVIEW_DIR, slug);
+    const beforeHtmlPath = path.join(routeDomDir, 'before.html');
+    const afterHtmlPath = path.join(routeDomDir, 'after.html');
+    const diffPath = path.join(routeDomDir, 'diff.txt');
+    const jsonPath = path.join(DOM_REVIEW_DIR, `${slug}.json`);
+
+    if (!fs.existsSync(beforeHtmlPath) || !fs.existsSync(afterHtmlPath)) {
+      throw new Error(`Missing DOM captures for ${route}. Run \`pnpm impact:visual-diff\` first.`);
+    }
+
+    const beforeHtml = normalizeHtml(fs.readFileSync(beforeHtmlPath, 'utf8'));
+    const afterHtml = normalizeHtml(fs.readFileSync(afterHtmlPath, 'utf8'));
+    const metrics = summarizeDom(beforeHtml, afterHtml);
+    writeTextDiff(beforeHtml, afterHtml, diffPath);
+
+    const summary: DomRouteSummary = {
+      route,
+      slug,
+      beforeHtmlPath: path.relative(process.cwd(), beforeHtmlPath),
+      afterHtmlPath: path.relative(process.cwd(), afterHtmlPath),
+      diffPath: path.relative(process.cwd(), diffPath),
+      metrics,
+      severity: domSeverity(metrics.nodesAdded + metrics.nodesRemoved)
+    };
+
+    fs.writeFileSync(jsonPath, JSON.stringify(summary, null, 2));
+    summaries.push(summary);
+  }
+
+  fs.writeFileSync(DOM_SUMMARY_PATH, JSON.stringify({ routes: summaries }, null, 2));
+  generateDeploymentReport(summaries, readVisualSummaries());
+  console.log(`✅ DOM diffs generated in ${DOM_REVIEW_DIR}`);
+  console.log(`✅ Deployment review report generated at ${deploymentReviewPath}`);
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(`❌ DOM diff failed: ${error instanceof Error ? error.message : String(error)}`);
+  process.exit(1);
+}

--- a/scripts/impact-review-utils.ts
+++ b/scripts/impact-review-utils.ts
@@ -1,0 +1,137 @@
+import { spawn, type ChildProcess } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+export interface ImpactAnalysisArtifact {
+  routes?: string[];
+  visualReviewRequired?: string[];
+  changedFiles?: string[];
+  affectedPages?: string[];
+  impactLevel?: 'HIGH' | 'MEDIUM' | 'LOW';
+}
+
+export interface VisualRouteSummary {
+  route: string;
+  slug: string;
+  beforePath: string;
+  afterPath: string;
+  diffPath: string;
+  diffPixels: number;
+  totalPixels: number;
+  differencePercent: number;
+  severity: 'LOW' | 'MEDIUM' | 'HIGH';
+}
+
+export interface DomRouteSummary {
+  route: string;
+  slug: string;
+  beforeHtmlPath: string;
+  afterHtmlPath: string;
+  diffPath: string;
+  metrics: {
+    nodesAdded: number;
+    nodesRemoved: number;
+    imagesAdded: number;
+    imagesRemoved: number;
+    linksAdded: number;
+    linksRemoved: number;
+  };
+  severity: 'LOW' | 'MEDIUM' | 'HIGH';
+}
+
+export const ARTIFACTS_DIR = path.join(process.cwd(), 'artifacts');
+export const VISUAL_REVIEW_DIR = path.join(ARTIFACTS_DIR, 'visual-review');
+export const DOM_REVIEW_DIR = path.join(ARTIFACTS_DIR, 'dom-review');
+export const IMPACT_ANALYSIS_PATH = path.join(ARTIFACTS_DIR, 'impact-analysis.json');
+export const VISUAL_SUMMARY_PATH = path.join(VISUAL_REVIEW_DIR, 'summary.json');
+export const DOM_SUMMARY_PATH = path.join(DOM_REVIEW_DIR, 'summary.json');
+
+export function ensureDirectory(directory: string): void {
+  fs.mkdirSync(directory, { recursive: true });
+}
+
+export function routeToSlug(route: string): string {
+  if (route === '/') return 'home';
+
+  const withoutQuery = route.split('?')[0] ?? route;
+  const slug = withoutQuery
+    .replace(/^\/+|\/+$/g, '')
+    .replace(/[:*]/g, '')
+    .replace(/[^a-zA-Z0-9-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .toLowerCase();
+
+  return slug || 'home';
+}
+
+export function readImpactAnalysis(): Required<Pick<ImpactAnalysisArtifact, 'routes'>> & ImpactAnalysisArtifact {
+  const candidates = [
+    IMPACT_ANALYSIS_PATH,
+    path.join(ARTIFACTS_DIR, 'impact-analysis', 'impact.json')
+  ];
+
+  const artifactPath = candidates.find(candidate => fs.existsSync(candidate));
+  if (!artifactPath) {
+    throw new Error('Missing impact analysis artifact. Run `pnpm impact:analysis` first.');
+  }
+
+  const artifact = JSON.parse(fs.readFileSync(artifactPath, 'utf8')) as ImpactAnalysisArtifact;
+  const routes = artifact.routes ?? artifact.visualReviewRequired ?? [];
+
+  return { ...artifact, routes };
+}
+
+export function visualSeverity(percent: number): 'LOW' | 'MEDIUM' | 'HIGH' {
+  if (percent > 5) return 'HIGH';
+  if (percent > 1) return 'MEDIUM';
+  return 'LOW';
+}
+
+export function domSeverity(nodesChanged: number): 'LOW' | 'MEDIUM' | 'HIGH' {
+  if (nodesChanged > 20) return 'HIGH';
+  if (nodesChanged > 5) return 'MEDIUM';
+  return 'LOW';
+}
+
+export function combinedSeverity(...severities: Array<'LOW' | 'MEDIUM' | 'HIGH' | undefined>): 'LOW' | 'MEDIUM' | 'HIGH' {
+  if (severities.includes('HIGH')) return 'HIGH';
+  if (severities.includes('MEDIUM')) return 'MEDIUM';
+  return 'LOW';
+}
+
+export function startPreview(cwd: string, port: number): ChildProcess {
+  const child = spawn('pnpm', ['exec', 'vite', 'preview', '--host', '127.0.0.1', '--port', String(port)], {
+    cwd,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: {
+      ...process.env,
+      VITE_BASE_PATH: '/'
+    }
+  });
+
+  child.stdout?.on('data', data => process.stdout.write(`[preview:${port}] ${String(data)}`));
+  child.stderr?.on('data', data => process.stderr.write(`[preview:${port}] ${String(data)}`));
+
+  return child;
+}
+
+export async function waitForServer(url: string, timeoutMs = 30_000): Promise<void> {
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    try {
+      const response = await fetch(url);
+      if (response.ok || response.status < 500) return;
+    } catch {
+      // Retry until timeout.
+    }
+    await new Promise(resolve => setTimeout(resolve, 500));
+  }
+
+  throw new Error(`Timed out waiting for ${url}`);
+}
+
+export function stopPreview(child: ChildProcess): void {
+  if (!child.killed) {
+    child.kill('SIGTERM');
+  }
+}

--- a/scripts/impact-visual-diff.ts
+++ b/scripts/impact-visual-diff.ts
@@ -1,0 +1,147 @@
+import { chromium } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+import pixelmatch from 'pixelmatch';
+import { PNG } from 'pngjs';
+import {
+  ARTIFACTS_DIR,
+  DOM_REVIEW_DIR,
+  VISUAL_REVIEW_DIR,
+  VISUAL_SUMMARY_PATH,
+  ensureDirectory,
+  readImpactAnalysis,
+  routeToSlug,
+  startPreview,
+  stopPreview,
+  visualSeverity,
+  waitForServer,
+  type VisualRouteSummary
+} from './impact-review-utils';
+
+const basePort = Number(process.env.IMPACT_BASE_PORT ?? 4173);
+const headPort = Number(process.env.IMPACT_HEAD_PORT ?? 4174);
+const baseUrl = process.env.IMPACT_BASE_URL ?? `http://127.0.0.1:${basePort}`;
+const headUrl = process.env.IMPACT_HEAD_URL ?? `http://127.0.0.1:${headPort}`;
+const baseWorktree = process.env.IMPACT_BASE_WORKTREE ?? path.join(process.cwd(), '.tmp-main');
+
+function whiteCanvas(width: number, height: number): PNG {
+  const image = new PNG({ width, height });
+  for (let index = 0; index < image.data.length; index += 4) {
+    image.data[index] = 255;
+    image.data[index + 1] = 255;
+    image.data[index + 2] = 255;
+    image.data[index + 3] = 255;
+  }
+  return image;
+}
+
+function copyImage(source: PNG, target: PNG): void {
+  PNG.bitblt(source, target, 0, 0, source.width, source.height, 0, 0);
+}
+
+async function captureRoute(base: string, route: string, imagePath: string, htmlPath: string): Promise<void> {
+  const browser = await chromium.launch();
+  try {
+    const page = await browser.newPage({ viewport: { width: 1440, height: 900 } });
+    await page.goto(new URL(route, base).toString(), { waitUntil: 'domcontentloaded' });
+    await page.waitForLoadState('networkidle', { timeout: 10_000 }).catch(() => {
+      console.warn(`Network did not become idle for ${route}; continuing with captured DOM state.`);
+    });
+    await page.screenshot({ path: imagePath, fullPage: true });
+    fs.writeFileSync(htmlPath, await page.content());
+  } finally {
+    await browser.close();
+  }
+}
+
+function createVisualDiff(beforePath: string, afterPath: string, diffPath: string): Omit<VisualRouteSummary, 'route' | 'slug' | 'beforePath' | 'afterPath' | 'diffPath' | 'severity'> {
+  const beforeRaw = PNG.sync.read(fs.readFileSync(beforePath));
+  const afterRaw = PNG.sync.read(fs.readFileSync(afterPath));
+  const width = Math.max(beforeRaw.width, afterRaw.width);
+  const height = Math.max(beforeRaw.height, afterRaw.height);
+  const before = whiteCanvas(width, height);
+  const after = whiteCanvas(width, height);
+  const diff = whiteCanvas(width, height);
+
+  copyImage(beforeRaw, before);
+  copyImage(afterRaw, after);
+
+  const diffPixels = pixelmatch(before.data, after.data, diff.data, width, height, { threshold: 0.1 });
+  const totalPixels = width * height;
+  const differencePercent = totalPixels === 0 ? 0 : (diffPixels / totalPixels) * 100;
+
+  fs.writeFileSync(diffPath, PNG.sync.write(diff));
+
+  return { diffPixels, totalPixels, differencePercent };
+}
+
+async function main(): Promise<void> {
+  const impact = readImpactAnalysis();
+  const routes = impact.routes.filter(route => !route.includes(':'));
+
+  ensureDirectory(ARTIFACTS_DIR);
+  ensureDirectory(VISUAL_REVIEW_DIR);
+  ensureDirectory(DOM_REVIEW_DIR);
+
+  if (routes.length === 0) {
+    fs.writeFileSync(VISUAL_SUMMARY_PATH, JSON.stringify({ routes: [] }, null, 2));
+    console.log('✅ No concrete routes require visual review.');
+    return;
+  }
+
+  if (!fs.existsSync(path.join(baseWorktree, 'dist'))) {
+    throw new Error('Missing built base worktree dist. Run `pnpm impact:build-main` first.');
+  }
+
+  if (!fs.existsSync(path.join(process.cwd(), 'dist'))) {
+    throw new Error('Missing PR dist. Run `pnpm build` before visual diff.');
+  }
+
+  const basePreview = startPreview(baseWorktree, basePort);
+  const headPreview = startPreview(process.cwd(), headPort);
+
+  try {
+    await Promise.all([waitForServer(baseUrl), waitForServer(headUrl)]);
+
+    const summaries: VisualRouteSummary[] = [];
+    for (const route of routes) {
+      const slug = routeToSlug(route);
+      const routeVisualDir = path.join(VISUAL_REVIEW_DIR, slug);
+      const routeDomDir = path.join(DOM_REVIEW_DIR, slug);
+      ensureDirectory(routeVisualDir);
+      ensureDirectory(routeDomDir);
+
+      const beforePath = path.join(routeVisualDir, 'before.png');
+      const afterPath = path.join(routeVisualDir, 'after.png');
+      const diffPath = path.join(routeVisualDir, 'diff.png');
+      const beforeHtmlPath = path.join(routeDomDir, 'before.html');
+      const afterHtmlPath = path.join(routeDomDir, 'after.html');
+
+      console.log(`📸 Capturing ${route}`);
+      await captureRoute(baseUrl, route, beforePath, beforeHtmlPath);
+      await captureRoute(headUrl, route, afterPath, afterHtmlPath);
+
+      const diff = createVisualDiff(beforePath, afterPath, diffPath);
+      summaries.push({
+        route,
+        slug,
+        beforePath: path.relative(process.cwd(), beforePath),
+        afterPath: path.relative(process.cwd(), afterPath),
+        diffPath: path.relative(process.cwd(), diffPath),
+        ...diff,
+        severity: visualSeverity(diff.differencePercent)
+      });
+    }
+
+    fs.writeFileSync(VISUAL_SUMMARY_PATH, JSON.stringify({ routes: summaries }, null, 2));
+    console.log(`✅ Visual diffs generated in ${VISUAL_REVIEW_DIR}`);
+  } finally {
+    stopPreview(basePreview);
+    stopPreview(headPreview);
+  }
+}
+
+main().catch(error => {
+  console.error(`❌ Visual diff failed: ${error instanceof Error ? error.message : String(error)}`);
+  process.exit(1);
+});


### PR DESCRIPTION
### Motivation
- Reduce noisy review surface by verifying whether affected routes show real visual or structural changes before requiring human review. 
- Capture both pixel-level and DOM-level changes for each impacted route so reviewers get actionable artifacts (screenshots, diffs, and a summarized report). 
- Provide a CI-friendly, reproducible pipeline that can build the base branch without switching branches and run side-by-side comparisons. 

### Description
- Extend the impact analyzer to emit route artifacts (`routes`) and write a machine-readable artifact at `artifacts/impact-analysis.json` for downstream stages by updating `scripts/impact-analysis.ts`. 
- Add new scripts: `scripts/impact-build-main.ts` (base-branch worktree build), `scripts/impact-visual-diff.ts` (Playwright screenshot + Pixelmatch visual diffs), `scripts/impact-dom-diff.ts` (JSDOM normalization + DOM diffs + metrics + markdown `deployment-review.md`), and `scripts/impact-review-utils.ts` (shared helpers and constants). 
- Wire new npm scripts (`impact:build-main`, `impact:visual-diff`, `impact:dom-diff`) and add dev dependencies required for the pipeline (`pixelmatch`, `pngjs`, `diff`, Playwright tooling), plus small package metadata updates. 
- Update CI: run Playwright browser install, run `impact:analysis`, build main via worktree, build PR, run visual and DOM diffs, and upload `artifacts/` as `deployment-review`; also update the node/pnpm setup action to `actions/setup-node@v6`. 

### Testing
- Runtime and environment checks were run via `corepack enable && corepack prepare pnpm@10.28.2 --activate && pnpm run check:runtime-files && pnpm run doctor` and succeeded. 
- Lint and static audits passed with `pnpm run audit` and `pnpm run lint`, and TypeScript checks on the new scripts passed using the project `tsc` invocation. 
- End-to-end pipeline commands executed locally: `pnpm run impact:analysis` produced `artifacts/impact-analysis`, `IMPACT_BASE_WORKTREE=. pnpm run impact:visual-diff` produced `artifacts/visual-review`, and `pnpm run impact:dom-diff` produced `artifacts/dom-review` and `artifacts/deployment-review.md`; these runs succeeded after installing browsers with `pnpm exec playwright install chromium`. 
- One environment warning was observed when running `python3 dev-tools/td_cli.py gh conflicts` due to a malformed `origin` remote URL in this environment, which does not affect the pipeline scripts themselves.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2cab81cfa8832583446a70ed82e528)