### PR TITLE
feat(dev-tools): add PAT_TOKEN support to get_github_token and conflict checking

### DIFF
--- a/dev-tools/dev_tools_sdk/utils/auth.py
+++ b/dev-tools/dev_tools_sdk/utils/auth.py
@@ -9,7 +9,7 @@ class AuthError(RuntimeError):
     pass
 
 
-def get_github_token(env_vars: Sequence[str] = ("CODEX_GH_TOKEN", "GH_TOKEN", "GITHUB_TOKEN")) -> str:
+def get_github_token(env_vars: Sequence[str] = ("CODEX_GH_TOKEN", "GH_TOKEN", "GITHUB_TOKEN", "PAT_TOKEN")) -> str:
     for var in env_vars:
         value = os.getenv(var)
         if value:

--- a/dev-tools/tdw_services/orchestrator.py
+++ b/dev-tools/tdw_services/orchestrator.py
@@ -385,10 +385,9 @@ class Orchestrator:
         return formatted
 
     def _get_conflicts_github_token(self) -> Tuple[Optional[str], Optional[str]]:
-        if os.environ.get("CODEX_GH_TOKEN"):
-            return os.environ["CODEX_GH_TOKEN"], "CODEX_GH_TOKEN"
-        if os.environ.get("GITHUB_TOKEN"):
-            return os.environ["GITHUB_TOKEN"], "GITHUB_TOKEN"
+        for var in ("CODEX_GH_TOKEN", "GH_TOKEN", "GITHUB_TOKEN", "PAT_TOKEN"):
+            if os.environ.get(var):
+                return os.environ[var], var
         return None, None
 
     def _validate_github_token_for_conflicts(self, repo_slug: str) -> Optional[Dict[str, str]]:
@@ -396,7 +395,7 @@ class Orchestrator:
         if not token:
             return {
                 "status": "environment_error",
-                "message": "Missing GitHub token. Set CODEX_GH_TOKEN or GITHUB_TOKEN before running `python3 dev-tools/td_cli.py gh conflicts`.",
+                "message": "Missing GitHub token. Set CODEX_GH_TOKEN, GITHUB_TOKEN, or PAT_TOKEN before running `python3 dev-tools/td_cli.py gh conflicts`.",
             }
 
         if any(char.isspace() for char in token) or any(ord(char) < 32 for char in token):

--- a/dev-tools/utils.py
+++ b/dev-tools/utils.py
@@ -179,7 +179,7 @@ def run_command(cmd: Union[str, List[str]], shell: bool = False, check: bool = T
 
 def get_github_token() -> Optional[str]:
     """Retrieves the GitHub token from environment (prioritizing CODEX_GH_TOKEN) or via gh CLI."""
-    token = os.getenv("CODEX_GH_TOKEN") or os.getenv("GH_TOKEN") or os.getenv("GITHUB_TOKEN")
+    token = os.getenv("CODEX_GH_TOKEN") or os.getenv("GH_TOKEN") or os.getenv("GITHUB_TOKEN") or os.getenv("PAT_TOKEN")
     if token:
         return token
     try:


### PR DESCRIPTION
This PR fixes Issue #2275 by adding `PAT_TOKEN` to the recognized environment variables for GitHub API token resolution. 

### Changes:
- Updates `get_github_token` in `dev_tools_sdk/utils/auth.py` and `dev-tools/utils.py` to check `os.getenv("PAT_TOKEN")` as a fallback.
- Updates `_get_conflicts_github_token` and `_validate_github_token_for_conflicts` in `orchestrator.py` to support `GH_TOKEN` and `PAT_TOKEN` during merge conflict checks.