### PR TITLE
feat: optimize docker base image version align to Playwright 1.60.0

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/playwright:v1.61.0-noble
+FROM mcr.microsoft.com/playwright:v1.60.0-noble
 
 # Links the image to your repository
 LABEL org.opencontainers.image.source="https://github.com/arii/tech-dancer"


### PR DESCRIPTION
Closes #2888. Align base image version in Dockerfile from v1.61.0-noble to v1.60.0-noble to match package.json dependencies.