### PR TITLE
Fix workflow paths 9924942996482727025

### DIFF
--- a/.github/actions/setup-workspace/action.yml
+++ b/.github/actions/setup-workspace/action.yml
@@ -17,7 +17,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: ./boomtick-pkg/mcp/actions/setup-workspace
+    - uses: ./boomtick-pkg/.github/actions/setup-workspace
       with:
         setup-node: ${{ inputs.setup-node }}
         setup-python: ${{ inputs.setup-python }}

--- a/.github/workflows/auto-conflict-resolver.yml
+++ b/.github/workflows/auto-conflict-resolver.yml
@@ -104,7 +104,7 @@ jobs:
         with:
           node-version-file: '.node-version'
       - name: Setup Workspace
-        uses: arii/boomtick/mcp/actions/setup-workspace@main # nosemgrep: yaml.github-actions.security.github-actions-mutable-action-tag.github-actions-mutable-action-tag
+        uses: arii/boomtick/.github/actions/setup-workspace@main # nosemgrep: yaml.github-actions.security.github-actions-mutable-action-tag.github-actions-mutable-action-tag
         with:
           setup-python: 'false'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
           node-version-file: '.node-version'
 
       - name: Setup Workspace
-        uses: ./boomtick-pkg/mcp/actions/setup-workspace
+        uses: ./boomtick-pkg/.github/actions/setup-workspace
         with:
           setup-python: 'true'
 
@@ -156,7 +156,7 @@ jobs:
           node-version-file: '.node-version'
 
       - name: Setup Workspace
-        uses: ./boomtick-pkg/mcp/actions/setup-workspace
+        uses: ./boomtick-pkg/.github/actions/setup-workspace
         with:
           setup-python: 'true'
 
@@ -204,7 +204,7 @@ jobs:
           node-version-file: '.node-version'
 
       - name: Setup Workspace
-        uses: ./boomtick-pkg/mcp/actions/setup-workspace
+        uses: ./boomtick-pkg/.github/actions/setup-workspace
         with:
           setup-python: 'true'
 
@@ -301,7 +301,7 @@ jobs:
           node-version-file: '.node-version'
 
       - name: Setup Workspace
-        uses: ./boomtick-pkg/mcp/actions/setup-workspace
+        uses: ./boomtick-pkg/.github/actions/setup-workspace
         with:
           setup-python: 'true'
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,7 +47,7 @@ jobs:
           node-version-file: '.node-version'
 
       - name: Setup Workspace
-        uses: ./boomtick-pkg/mcp/actions/setup-workspace # nosemgrep: yaml.github-actions.security.github-actions-mutable-action-tag.github-actions-mutable-action-tag
+        uses: ./boomtick-pkg/.github/actions/setup-workspace # nosemgrep: yaml.github-actions.security.github-actions-mutable-action-tag.github-actions-mutable-action-tag
         with:
           setup-python: 'true'
 

--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -67,7 +67,7 @@ jobs:
           node-version-file: '.node-version'
 
       - name: Setup Workspace
-        uses: arii/boomtick/mcp/actions/setup-workspace@main # nosemgrep: yaml.github-actions.security.github-actions-mutable-action-tag.github-actions-mutable-action-tag
+        uses: arii/boomtick/.github/actions/setup-workspace@main # nosemgrep: yaml.github-actions.security.github-actions-mutable-action-tag.github-actions-mutable-action-tag
         with:
           setup-python: 'false'
 

--- a/.github/workflows/update-submodule.yml
+++ b/.github/workflows/update-submodule.yml
@@ -38,7 +38,7 @@ jobs:
           node-version-file: '.node-version'
 
       - name: Setup Workspace
-        uses: ./boomtick-pkg/mcp/actions/setup-workspace
+        uses: ./boomtick-pkg/.github/actions/setup-workspace
         with:
           setup-python: 'false'
 


### PR DESCRIPTION
Updated all references to `setup-workspace` in tech-dancer workflows to point to the new `.github/actions` directory in `boomtick-pkg`, resolving CI failures. `impact-analysis` remains unchanged.

---
*PR created automatically by Jules for task [9924942996482727025](https://jules.google.com/task/9924942996482727025) started by @arii*