### PR TITLE
Aggregated Feature: feat/aggregate-2397-2396-2394-2392-2390

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,4 @@ dev-tools/logs/audits/
 .pr_cache.pkl
 gh_2.54.0_linux_amd64/
 gh_2.54.0_linux_amd64.tar.gz
+.tmp-main

--- a/content/posts/2026-04-18-halloween-costumes.md
+++ b/content/posts/2026-04-18-halloween-costumes.md
@@ -1,9 +1,9 @@
 ---
 type: post
 title: "Halloween costumes you can dance in"
-date: "2026-10-31"
+date: "2026-04-18"
 author: "Ariel Anders, PhD"
-category: "Gear"
+category: "Costumes"
 excerpt: "Easiest DIY pumpkin costume: orange outfit + pumpkin headband + stick-on jack-o’-lantern face. No sewing, no felt cutting, still cute enough for Halloween dancing."
 image: "/images/gear/sketches/assembly-guide.webp"
 tags:
@@ -47,6 +47,4 @@ Need a Halloween costume in two minutes that won't restrict your movement or mak
 * **Adhesive Pumpkin Face Stickers**: Large, pre-cut felt stickers that let you assemble a perfect jack-o’-lantern face in seconds.
 
 Disclosure: As an Amazon Associate, I may earn from qualifying purchases.
-
-[Check out the Gear specific review here](/gear)
 

--- a/content/posts/2026-06-01-event-travel-packing.md
+++ b/content/posts/2026-06-01-event-travel-packing.md
@@ -3,7 +3,7 @@ type: post
 title: "Event Travel & Packing"
 date: "2026-06-01"
 author: "Ariel Anders, PhD"
-category: "Gear"
+category: "Travel"
 excerpt: "Packing organizers and garment care items for out-of-town events."
 image: "/images/gear/sketches/compression-cubes.webp"
 affiliateIds:

--- a/content/posts/2026-06-01-general-health-home-care.md
+++ b/content/posts/2026-06-01-general-health-home-care.md
@@ -3,7 +3,7 @@ type: post
 title: "General Health & Home Care for Dancers"
 date: "2026-06-01"
 author: "Ariel Anders, PhD"
-category: "Gear"
+category: "Health"
 excerpt: "Self-care and body maintenance items primarily used at home for recovery."
 image: "/images/gear/sketches/foam-roller.webp"
 affiliateIds:

--- a/content/posts/2026-06-01-theme-wear-costumes-accessories.md
+++ b/content/posts/2026-06-01-theme-wear-costumes-accessories.md
@@ -3,7 +3,7 @@ type: post
 title: "Theme Wear, Costumes & Accessories"
 date: "2026-06-01"
 author: "Ariel Anders, PhD"
-category: "Gear"
+category: "Costumes"
 excerpt: "Accessories and props curated for themed social dance nights (e.g., Space/Alien, Glow, Nerd, Halloween)."
 image: "/images/gear/sketches/glow_suspenders.webp"
 affiliateIds:

--- a/src/components/editorial/ArticleNavigation.tsx
+++ b/src/components/editorial/ArticleNavigation.tsx
@@ -1,0 +1,89 @@
+import { Box, Grid } from '@/layouts/Primitives';
+import { ContentCard } from '@/components/ui/ContentCard';
+
+import { Stack, Text } from '@/layouts/Primitives';
+import { ArrowLeft, ArrowRight } from 'lucide-react';
+import { Icon } from '@/components/ui/Icon';
+
+export interface ArticleNavItem {
+  title: string;
+  href: string;
+  category?: string;
+  excerpt?: string;
+  slug: string;
+  basePath: string;
+  date?: string;
+  readingTime?: string;
+  image?: string;
+  imageAlt?: string;
+}
+
+interface ArticleNavigationProps {
+  previous?: ArticleNavItem;
+  next?: ArticleNavItem;
+}
+
+export function ArticleNavigation({ previous, next }: ArticleNavigationProps) {
+  if (!previous && !next) return null;
+
+  return (
+    <Box paddingY={12} border="t" borderColor="line" className="border-opacity-medium">
+      <Grid cols={{ base: 1, md: 2 }} gap={4}>
+        <Box>
+          {previous && (
+            <Stack gap={2} height="full">
+              <Stack direction="row" align="center" gap={2}>
+                <Icon
+                  icon={ArrowLeft}
+                  size="sm"
+                  className="transition-transform group-hover:-translate-x-1"
+                />
+                <Text variant="mono" size="xs" color="dim" weight="font-bold" uppercase tracking="widest">
+                  Previous Article
+                </Text>
+              </Stack>
+              <ContentCard
+                title={previous.title}
+                slug={previous.slug}
+                basePath={previous.basePath}
+                category={previous.category || ''}
+                excerpt={previous.excerpt}
+                date={previous.date}
+                readingTime={previous.readingTime}
+                image={previous.image}
+                imageAlt={previous.imageAlt}
+              />
+            </Stack>
+          )}
+        </Box>
+        <Box>
+          {next && (
+            <Stack gap={2} align="end" height="full">
+              <Stack direction="row" align="center" gap={2}>
+                <Text variant="mono" size="xs" color="dim" weight="font-bold" uppercase tracking="widest">
+                  Next Article
+                </Text>
+                <Icon
+                  icon={ArrowRight}
+                  size="sm"
+                  className="transition-transform group-hover:translate-x-1"
+                />
+              </Stack>
+              <ContentCard
+                title={next.title}
+                slug={next.slug}
+                basePath={next.basePath}
+                category={next.category || ''}
+                excerpt={next.excerpt}
+                date={next.date}
+                readingTime={next.readingTime}
+                image={next.image}
+                imageAlt={next.imageAlt}
+              />
+            </Stack>
+          )}
+        </Box>
+      </Grid>
+    </Box>
+  );
+}

--- a/src/components/ui/ContentCard.tsx
+++ b/src/components/ui/ContentCard.tsx
@@ -12,6 +12,8 @@ interface ContentCardProps extends BaseProps, Partial<HTMLMotionProps<"a">> {
   basePath: string;
   date?: string;
   readingTime?: string;
+  image?: string;
+  imageAlt?: string;
   [key: string]: unknown;
 }
 
@@ -26,6 +28,8 @@ export function ContentCard(props: ContentCardProps) {
     basePath,
     date,
     readingTime,
+    image,
+    imageAlt,
   } = props;
 
   const motionProps = pickRest(props, [
@@ -46,20 +50,31 @@ export function ContentCard(props: ContentCardProps) {
     <BaseCard
       as={MotionArticle}
       direction="col"
-      gap={4}
       height="full"
-      padding={6}
       to={`${basePath}/${slug}`}
       ariaLabel={`Read article: ${title}`}
+      className="overflow-hidden"
       {...motionProps}
     >
-      <Box
-        paddingX={2}
-        paddingY={1}
-        radius="full"
-        border
-        className="border-line w-fit"
-      >
+      {image && (
+        <Box width="full" className="aspect-video bg-surface-alt border-b border-line overflow-hidden">
+          <img
+            src={image}
+            alt={imageAlt || title}
+            className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
+            loading="lazy"
+          />
+        </Box>
+      )}
+
+      <Stack gap={4} padding={6} height="full">
+        <Box
+          paddingX={2}
+          paddingY={1}
+          radius="full"
+          border
+          className="border-line w-fit"
+        >
         <Text
           variant="mono"
           size="xs"
@@ -89,14 +104,15 @@ export function ContentCard(props: ContentCardProps) {
         </Text>
       </Stack>
 
-      <Box display="flex" align="center" justify="between" marginTop="auto">
-        <Text variant="mono" size="xs" color="dim" data-testid="content-date">
-          {[date, readingTime].filter(Boolean).join(' • ') || category}
-        </Text>
-        <Text variant="mono" size="sm" weight="font-bold" color="accent" tracking="wide">
-          Read article
-        </Text>
-      </Box>
+        <Box display="flex" align="center" justify="between" marginTop="auto">
+          <Text variant="mono" size="xs" color="dim" data-testid="content-date">
+            {[date, readingTime].filter(Boolean).join(' • ') || category}
+          </Text>
+          <Text variant="mono" size="sm" weight="font-bold" color="accent" tracking="wide">
+            Read article
+          </Text>
+        </Box>
+      </Stack>
     </BaseCard>
   );
 }

--- a/src/config/research-tools.ts
+++ b/src/config/research-tools.ts
@@ -1,9 +1,15 @@
+/**
+ * Represents a tool or project in the research portfolio.
+ * The `taxonomyBucket` field is strictly enforced by the layout engine
+ * in `ResearchAnalytics.tsx` to group and render items into respective sections.
+ */
 export interface ResearchTool {
   id: string;
   title: string;
   subtitle: string;
   description: string;
   category: string;
+  taxonomyBucket?: 'flagship' | 'engineering' | 'data-content' | 'e-commerce';
   status: string;
   tags: string[];
   canonicalPath?: string;
@@ -19,6 +25,7 @@ export interface ResearchTool {
 export const RESEARCH_TOOLS: ResearchTool[] = [
   {
     id: 'hrm-flagship',
+    taxonomyBucket: 'flagship',
     title: 'HRM (Heart Rate Monitor)',
     subtitle: 'Flagship Training Dashboard',
     description: 'The original product built using AI-assisted engineering. It integrates Web Bluetooth heart-rate telemetry with Spotify API context, demonstrating full-stack Dev AI orchestration for complex browser-based applications.',
@@ -33,6 +40,7 @@ export const RESEARCH_TOOLS: ResearchTool[] = [
   },
   {
     id: 'repo-auditor-ai',
+    taxonomyBucket: 'flagship',
     title: 'RepoAuditor AI',
     subtitle: 'DevAI Workflow Console',
     description: 'A purpose-built AI orchestration console for GitHub. It leverages custom prompt engineering to audit pull requests, analyze workflow health, and generate structured issues for Jules coding agents, unblocking rapid multi-repo development.',
@@ -48,6 +56,7 @@ export const RESEARCH_TOOLS: ResearchTool[] = [
   },
   {
     id: 'gitops-pr-reviewer',
+    taxonomyBucket: 'engineering',
     title: 'GitOps Code Review Agent',
     subtitle: 'Automated Local PR Auditing',
     description: 'A model-agnostic ML engineering example using local LLMs to audit code style and pattern consistency. It serves as a GitOps-driven RAG prototype for private codebase documentation and policy enforcement.',
@@ -58,6 +67,7 @@ export const RESEARCH_TOOLS: ResearchTool[] = [
   },
   {
     id: 'scope-blast-radius',
+    taxonomyBucket: 'engineering',
     title: 'Blast-Radius Analyzer',
     subtitle: 'Static Workspace Dependency Checker',
     description: 'Demonstrates AI-assisted static analysis by calculating the semantic impact of code changes. Essential for AI orchestration to minimize token waste and provide agents with high-precision context.',
@@ -68,6 +78,7 @@ export const RESEARCH_TOOLS: ResearchTool[] = [
   },
   {
     id: 'ux-auditor',
+    taxonomyBucket: 'engineering',
     title: 'Visual Regression & UX Auditor',
     subtitle: 'Perception Telemetry System',
     description: 'An AI-assisted perception pipeline that maps DOM shifts to visual regressions. It uses automated Playwright workflows to provide high-fidelity telemetry for AI-driven frontend optimization.',
@@ -78,6 +89,7 @@ export const RESEARCH_TOOLS: ResearchTool[] = [
   },
   {
     id: 'wcs-scraper',
+    taxonomyBucket: 'data-content',
     title: 'High-Scale Telemetry Ingestion ETL',
     subtitle: 'Scraper-to-Parquet Pipeline',
     description: 'A data engineering showcase for Dev AI systems, transforming raw competitive dance records into compressed Parquet formats. This enables efficient RAG indexing and complex analytical queries.',
@@ -88,6 +100,7 @@ export const RESEARCH_TOOLS: ResearchTool[] = [
   },
   {
     id: 'blog-drafter',
+    taxonomyBucket: 'data-content',
     title: 'AI Blog Drafter',
     subtitle: 'Human-in-the-Loop Content Engine',
     description: 'A prompt engineering platform designed for brand-consistent content generation. It combines RAG over existing blog posts with a human-in-the-loop workflow to maintain editorial quality.',
@@ -98,6 +111,7 @@ export const RESEARCH_TOOLS: ResearchTool[] = [
   },
   {
     id: 'ecommerce-automation',
+    taxonomyBucket: 'e-commerce',
     title: 'Ecommerce Automation Experiments',
     subtitle: 'Printful & Merch Pipeline',
     description: 'Automated merch operations including programmatic design generation, Printful API storefront sync, and incoming Amazon affiliate integration workflows.',

--- a/src/features/home/TopicGrid.tsx
+++ b/src/features/home/TopicGrid.tsx
@@ -1,5 +1,5 @@
 // impeccable-ignore-file
-import { BookOpen } from 'lucide-react';
+import { BookOpen, Backpack, Plane, Heart, Shirt } from 'lucide-react';
 import { NavLink } from 'react-router-dom';
 import { Box, Grid, Stack, Text } from '@/layouts/Primitives';
 
@@ -11,6 +11,34 @@ const TOPICS = [
     cta: 'Read posts →',
     href: '/blog',
   },
+  {
+    icon: Backpack,
+    label: 'Gear',
+    description: 'Equipment, shoes, and tech essentials for social dancing.',
+    cta: 'View gear →',
+    href: '/blog?category=Gear',
+  },
+  {
+    icon: Plane,
+    label: 'Travel',
+    description: 'Tips and tools for packing and surviving event weekends.',
+    cta: 'Travel tips →',
+    href: '/blog?category=Travel',
+  },
+  {
+    icon: Heart,
+    label: 'Health & Recovery',
+    description: 'Self-care routines and physical maintenance for dancers.',
+    cta: 'Read more →',
+    href: '/blog?category=Health',
+  },
+  {
+    icon: Shirt,
+    label: 'Costumes',
+    description: 'DIY and dance-friendly outfits for themed social nights.',
+    cta: 'View costumes →',
+    href: '/blog?category=Costumes',
+  },
 ];
 
 export function TopicGrid() {
@@ -19,7 +47,7 @@ export function TopicGrid() {
       <Text as="h2" variant="headline" size="xl" weight="font-black" marginBottom={3}>
         Explore by topic
       </Text>
-      <Grid cols={{ base: 1, md: 1 }} gap={3}>
+      <Grid cols={{ base: 1, sm: 2, lg: 3 }} gap={3}>
         {TOPICS.map(({ icon: Icon, label, description, cta, href }) => (
           <Stack
             key={label}

--- a/src/features/journal/components/BlogPostDetail.tsx
+++ b/src/features/journal/components/BlogPostDetail.tsx
@@ -10,6 +10,8 @@ import { EditorialHeader } from '@/components/editorial/EditorialHeader';
 import { EditorialHero } from '@/components/editorial/EditorialHero';
 import { MarkdownRenderer } from '@/components/ui/MarkdownRenderer';
 import { EditorialRelated } from '@/components/editorial/EditorialRelated';
+import { ArticleNavigation } from '@/components/editorial/ArticleNavigation';
+import { useArticleNavigation } from '@/lib/hooks/useArticleNavigation';
 
 interface BlogPostDetailProps {
   post: Post;
@@ -59,6 +61,9 @@ export function BlogPostDetail({ post, onBack, backLabel }: BlogPostDetailProps)
   const affiliateLinks = (post.affiliateIds || [])
     .map(id => affiliateManager.getLink(id))
     .filter((link): link is NonNullable<typeof link> => !!link);
+
+  const allPosts = getPosts();
+  const { previous, next } = useArticleNavigation(allPosts, post.slug, '/blog');
 
   return (
     <EditorialLayout
@@ -120,6 +125,7 @@ export function BlogPostDetail({ post, onBack, backLabel }: BlogPostDetailProps)
       }
       footer={
         <Stack gap={12}>
+          <ArticleNavigation previous={previous} next={next} />
           <EditorialRelated items={relatedItems} />
         </Stack>
       }

--- a/src/features/research/ResearchAnalytics.tsx
+++ b/src/features/research/ResearchAnalytics.tsx
@@ -95,8 +95,10 @@ export default function ResearchAnalytics() {
   const { studies, tools } = useResearch();
   const baseUrl = (import.meta.env.BASE_URL || '/').replace(/\/$/, '');
 
-  const flagshipTools = tools.filter(t => t.isFlagship);
-  const engineeringTools = tools.filter(t => !t.isFlagship);
+  const flagshipTools = tools.filter(t => t.taxonomyBucket === 'flagship' || t.isFlagship);
+  const engineeringTools = tools.filter(t => t.taxonomyBucket === 'engineering');
+  const dataContentTools = tools.filter(t => t.taxonomyBucket === 'data-content');
+  const e_commerceTools = tools.filter(t => t.taxonomyBucket === 'e-commerce');
 
   return (
     <Box as="section">
@@ -253,18 +255,50 @@ export default function ResearchAnalytics() {
           </Stack>
         </Grid>
 
-        <Stack gap={12}>
-          <Box paddingBottom={4} display="flex" justify="between" align="end" border="b">
-            <Text variant="headline" size="2xl" weight="font-black">Engineering Systems</Text>
-            <Text variant="mono" size="xs" color="dim" weight="font-semibold" uppercase tracking="widest" opacityVariant="subtle">{engineeringTools.length} TOOLS</Text>
-          </Box>
+        {engineeringTools.length > 0 && (
+          <Stack gap={12}>
+            <Box paddingBottom={4} display="flex" justify="between" align="end" border="b">
+              <Text variant="headline" size="2xl" weight="font-black">Engineering Systems</Text>
+              <Text variant="mono" size="xs" color="dim" weight="font-semibold" uppercase tracking="widest" opacityVariant="subtle">{engineeringTools.length} TOOLS</Text>
+            </Box>
 
-          <Grid cols={{ base: 1, md: 2, lg: 3 }} gapX={6} gapY={12}>
-            {engineeringTools.map((tool) => (
-              <ToolCard key={tool.id} tool={tool} navigate={navigate} />
-            ))}
-          </Grid>
-        </Stack>
+            <Grid cols={{ base: 1, md: 2, lg: 3 }} gapX={6} gapY={12}>
+              {engineeringTools.map((tool) => (
+                <ToolCard key={tool.id} tool={tool} navigate={navigate} />
+              ))}
+            </Grid>
+          </Stack>
+        )}
+
+        {dataContentTools.length > 0 && (
+          <Stack gap={12}>
+            <Box paddingBottom={4} display="flex" justify="between" align="end" border="b">
+              <Text variant="headline" size="2xl" weight="font-black">Data & Content Systems</Text>
+              <Text variant="mono" size="xs" color="dim" weight="font-semibold" uppercase tracking="widest" opacityVariant="subtle">{dataContentTools.length} TOOLS</Text>
+            </Box>
+
+            <Grid cols={{ base: 1, md: 2, lg: 3 }} gapX={6} gapY={12}>
+              {dataContentTools.map((tool) => (
+                <ToolCard key={tool.id} tool={tool} navigate={navigate} />
+              ))}
+            </Grid>
+          </Stack>
+        )}
+
+        {e_commerceTools.length > 0 && (
+          <Stack gap={12}>
+            <Box paddingBottom={4} display="flex" justify="between" align="end" border="b">
+              <Text variant="headline" size="2xl" weight="font-black">Ecommerce Experiments</Text>
+              <Text variant="mono" size="xs" color="dim" weight="font-semibold" uppercase tracking="widest" opacityVariant="subtle">{e_commerceTools.length} TOOLS</Text>
+            </Box>
+
+            <Grid cols={{ base: 1, md: 2, lg: 3 }} gapX={6} gapY={12}>
+              {e_commerceTools.map((tool) => (
+                <ToolCard key={tool.id} tool={tool} navigate={navigate} />
+              ))}
+            </Grid>
+          </Stack>
+        )}
 
         {studies.length > 0 && (
           <Stack gap={12} id="articles">

--- a/src/features/research/ResearchDetail.tsx
+++ b/src/features/research/ResearchDetail.tsx
@@ -12,6 +12,8 @@ import { EditorialLayout } from '@/components/editorial/EditorialLayout';
 import { EditorialHeader } from '@/components/editorial/EditorialHeader';
 import { MarkdownRenderer } from '@/components/ui/MarkdownRenderer';
 import { readingTime } from '@/lib/content';
+import { ArticleNavigation } from '@/components/editorial/ArticleNavigation';
+import { useArticleNavigation } from '@/lib/hooks/useArticleNavigation';
 
 // Lazy load tool components to help with bundle size
 const BlogDrafter = lazy(() => import('@/features/lab/BlogDrafter').then(m => ({ default: m.BlogDrafter })));
@@ -33,7 +35,7 @@ export default function ResearchDetail() {
   const { id: paramId } = useParams();
   const { pathname } = useLocation();
 
-  const { getTool, getStudy } = useResearch();
+  const { getTool, getStudy, studies } = useResearch();
 
   const id = useMemo(() => {
     if (paramId) return paramId;
@@ -84,6 +86,12 @@ export default function ResearchDetail() {
     return segments.includes('research');
   }, [pathname]);
 
+  const { previous: studyPrevious, next: studyNext } = useArticleNavigation(
+    studies,
+    study?.slug || '',
+    '/research'
+  );
+
   if (tool?.canonicalPath && pathname !== tool.canonicalPath && isResearchPath) {
     return <Navigate to={tool.canonicalPath} replace />;
   }
@@ -111,6 +119,11 @@ export default function ResearchDetail() {
               author={study.author}
               authorAvatarSrc={study.authorImage}
             />
+          }
+          footer={
+            <Stack gap={12}>
+              <ArticleNavigation previous={studyPrevious} next={studyNext} />
+            </Stack>
           }
         >
           <Box className="prose-editorial">

--- a/src/lib/hooks/useArticleNavigation.ts
+++ b/src/lib/hooks/useArticleNavigation.ts
@@ -1,0 +1,42 @@
+export interface NavigableItem {
+  slug: string;
+  title: string;
+  category?: string;
+  excerpt?: string;
+  date?: string;
+  readingTime?: string;
+  image?: string;
+  imageAlt?: string;
+}
+
+export function useArticleNavigation<T extends NavigableItem>(
+  items: T[],
+  currentSlug: string,
+  basePath: string
+) {
+  const currentIndex = items.findIndex(item => item.slug === currentSlug);
+
+  const nextItem = currentIndex > 0 ? items[currentIndex - 1] : undefined;
+  const previousItem = currentIndex !== -1 && currentIndex < items.length - 1 ? items[currentIndex + 1] : undefined;
+
+  const mapToNavigable = (item?: T) => {
+    if (!item) return undefined;
+    return {
+      title: item.title,
+      href: `${basePath}/${item.slug}`,
+      slug: item.slug,
+      basePath,
+      category: item.category,
+      excerpt: item.excerpt,
+      date: item.date,
+      readingTime: item.readingTime,
+      image: item.image,
+      imageAlt: item.imageAlt,
+    };
+  };
+
+  return {
+    previous: mapToNavigable(previousItem),
+    next: mapToNavigable(nextItem)
+  };
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,6 +1,6 @@
 // impeccable-ignore-file
 import { SEO } from '@/components/SEO';
-import { Box, Stack } from '@/layouts/Primitives';
+import { Box, Stack, Grid } from '@/layouts/Primitives';
 import { STATIC_SCHEMAS } from '@/config/constants';
 import { FeaturedGuidePanel } from '@/features/home/FeaturedGuidePanel';
 import { TopicGrid } from '@/features/home/TopicGrid';
@@ -18,27 +18,38 @@ export default function Home() {
       />
 
       {/* Hero + Featured Guide: editorial two-column on desktop, stacked on mobile */}
-      <Box
+      <Grid
         as="section"
-        display="grid"
-        className="w-full max-w-full min-w-0 items-center gap-0 lg:gap-6 lg:grid-cols-[minmax(0,1fr)_420px]"
+        cols={{ base: 1 }}
+        gap={{ base: 0, lg: 6 }}
+        width="full"
+        maxWidth="full"
+        minWidth={0}
+        align="center"
+        className="lg:grid-cols-[minmax(0,1fr)_420px]"
       >
         <HeroSection />
         <FeaturedGuidePanel />
-      </Box>
+      </Grid>
 
       <Stack
         gap={{ base: 8, lg: 'section-spacing' }}
         marginTop={{ base: 8, lg: 'section-spacing' }}
-        className="w-full max-w-full min-w-0"
+        width="full"
+        maxWidth="full"
+        minWidth={0}
       >
-        <Box
-          display="grid"
-          className="w-full max-w-full min-w-0 gap-8 lg:grid-cols-[minmax(0,1.6fr)_minmax(300px,0.8fr)]"
+        <Grid
+          cols={{ base: 1 }}
+          gap={8}
+          width="full"
+          maxWidth="full"
+          minWidth={0}
+          className="lg:grid-cols-[minmax(0,1.6fr)_minmax(300px,0.8fr)]"
         >
           <LatestPosts />
           <DevLabCallout />
-        </Box>
+        </Grid>
         <TopicGrid />
       </Stack>
     </Box>


### PR DESCRIPTION
Closes #2397

### Description from PR #2397 (refactor(home): implement mobile responsive layout with Grid primitive):
Resolves issue #2322 by updating `src/pages/Home.tsx` to use the native `Grid` primitive, ensuring a 1-column responsive layout for mobile devices using `cols={{ base: 1 }}`. Existing raw class configurations for `lg:grid-cols-*` were maintained within the `className` attribute so that Tailwind CSS can properly analyze and compile them for larger viewports. Also updated visual test snapshots.

---
*PR created automatically by Jules for task [3195585388800722945](https://jules.google.com/task/3195585388800722945) started by @arii*

---
Closes #2396

### Description from PR #2396 (feat: Implement Previous/Next Article Navigation):
Closes #2345.

This PR implements the "Previous Article" and "Next Article" navigation at the bottom of article pages (blog posts and research studies). It introduces a reusable `ArticleNavigation` component and wires it up using the existing content fetching utilities (`getPosts` and `useResearch()`). Snapshots have been updated and visual verification was confirmed via Playwright screenshots.

---
*PR created automatically by Jules for task [18019999431361707233](https://jules.google.com/task/18019999431361707233) started by @arii*

---
Closes #2394

### Description from PR #2394 (Fix Homepage Latest Posts date sorting and expand Topic Grid):
The date of "Halloween costumes you can dance in" was incorrectly set to `2026-10-31`, causing it to float to the top of the "Latest Posts" list. I have corrected the date to `2026-04-18` based on the file name.

Also, I have audited the image usage on the homepage hero and the latest posts based on user instruction and found no instances of duplicated imagery. 

Lastly, the "Explore by topic" section was very limited, only displaying "Blog Posts". Based on user suggestion, I expanded the topics to feature "Gear", "Travel", "Health & Recovery", and "Guides", adding relevant icons and descriptions for each category.

---
*PR created automatically by Jules for task [9319421272519650492](https://jules.google.com/task/9319421272519650492) started by @arii*

---
Closes #2392

### Description from PR #2392 (chore: update search placeholders to reflect site terminology):
Replaced placeholder text in GlobalSearch.tsx and updated E2E test specs to remove references to the decommissioned gear and events guides.

---
*PR created automatically by Jules for task [10773008494980085214](https://jules.google.com/task/10773008494980085214) started by @arii*

---
Closes #2390

### Description from PR #2390 (Update research page taxonomy and layouts):
Implemented the final project taxonomy checklist and buckets for the research page. The projects are now categorized into: flagship outputs, engineering systems, data/content systems, ecommerce experiments, and articles.

---
*PR created automatically by Jules for task [8131001377896041073](https://jules.google.com/task/8131001377896041073) started by @arii*

---
