### PR TITLE
fix(docker): use playwright 1.60.0 for python because 1.61.0 is not on PyPI

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -56,7 +56,7 @@ RUN pip3 install --no-cache-dir --break-system-packages \
     pytest==9.1.1 \
     pytest-asyncio==1.4.0 \
     pytest-mock==3.15.1 \
-    playwright==1.61.0 \
+    playwright==1.60.0 \
     beautifulsoup4==4.14.3 \
     pandas==3.0.3 \
     pyarrow==24.0.0 \

--- a/etl/requirements.txt
+++ b/etl/requirements.txt
@@ -1,4 +1,4 @@
-playwright==1.61.0
+playwright==1.60.0
 beautifulsoup4==4.14.3
 pandas==3.0.3
 pyarrow==23.0.1


### PR DESCRIPTION
Fixes the Docker image build failure. Even though the Playwright base image has been bumped to v1.61.0, the Python playwright package version 1.61.0 is not yet released on PyPI. We revert the python package version back to 1.60.0 in the Dockerfile and etl/requirements.txt so that pip install succeeds.