### PR TITLE
fix(npmrc): remove unsupported use-node-version config for Vercel builds

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -2,4 +2,3 @@
 engine-strict=true
 node-linker=hoisted
 prefer-offline=true
-use-node-version=24.16.0


### PR DESCRIPTION
Removes the `use-node-version` configuration property from `.npmrc` since Vercel builds do not support it and explicitly error out. Version checks are already enforced via `engines` in `package.json`.