### PR TITLE
fix(docker): remove pre-installed nodejs to force Node 22 downgrade

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -36,7 +36,8 @@ RUN apt-get update \
 # ── Node.js 22.22.2 (matches .node-version / runtime contract) ────────────────
 # Uses NodeSource to get the exact patch version, then locks it via corepack.
 ENV NODE_MAJOR=22
-RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_MAJOR}.x | bash - \
+RUN apt-get remove -y nodejs \
+  && curl -fsSL https://deb.nodesource.com/setup_${NODE_MAJOR}.x | bash - \
   && apt-get install -y nodejs \
   && node --version
 


### PR DESCRIPTION
Fixes the issue where Node.js v24 is kept in the final image instead of downgrading to v22 because apt-get install doesn't downgrade packages automatically. This resolves the engines mismatch error where expected Node version is 22.x but runner gets v24.16.0.