### PR TITLE
ci: tighten triggers and AI review prompts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,7 @@ name: CI
 
 on:
   push:
-    branches:
-      - '**'
+    branches: [main]
     paths:
       - 'src/**'
       - 'etl/**'
@@ -19,8 +18,7 @@ on:
       - '*.config.ts'
       - 'tsconfig*.json'
   pull_request:
-    branches:
-      - '**'
+    branches: ['**']
     paths:
       - 'src/**'
       - 'etl/**'
@@ -29,6 +27,7 @@ on:
       - 'scripts/**'
       - 'package.json'
       - 'pnpm-lock.yaml'
+      - '.github/workflows/ci.yml'
       - '.github/actions/**'
       - 'AGENTS.md'
       - 'docs/github-workflows.md'
@@ -253,7 +252,7 @@ jobs:
         if: always() && github.event_name == 'pull_request'
         continue-on-error: true
         env:
-          MAX_AI_REVIEWS: '2'
+          MAX_AI_REVIEWS: ${{ vars.MAX_AI_REVIEWS }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
@@ -263,7 +262,7 @@ jobs:
         if: always() && github.event_name == 'pull_request'
         continue-on-error: true
         env:
-          MAX_AI_REVIEWS: '2'
+          MAX_AI_REVIEWS: ${{ vars.MAX_AI_REVIEWS }}
           GITHUB_MODELS_MODEL: gpt-4o-mini
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
@@ -272,7 +271,7 @@ jobs:
       - name: Visual review agent
         if: always() && steps.check_visuals.outputs.changed_routes != '0'
         env:
-          MAX_AI_REVIEWS: '1'
+          MAX_AI_REVIEWS: ${{ vars.MAX_AI_REVIEWS }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
@@ -281,7 +280,7 @@ jobs:
       - name: Visual review github models agent
         if: always() && steps.check_visuals.outputs.changed_routes != '0'
         env:
-          MAX_AI_REVIEWS: '1'
+          MAX_AI_REVIEWS: ${{ vars.MAX_AI_REVIEWS }}
           GITHUB_MODELS_MODEL: gpt-4o-mini
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}

--- a/scripts/clients/geminiCodeReviewClient.ts
+++ b/scripts/clients/geminiCodeReviewClient.ts
@@ -8,12 +8,23 @@ const SYSTEM_PROMPT = `You are an expert software engineer reviewing a pull requ
 Review the following code diff for bugs, anti-patterns, missing types, and performance issues.
 Provide actionable feedback. Focus on HIGH severity issues.
 
+Severity rules — apply these strictly:
+- HIGH / Blocking: you can point to a concrete contradiction in the diff itself — a value
+  passed where the type doesn't allow it, a class or function that doesn't exist, a call
+  with the wrong arity, a test that would fail. Cite the exact line(s).
+- If your concern is phrased with "could," "might," "unless," "if not handled properly,"
+  or similar hedging language, it is NOT blocking. Downgrade it to a "Question" or
+  "Nitpick" section instead.
+- Do not raise a concern you cannot verify against the code you were given. State what
+  you'd need to see to verify it, rather than assuming the worst case.
+
 You MUST end your review with exactly one of the following strings indicating your final verdict:
 [VERDICT: PASS]
 [VERDICT: WARN]
 [VERDICT: FAIL]
 
-Use [VERDICT: FAIL] ONLY if there are blocking bugs or severe anti-patterns.
+Use [VERDICT: FAIL] ONLY if there are blocking bugs or severe anti-patterns that you can
+demonstrate with evidence from the diff.
 `;
 
 function createModel(): ChatGoogleGenerativeAI {

--- a/scripts/clients/geminiCodeReviewClient.ts
+++ b/scripts/clients/geminiCodeReviewClient.ts
@@ -4,11 +4,18 @@ import { parseCodeReviewVerdict } from './githubModelsCodeReviewClient';
 import type { CodeReviewSummary, CodeReviewResult } from '../lib/codeReviewTypes';
 import type { CodeReviewClientStrategy } from '../lib/codeReviewOrchestrator';
 
-const SYSTEM_PROMPT = `You are an expert software engineer reviewing a pull request.
+function buildSystemPrompt(prGoal: string | undefined): string {
+  const goalSection = prGoal
+    ? `This PR's stated goal:
+"${prGoal}"
+
+`
+    : '';
+  return `You are an expert software engineer reviewing a pull request.
 Review the following code diff for bugs, anti-patterns, missing types, and performance issues.
 Provide actionable feedback. Focus on HIGH severity issues.
 
-Severity rules — apply these strictly:
+${goalSection}Severity rules — apply these strictly:
 - HIGH / Blocking: you can point to a concrete contradiction in the diff itself — a value
   passed where the type doesn't allow it, a class or function that doesn't exist, a call
   with the wrong arity, a test that would fail. Cite the exact line(s).
@@ -18,6 +25,12 @@ Severity rules — apply these strictly:
 - Do not raise a concern you cannot verify against the code you were given. State what
   you'd need to see to verify it, rather than assuming the worst case.
 
+Scope and security rules:
+- Flag security issues ONLY if this diff introduces a NEW untrusted input path (e.g. new
+  user-controlled data flowing somewhere it wasn't before). Do not flag pre-existing patterns.
+- Do not introduce review topics unrelated to the PR's stated goal unless you find a
+  genuine, evidence-backed regression caused by this diff.
+
 You MUST end your review with exactly one of the following strings indicating your final verdict:
 [VERDICT: PASS]
 [VERDICT: WARN]
@@ -26,6 +39,7 @@ You MUST end your review with exactly one of the following strings indicating yo
 Use [VERDICT: FAIL] ONLY if there are blocking bugs or severe anti-patterns that you can
 demonstrate with evidence from the diff.
 `;
+}
 
 function createModel(): ChatGoogleGenerativeAI {
   const apiKey = process.env.GEMINI_API_KEY;
@@ -47,7 +61,7 @@ export const geminiCodeReviewClient: CodeReviewClientStrategy = {
   invokeReview: async (summary: CodeReviewSummary): Promise<CodeReviewResult> => {
     const model = createModel();
     const baseContent = [
-      { type: 'text', text: SYSTEM_PROMPT } as const,
+      { type: 'text', text: buildSystemPrompt(summary.prGoal) } as const,
       { type: 'text', text: `DIFF:\n\n${summary.diffContext}` } as const,
     ];
 

--- a/scripts/clients/githubModelsCodeReviewClient.ts
+++ b/scripts/clients/githubModelsCodeReviewClient.ts
@@ -8,13 +8,25 @@ const SYSTEM_PROMPT = `You are an expert software engineer reviewing a pull requ
 Review the following code diff for bugs, anti-patterns, missing types, and performance issues.
 Provide actionable feedback. Focus on HIGH severity issues.
 
+Severity rules — apply these strictly:
+- HIGH / Blocking: you can point to a concrete contradiction in the diff itself — a value
+  passed where the type doesn't allow it, a class or function that doesn't exist, a call
+  with the wrong arity, a test that would fail. Cite the exact line(s).
+- If your concern is phrased with "could," "might," "unless," "if not handled properly,"
+  or similar hedging language, it is NOT blocking. Downgrade it to a "Question" or
+  "Nitpick" section instead.
+- Do not raise a concern you cannot verify against the code you were given. State what
+  you'd need to see to verify it, rather than assuming the worst case.
+
 You MUST end your review with exactly one of the following strings indicating your final verdict:
 [VERDICT: PASS]
 [VERDICT: WARN]
 [VERDICT: FAIL]
 
-Use [VERDICT: FAIL] ONLY if there are blocking bugs or severe anti-patterns.
+Use [VERDICT: FAIL] ONLY if there are blocking bugs or severe anti-patterns that you can
+demonstrate with evidence from the diff.
 `;
+
 
 export function parseCodeReviewVerdict(feedback: string): 'pass' | 'fail' | 'warn' {
   if (feedback.includes('[VERDICT: FAIL]')) return 'fail';

--- a/scripts/clients/githubModelsCodeReviewClient.ts
+++ b/scripts/clients/githubModelsCodeReviewClient.ts
@@ -4,11 +4,18 @@ import type { CodeReviewSummary, CodeReviewResult } from '../lib/codeReviewTypes
 import type { CodeReviewClientStrategy } from '../lib/codeReviewOrchestrator';
 import { pickOptimalModel } from '../lib/modelPicker';
 
-const SYSTEM_PROMPT = `You are an expert software engineer reviewing a pull request.
+function buildSystemPrompt(prGoal: string | undefined): string {
+  const goalSection = prGoal
+    ? `This PR's stated goal:
+"${prGoal}"
+
+`
+    : '';
+  return `You are an expert software engineer reviewing a pull request.
 Review the following code diff for bugs, anti-patterns, missing types, and performance issues.
 Provide actionable feedback. Focus on HIGH severity issues.
 
-Severity rules — apply these strictly:
+${goalSection}Severity rules — apply these strictly:
 - HIGH / Blocking: you can point to a concrete contradiction in the diff itself — a value
   passed where the type doesn't allow it, a class or function that doesn't exist, a call
   with the wrong arity, a test that would fail. Cite the exact line(s).
@@ -18,6 +25,12 @@ Severity rules — apply these strictly:
 - Do not raise a concern you cannot verify against the code you were given. State what
   you'd need to see to verify it, rather than assuming the worst case.
 
+Scope and security rules:
+- Flag security issues ONLY if this diff introduces a NEW untrusted input path (e.g. new
+  user-controlled data flowing somewhere it wasn't before). Do not flag pre-existing patterns.
+- Do not introduce review topics unrelated to the PR's stated goal unless you find a
+  genuine, evidence-backed regression caused by this diff.
+
 You MUST end your review with exactly one of the following strings indicating your final verdict:
 [VERDICT: PASS]
 [VERDICT: WARN]
@@ -26,7 +39,7 @@ You MUST end your review with exactly one of the following strings indicating yo
 Use [VERDICT: FAIL] ONLY if there are blocking bugs or severe anti-patterns that you can
 demonstrate with evidence from the diff.
 `;
-
+}
 
 export function parseCodeReviewVerdict(feedback: string): 'pass' | 'fail' | 'warn' {
   if (feedback.includes('[VERDICT: FAIL]')) return 'fail';
@@ -61,7 +74,7 @@ export const githubModelsCodeReviewClient: CodeReviewClientStrategy = {
   invokeReview: async (summary: CodeReviewSummary): Promise<CodeReviewResult> => {
     const model = await createModel();
     const baseContent = [
-      { type: 'text', text: SYSTEM_PROMPT } as const,
+      { type: 'text', text: buildSystemPrompt(summary.prGoal) } as const,
       { type: 'text', text: `DIFF:\n\n${summary.diffContext}` } as const,
     ];
 

--- a/scripts/lib/codeReviewOrchestrator.ts
+++ b/scripts/lib/codeReviewOrchestrator.ts
@@ -15,7 +15,26 @@ export interface CodeReviewClientStrategy {
 
 const MAX_REVIEWS_PER_PR = parseInt(process.env.MAX_AI_REVIEWS ?? '2', 10);
 
-export function getCodeDiffSummary(): CodeReviewSummary {
+async function fetchPRGoal(): Promise<string | undefined> {
+  const token = process.env.GITHUB_TOKEN;
+  const repo = process.env.GITHUB_REPOSITORY;
+  const prNumber = process.env.PR_NUMBER;
+  if (!token || !repo || !prNumber) return undefined;
+
+  try {
+    const res = await fetch(`https://api.github.com/repos/${repo}/pulls/${prNumber}`, {
+      headers: { Authorization: `Bearer ${token}`, Accept: 'application/vnd.github+json' },
+    });
+    if (!res.ok) return undefined;
+    const pr = await res.json() as { title: string; body: string | null };
+    const body = pr.body?.trim() ? `\n\n${pr.body.trim()}` : '';
+    return `${pr.title}${body}`;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function getCodeDiffSummary(): Promise<CodeReviewSummary> {
   try {
     let diffCommand = 'git diff origin/main...HEAD';
     let nameOnlyCommand = 'git diff --name-only origin/main...HEAD';
@@ -40,9 +59,12 @@ export function getCodeDiffSummary(): CodeReviewSummary {
       .split('\n')
       .filter(Boolean);
 
+    const prGoal = await fetchPRGoal();
+
     return {
       files,
-      diffContext
+      diffContext,
+      prGoal,
     };
   } catch (error) {
     console.warn('Could not generate code diff:', error);
@@ -98,7 +120,7 @@ export async function orchestrateCodeReview(
     return;
   }
 
-  const summary = getCodeDiffSummary();
+  const summary = await getCodeDiffSummary();
 
   if (summary.files.length === 0 || !summary.diffContext) {
     console.log(`✅ No code changes detected — skipping agent review.`);

--- a/scripts/lib/codeReviewTypes.ts
+++ b/scripts/lib/codeReviewTypes.ts
@@ -1,6 +1,7 @@
 export interface CodeReviewSummary {
   files: string[];
   diffContext: string;
+  prGoal?: string;
 }
 
 export interface CodeReviewResult {


### PR DESCRIPTION
## Summary

### CI trigger changes ([ci.yml](https://github.com/arii/tech-dancer/blob/ari/ci-fix/.github/workflows/ci.yml))
- **Push**: now fires on `main` only (was `**`); path filter restored and kept symmetric with PRs
- **Pull request**: targets all branches; same path filter as push (no more divergence)
- `workflow_dispatch` unchanged

### MAX_AI_REVIEWS variable
- Hardcoded `'2'`/`'1'` values replaced with `${{ vars.MAX_AI_REVIEWS }}` across all four AI review steps
- GitHub Actions variable `MAX_AI_REVIEWS` set to `2` via `gh variable set`

### AI review prompt — evidentiary severity bar
Addresses repeated false-positive HIGH/Blocking findings phrased as speculation.

Added to both `geminiCodeReviewClient.ts` and `githubModelsCodeReviewClient.ts`:

> **Severity rules — apply these strictly:**
> - HIGH / Blocking: you can point to a concrete contradiction in the diff itself — a value passed where the type doesn't allow it, a class or function that doesn't exist, a call with the wrong arity, a test that would fail. Cite the exact line(s).
> - If your concern is phrased with "could," "might," "unless," "if not handled properly," or similar hedging language, it is NOT blocking. Downgrade it to a "Question" or "Nitpick" section instead.
> - Do not raise a concern you cannot verify against the code you were given. State what you'd need to see to verify it, rather than assuming the worst case.

`[VERDICT: FAIL]` now explicitly requires evidence from the diff.